### PR TITLE
fix pkg bug, so now it finds node-gyp and npm modules in parent cli d…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
       "lib/auth/*.js"
     ],
     "assets": [
-      "node_modules/npm/node_modules/node-gyp/**/*",
-      "node_modules/npm/lib/"
+      "../../npm/node_modules/node-gyp/**/*",
+      "../../npm/lib/"
     ]
   },
   "files": [


### PR DESCRIPTION
When CLI installs imperative some of its node-modules move into CLI node-modules, that's why pkg script cannot find them inside of imperative node-modules

Signed-off-by: nurra01 <nurra01@ca.com>