### PR TITLE
fix #107

### DIFF
--- a/packages/imperative/src/doc/IImperativeOverrides.ts
+++ b/packages/imperative/src/doc/IImperativeOverrides.ts
@@ -9,76 +9,61 @@
 *
 */
 
+/**
+ * @file This file types everything for Imperative Override capabilities.
+ *
+ * Based on architectural decisions and ease of development, all future
+ * additions to the {@link ImperativeOverrides} object must represent one of the
+ * following 2 types:
+ *
+ * - **{@link IConstructor}** - This is a reference to a class constructor that
+ * will be used by the {@link OverridesLoader} when creating the various
+ * overrides factories.
+ * - **string** - An absolute or relative path to an import module from which
+ * either the {@link OverridesLoader} or the {@link PluginManagementFacility}
+ * will load before using the constructor in a factory. If defined in this
+ * manner, all type checks will be lost and we gain the ability to reside in a
+ * static file.
+ *
+ * Available overrides are defined by the {@link ImperativeOverrides}
+ * interface. The interface requires all keys to be a constructor based on the
+ * usage of this interface. The type {@link IImperativeOverrides} is what
+ * enforces that each constructor key on ImperativeOverrides to also allow
+ * strings and undefined values.
+ */
+
 import { ICredentialManagerConstructor } from "../../../security";
 import { IConstructor } from "../../../interfaces";
 
 /**
- * Type of the {@link IImperativeOverrides} interface. This will ensure that all keys
- * are pointing to a constructor or a string.
- *
- * Based on architectural decisions and ease of development, all future additions to
- * the {@link IImperativeOverrides} object must represent one of the following 2 types:
- *
- * - **{@link IConstructor}** - This is a reference to a class constructor that will be used
- * by the {@link OverridesLoader} when creating the various
- * overrides factories.
- * - **string** - An absolute or relative path to an import module from which either the
- * {@link OverridesLoader} or the {@link PluginManagementFacility} will
- * load before using the constructor in a factory. If defined in thi
- * sense, all type checks will be lost and we gain the ability to reside
- * in a static file.
- *
+ * Type of the {@link ImperativeOverrides} interface. This ensures that all
+ * keys of the interface reference a proper constructor definition.
  */
 interface IOverridesRestriction {
-    [key: string]: IConstructor<any> | string;
+    [key: string]: IConstructor<any>;
 }
 
 /**
- * All of the Default Imperative classes that can be changed by your Imperative CLI app.
- *
- * A plugin can also define overrides through the same means as an Imperative CLI app.
- * When additional overrides provided by plugins are present, Imperative will favor
- * those classes over ones provided by your application.
- *
- * Whether you are defining an Imperative Plugin or an Imperative CLI app, all keys in
- * this object are expected to be a class constructor or of type string.
- *
- * - A class constructor will be instantiated directly from imperative with no additional work
- * by the provider. (Assuming it is properly defined for the specific key)
- * - A string will trigger imperative to load the module before instantiating it.
- *     - If the string is absolute, nothing special happens.
- *     - If the string is relative, then imperative will base the load on a well known location
- *       depending on if it is a plugin provided override or base cli provided override.
- *         - For Imperative Plugins: The module is located relative to the packages default import path (e.g `require('package-name')`)
- *         - For Imperative CLI Apps: The module is located relative to the main entry point of your application
- *
- * When defining the location of an overrides as a string, it must adhere to the following format. Otherwise
- * Imperative will not be able to load the class.
- *
- * _Exporting an Anonymous Class_
- * ```TypeScript
- * export = class {
- *   // Code goes here
- * };
- * ```
- *
- * _Exporting a Named Class_
- * ```TypeScript
- * export = class YourOverridesClass {
- *   // Code goes here
- * };
- * ```
- *
- * _Using `module.exports` (Not preferred for TypeScript Users)_
- * ```TypeScript
- * class YourOverridesClass {
- *   // Code goes here
- * }
- *
- * module.exports = YourOverridesClass;
- * ```
+ * Converts {@link ImperativeOverrides} to an object where all keys are optional
+ * and can be of either constructor or string type.
  */
