### PR TITLE
Allow space for validate

### DIFF
--- a/packages/imperative/src/plugins/utilities/runValidatePlugin.ts
+++ b/packages/imperative/src/plugins/utilities/runValidatePlugin.ts
@@ -30,12 +30,12 @@ import { PMFConstants } from "./PMFConstants";
  */
 export function runValidatePlugin(pluginName: string): string {
     const extLen = 3;
-    let cmdToRun = "node";
+    let cmdToRun = `"${process.execPath}"`;
     const cliPgmToRun = process.mainModule.filename;
     if (cliPgmToRun.substring(cliPgmToRun.length - extLen) === ".ts") {
         cmdToRun += " --require ts-node/register";
     }
-    cmdToRun += " " + cliPgmToRun;
+    cmdToRun += ` "${cliPgmToRun}"`;
 
     const impLogger = Logger.getImperativeLogger();
     impLogger.debug(`Running plugin validation command = ${cmdToRun} plugins validate "${pluginName}" --response-format-json`);


### PR DESCRIPTION
There was an issue with spaces in the path when doing the validate command. This problem could also surface when inside of an executable bundled with pkg due to how node is translated in that environment.