### PR TITLE
Don't populate --name and --type arguments from profiles

### DIFF
--- a/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
@@ -288,4 +288,22 @@ describe("cmd-cli profile mapping", () => {
         expect(response.stdout.toString()).toContain("Name: undefined");
         expect(response.stdout.toString()).toContain("Type: undefined");
     });
+
+    it("should still be able to specify --name and --type on command line", () => {
+        // values used as env variables
+        const color = "yellow";
+        const description = "A pretty good banana";
+        const moldType = "none";
+
+        const cliName = "Bonoror";
+        const cliType = "Big";
+        const response = runCliScript(__dirname + "/__scripts__/profiles/name_type_specify.sh",
+            TEST_ENVIRONMENT.workingDir, [color, description, moldType, cliName, cliType]);
+        expect(response.stderr.toString()).toBe("");
+        expect(response.status).toBe(0);
+
+        // name and type should be undefined since we did not specify them via command line
+        expect(response.stdout.toString()).toContain("Name: " + cliName);
+        expect(response.stdout.toString()).toContain("Type: " + cliType);
+    });
 });

--- a/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
@@ -279,7 +279,7 @@ describe("cmd-cli profile mapping", () => {
         const color = "yellow";
         const description = "A pretty good banana";
         const moldType = "none";
-        const response = runCliScript(__dirname + "/__scripts__/profiles/specify_env_sweetness.sh",
+        const response = runCliScript(__dirname + "/__scripts__/profiles/name_type_undefined.sh",
             TEST_ENVIRONMENT.workingDir, [color, description, moldType]);
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);

--- a/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/Cmd.cli.profile.option.mapping.integration.test.ts
@@ -273,4 +273,19 @@ describe("cmd-cli profile mapping", () => {
             expect(response.stdout.toString()).toContain(name.replace("\\'", "'"));
         }
     });
+
+    it("should not map profile fields to --name or --type", () => {
+        // values used as env variables
+        const color = "yellow";
+        const description = "A pretty good banana";
+        const moldType = "none";
+        const response = runCliScript(__dirname + "/__scripts__/profiles/specify_env_sweetness.sh",
+            TEST_ENVIRONMENT.workingDir, [color, description, moldType]);
+        expect(response.stderr.toString()).toBe("");
+        expect(response.status).toBe(0);
+
+        // name and type should be undefined since we did not specify them via command line
+        expect(response.stdout.toString()).toContain("Name: undefined");
+        expect(response.stdout.toString()).toContain("Type: undefined");
+    });
 });

--- a/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/__scripts__/profiles/name_type_specify.sh
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/__scripts__/profiles/name_type_specify.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+color=$1
+description=$2
+moldtype=$3
+# First create a banana profile
+cmd-cli profiles create banana-profile "test_banana" --color "$color" --banana-description "$description" --mold-type "$moldtype"
+CMDRC=$?
+if [ $CMDRC -gt 0 ]
+then
+    echo "Creating a test_banana profile of type banana failed!" 1>&2
+    exit $CMDRC
+fi
+
+cliName=$4
+cliType=$5
+# should print name: undefined type: undefined
+cmd-cli profile mapping-name-type "$cliName" --type "$cliType"
+CMDRC=$?
+if [ $CMDRC -gt 0 ]
+then
+    echo "Profile mapping command failed!" 1>&2
+    exit $CMDRC
+fi

--- a/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/__scripts__/profiles/name_type_undefined.sh
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/profiles/__scripts__/profiles/name_type_undefined.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+color=$1
+description=$2
+moldtype=$3
+# First create a banana profile
+cmd-cli profiles create banana-profile "test_banana" --color "$color" --banana-description "$description" --mold-type "$moldtype"
+CMDRC=$?
+if [ $CMDRC -gt 0 ]
+then
+    echo "Creating a test_banana profile of type banana failed!" 1>&2
+    exit $CMDRC
+fi
+
+# should print name: undefined type: undefined
+cmd-cli profile mapping-name-type
+CMDRC=$?
+if [ $CMDRC -gt 0 ]
+then
+    echo "Profile mapping command failed!" 1>&2
+    exit $CMDRC
+fi