-export interface IImperativeOverrides extends IOverridesRestriction {
+type ConstructorOrString<T extends IOverridesRestriction> = {
+    [K in keyof T] ?: T[K] | string;
+};
+
+/**
+ * This interface defines all the overrideable properties of an Imperative
+ * application. Each key in this interface must adhere to the
+ * {@link IOverridesRestriction} interface to ensure that each key defines a
+ * constructor.
+ *
+ * It has been decided that all overridable fields allow for an undefined value.
+ * If the value is defined, then it must accept either a string type or an
+ * {@link IConstructor} type.This interface only requires that each key be an
+ * IConstructor type. The capability for string and undefined types is added in
+ * the declaration of the {@link IImperativeOverrides} type.
+ */
+interface ImperativeOverrides extends IOverridesRestriction {
     /**
      * A class that your Imperative CLI app can provide us in place of our
      * {@link DefaultCredentialManager}, so that you can meet your security
@@ -144,5 +129,54 @@ export interface IImperativeOverrides extends IOverridesRestriction {
      * module.exports = CredentialManager;
      * ```
      */
-    CredentialManager?: ICredentialManagerConstructor | string;
+    CredentialManager: ICredentialManagerConstructor;
 }
+
+/**
+ * All of the Default Imperative classes that can be changed by your Imperative CLI app.
+ *
+ * A plugin can also define overrides through the same means as an Imperative CLI app.
+ * When additional overrides provided by plugins are present, Imperative will favor
+ * those classes over ones provided by your application.
+ *
+ * Whether you are defining an Imperative Plugin or an Imperative CLI app, all keys in
+ * this object are expected to be a class constructor or of type string.
+ *
+ * - A class constructor will be instantiated directly from imperative with no additional work
+ * by the provider. (Assuming it is properly defined for the specific key)
+ * - A string will trigger imperative to load the module before instantiating it.
+ *     - If the string is absolute, nothing special happens.
+ *     - If the string is relative, then imperative will base the load on a well known location
+ *       depending on if it is a plugin provided override or base cli provided override.
+ *         - For Imperative Plugins: The module is located relative to the packages default import path (e.g `require('package-name')`)
+ *         - For Imperative CLI Apps: The module is located relative to the main entry point of your application
+ *
+ * When defining the location of an overrides as a string, it must adhere to the following format. Otherwise
+ * Imperative will not be able to load the class.
+ *
+ * _Exporting an Anonymous Class_
+ * ```TypeScript
+ * export = class {
+ *   // Code goes here
+ * };
+ * ```
+ *
+ * _Exporting a Named Class_
+ * ```TypeScript
+ * export = class YourOverridesClass {
+ *   // Code goes here
+ * };
+ * ```
+ *
+ * _Using `module.exports` (Not preferred for TypeScript Users)_
+ * ```TypeScript
+ * class YourOverridesClass {
+ *   // Code goes here
+ * }
+ *
+ * module.exports = YourOverridesClass;
+ * ```
+ *
+ * @see {@link ImperativeOverrides} for documentation on the available keys.
+ */
+export type IImperativeOverrides = ConstructorOrString<ImperativeOverrides>;

--- a/packages/security/src/CredentialManagerFactory.ts
+++ b/packages/security/src/CredentialManagerFactory.ts
@@ -67,7 +67,7 @@ export class CredentialManagerFactory {
      * which implements the {@link AbstractCredentialManager} methods. All these methods have been designed to throw
      * the error we caught in the **CredentialManagerFactory.initialize** function.
      *
-     * @param {ICredentialManagerInit} - Initialization parameters, see interface for details.
+     * @param {ICredentialManagerInit} params - Initialization parameters, see interface for details.
      *
      * @throws {@link ImperativeError} When it has been detected that this method has been called before.
      *         It is important that this method only executes once.


### PR DESCRIPTION
## Changelog

- **[FIX]** Typing of `IImperativeOverrides` to allow for undefined values. Some external projects were complaining that type information wasn't matching because keys were marked as optional. (Fixes #107)