### PR TITLE
No longer need dbus_launch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -410,20 +410,22 @@ pipeline {
                 JEST_JUNIT_TITLE="{title}"
                 JEST_HTML_REPORTER_OUTPUT_PATH = "${INTEGRATION_RESULTS}/index.html"
                 JEST_HTML_REPORTER_PAGE_TITLE = "${BRANCH_NAME} - Integration Test"
-                TEST_SCRIPT = "./jenkins/integration_tests.sh"
             }
             steps {
                 timeout(time: 30, unit: 'MINUTES') {
                     echo 'Integration Test'
 
                     /**************************************************************************
-                     * Welp, IDK even how to describe this witchcraft in a simple fashion so
-                     * just checkout the README in the jenkins folder for a more in depth
-                     * explanation for what is going on here.
+                     * This used to be much more complicated to explain but now all we have to
+                     * do is unlock the daemon and run integration tests. I think we have to
+                     * unlock the keyring because of some PAM security misconfiguration in the
+                     * base image. For now, I call this progress :)
                      *
-                     * THE README IS EXTREMELY DENSE WITH CONTENT. READ AT YOUR OWN RISK!
+                     * If you would like to read how it was before, just take a look at the
+                     * README file in the jenkins folder.
                      *************************************************************************/
-                    sh "chmod +x $TEST_SCRIPT && dbus-launch $TEST_SCRIPT"
+                    sh "echo 'jenkins' | gnome-keyring-daemon --unlock"
+                    sh "npm run test:integration"
 
                     junit JEST_JUNIT_OUTPUT
 

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -14,7 +14,9 @@ This document covers important information about the Jenkins environment.
 
 The pipeline script is found in the project root's Jenkinsfile. Refer to that file for information about the pipeline steps.
 
-## Keytar Requirements
+## Keytar Requirements (Historical Information)
+
+***08-24-2018:** Information in this section has been left for historical purposes. The processes have been improved by incorporating these techniques in the base docker-containers.*
 
 The following sections describe the steps that were taken to ensure that the keytar Node module can be used on the agent.
 
@@ -25,7 +27,19 @@ In the Integration Test step of the pipeline, note the following statement:
 sh "chmod +x $TEST_SCRIPT && dbus-launch $TEST_SCRIPT"
 ```
 
-This command is used to run the tests. `$TEST_SCRIPT` is a string that points to [./jenkins/integration_tests.sh](./integration_tests.sh). The next section talks about that command in further detail.
+This command is used to run the tests. `$TEST_SCRIPT` is a string that points to `./jenkins/integration_test.sh`. The next section talks about that command in further detail.
+
+***08-24-2018:** The script linked to has been deleted. Here were the contents at the time of the deletion.*
+
+```bash
+#!/usr/bin/env bash
+
+# Unlock the keyring
+echo 'jenkins' | gnome-keyring-daemon --unlock
+
+# Run the tests
+npm run test:integration
+```
 
 At a high level, this command performs the following actions: 
 

--- a/jenkins/integration_tests.sh
+++ b/jenkins/integration_tests.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# Unlock the keyring
-echo 'jenkins' | gnome-keyring-daemon --unlock
-
-# Run the tests
-npm run test:integration


### PR DESCRIPTION
With a little jenkins knowhow and some pretty impressive docker image modifications, I have been able to replace the dbus_launch shell in the integration test phase with:

```groovy
sh "echo 'jenkins' | gnome-keyring-daemon --unlock"
sh "npm run test:integration"
```

**NOTE:** In testing I have seen that the `gnome-keyring-daemon --unlock` is not needed in every pipeline. I am still trying to determine why that is the case and how I can get that working in this pipeline.

For example, If this pipeline had run with the image `mikebauerca/docker-brightside` and I tried to create a bright profile, it would work without the need for unlocking. In our pipeline, however, a similar operation that happens in one of our test clis that are installed during pipeline execution will yield:

```
** Message: Remote error from secret service: org.freedesktop.DBus.Error.UnknownMethod: No such interface 'org.freedesktop.Secret.Collection' on object at path /org/freedesktop/secrets/collection/login
Command Error:
Unable to store the secure field \"username\" associated with the profile \"profile-name\" of type \"username-password\".
Error Details:
No such interface 'org.freedesktop.Secret.Collection' on object at path /org/freedesktop/secrets/collection/login
```
without the unlock line.

