### PR TITLE
Log cmd tree at trace

### DIFF
--- a/packages/imperative/__tests__/Imperative.test.ts
+++ b/packages/imperative/__tests__/Imperative.test.ts
@@ -78,7 +78,9 @@ describe("Imperative", () => {
         configurable: true,
         get: jest.fn(() => {
           return {
-            debug: jest.fn()
+            debug: jest.fn(),
+            info: jest.fn(),
+            trace: jest.fn()
           };
         })
       });
@@ -109,7 +111,9 @@ describe("Imperative", () => {
         configurable: true,
         get: jest.fn(() => {
           return {
-            debug: jest.fn()
+            debug: jest.fn(),
+            info: jest.fn(),
+            trace: jest.fn()
           };
         })
       });

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -145,12 +145,16 @@ export class Imperative {
                 this.mHelpGeneratorFactory = new ImperativeHelpGeneratorFactory(this.rootCommandName, ImperativeConfig.instance.loadedConfig);
 
                 // resolve command module globs, forming the root of the CLI command tree
-                this.log.debug("The following config was found: " + JSON.stringify(config, null, 2));
+                this.log.info(`Loaded and validated config for '${config.name}'. Config details at trace level of logging.`);
+                this.log.trace(`The config object for '${config.name}' is:\n` +
+                    JSON.stringify(config, null, 2)
+                );
                 const resolvedHostCliCmdTree: ICommandDefinition = ImperativeConfig.instance.resolvedCmdTree;
 
                 // If plugins are allowed, add plugins' commands and profiles to the CLI command tree
                 if (config.allowPlugins) {
                   PluginManagementFacility.instance.addPluginsToHostCli(resolvedHostCliCmdTree);
+                  this.log.info("Plugins added to the CLI command tree.");
                 }
 
                 // final preparation of the command tree
@@ -164,6 +168,12 @@ export class Imperative {
                 /**
                  * Define all known commands
                  */
+                this.log.info("Inherited traits applied to CLI command tree children. " +
+                    "Cmd tree details at trace level of logging."
+                );
+                this.log.trace("The CLI command tree before being defined to yargs: " +
+                    JSON.stringify(preparedHostCliCmdTree, null, 2)
+                );
                 this.defineCommands(preparedHostCliCmdTree);
 
                 /**
@@ -367,7 +377,6 @@ export class Imperative {
      *        which has already prepared by ImperativeConfig.getPreparedCmdTree.
      */
     private static defineCommands(preparedHostCliCmdTree: ICommandDefinition) {
-        this.log.debug("The following command tree was defined: " + JSON.stringify(preparedHostCliCmdTree, null, 2));
         const commandResponseParms: ICommandResponseParms = {
             primaryTextColor: ImperativeConfig.instance.loadedConfig.primaryTextColor,
             progressBarSpinner: ImperativeConfig.instance.loadedConfig.progressBarSpinner

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -219,10 +219,10 @@ export class PluginManagementFacility {
                 // log the issue list for this plugin
                 const issueListForPlugin = this.pluginIssues.getIssueListForPlugin(pluginName);
                 if (issueListForPlugin.length > 0) {
-                    this.impLogger.debug("addPluginsToHostCli: Issues for plugin = '" + pluginName + "':\n" +
+                    this.impLogger.info("addPluginsToHostCli: Issues for plugin = '" + pluginName + "':\n" +
                         JSON.stringify(issueListForPlugin, null, 2));
                 } else {
-                    this.impLogger.debug("addPluginsToHostCli: Plugin = '" + pluginName +
+                    this.impLogger.info("addPluginsToHostCli: Plugin = '" + pluginName +
                         "' was successfully validated with no issues.");
                 }
             }
@@ -313,9 +313,11 @@ export class PluginManagementFacility {
         }
 
         // add the new plugin group into the imperative command tree
-        this.impLogger.debug("addPlugin: Adding plug-in commands to Imperative for plugin = '" +
-            pluginName + "' with this plugin command group:\n" +
-            JSON.stringify(pluginCmdGroup, null, 2)
+        this.impLogger.info("addPlugin: Adding commands for plug-in '" +
+            pluginName + "' to CLI command tree. Plugin command details at trace level of logging."
+        );
+        this.impLogger.trace("addPlugin: Commands for plugin = '" +
+            pluginName + "':\n" + JSON.stringify(pluginCmdGroup, null, 2)
         );
         if (!this.addCmdGrpToResolvedCliCmdTree(pluginName, pluginCmdGroup)) {
             return;
@@ -825,9 +827,13 @@ export class PluginManagementFacility {
             return false;
         }
 
-        this.impLogger.debug("validatePlugin: Validating plugin = '" +
-            pluginName + "' with config:\n" +
-            JSON.stringify(pluginConfig, null, 2));
+        this.impLogger.info("validatePlugin: Validating plugin '" +
+            pluginName + "'. Plugin config details at trace level of logging."
+        );
+        this.impLogger.trace("validatePlugin: Config for plugin '" +
+            pluginName + "':\n" +
+            JSON.stringify(pluginConfig, null, 2)
+        );
 
         // is there an imperative.name property?
         if (!pluginConfig.hasOwnProperty("name")) {


### PR DESCRIPTION
Fixed the concern raised in issue "Config and command tree logging should be moved into trace" #1
by moving verbose messages into the 'trace' level of logging.