--- a/__tests__/__integration__/cmd/src/cli/profile/ProfileMapping.definition.ts
+++ b/__tests__/__integration__/cmd/src/cli/profile/ProfileMapping.definition.ts
@@ -12,13 +12,14 @@
 import { ICommandDefinition } from "../../../../../../packages/index";
 import { profileMappingCommand } from "./mapping/ProfileMapping.definition";
 import { profileMappingPositionalCommand } from "./mapping-positional/ProfileMapping.definition";
+import { profileMappingCommandNameType } from "./mapping-name-type/ProfileMappingNameType.definition";
 
 export const definition: ICommandDefinition = {
     name: "profile",
     description: "Invoke commands to validate that mapping profile fields to options is working correctly",
     summary: "Validate profile mapping",
     type: "group",
-    children: [profileMappingCommand, profileMappingPositionalCommand],
+    children: [profileMappingCommand, profileMappingPositionalCommand, profileMappingCommandNameType],
 };
 
 module.exports = definition;

--- a/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.definition.ts
+++ b/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.definition.ts
@@ -1,0 +1,37 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandDefinition } from "../../../../../../../packages/index";
+
+export const profileMappingCommandNameType: ICommandDefinition = {
+    name: "mapping-name-type",
+    description: "Tests that --type and --name are not filled in from profiles.",
+    type: "command",
+    handler: __dirname + "/ProfileMapping.handler",
+    options:
+        [
+            {
+                name: "type",
+                aliases: ["t"],
+                description: "The type of the banana.",
+                type: "string",
+                required: true,
+            },
+        ],
+    positionals: [
+        {
+            name: "name",
+            description: "the name of the banana",
+            type: "string"
+        }
+    ],
+    profile: {optional: ["banana"]}
+};

--- a/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.definition.ts
+++ b/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.definition.ts
@@ -22,8 +22,7 @@ export const profileMappingCommandNameType: ICommandDefinition = {
                 name: "type",
                 aliases: ["t"],
                 description: "The type of the banana.",
-                type: "string",
-                required: true,
+                type: "string"
             },
         ],
     positionals: [

--- a/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.definition.ts
+++ b/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.definition.ts
@@ -15,7 +15,7 @@ export const profileMappingCommandNameType: ICommandDefinition = {
     name: "mapping-name-type",
     description: "Tests that --type and --name are not filled in from profiles.",
     type: "command",
-    handler: __dirname + "/ProfileMapping.handler",
+    handler: __dirname + "/ProfileMappingNameType.handler",
     options:
         [
             {

--- a/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.handler.ts
+++ b/__tests__/__integration__/cmd/src/cli/profile/mapping-name-type/ProfileMappingNameType.handler.ts
@@ -1,0 +1,25 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandHandler, IHandlerParameters } from "../../../../../../../packages/index";
+
+/**
+ * Test of mapping of profile fields to options
+ * @export
+ * @class ProfileMappingNameTypeHandler
+ * @implements {ICommandHandler}
+ */
+export default class ProfileMappingNameTypeHandler implements ICommandHandler {
+    public async process(params: IHandlerParameters) {
+        params.response.console.log("Name: " + params.arguments.name);
+        params.response.console.log("Type: " + params.arguments.type);
+    }
+}

--- a/packages/utilities/src/CliUtils.ts
+++ b/packages/utilities/src/CliUtils.ts
@@ -141,6 +141,12 @@ export class CliUtils {
                 // For each option - extract the value if that exact property exists
                 options.forEach((opt) => {
 
+                    if (opt.name.toLowerCase() === "name" || opt.name.toLowerCase() === "type") {
+                        // name and type are reserved fields in the profile
+                        // that are not entered by the user
+                        // do not populate arguments from them
+                        return;
+                    }
                     // Get the camel an kebab case
                     const cases = CliUtils.getOptionFormat(opt.name);
 


### PR DESCRIPTION
When building arguments from profiles as implemented in #34, do not use the name or type fields of the profile as arguments since they are special reserved fields for profiles.

Add integration tests for the name/type scenario

Fix #112 