### PR TITLE
Add expectBuffer methods to restclient for 1.0.0 branch

### DIFF
--- a/__tests__/src/TestUtil.ts
+++ b/__tests__/src/TestUtil.ts
@@ -23,9 +23,9 @@ import {ICommandResponse} from "../../packages/cmd";
 import {ICompareParms} from "./doc/ICompareParms";
 import {TestLogger} from "../TestLogger";
 import * as nodePath from "path";
-import {basename, join, resolve} from "path";
-import {mkdirpSync} from "fs-extra";
+import { mkdirpSync } from "fs-extra";
 import * as fs from "fs";
+import { randomBytes } from "crypto";
 
 /**
  * Requires for non-typed.
@@ -61,7 +61,7 @@ export * from "fs";
 
 export const TEST_HOME: string = process.cwd() + "/__tests__/__results__/data/.testHomeDir";
 
-export const TEST_RESULT_DIR = resolve(__dirname + "/../__results__");
+export const TEST_RESULT_DIR = nodePath.resolve(__dirname + "/../__results__");
 
 /**
  * This function strips any new lines out of the string passed.
@@ -138,6 +138,23 @@ export function generateRandomAlphaNumericString(length: number, upToLength: boo
     }
     return result;
 }
+
+/**
+ * Get a buffer full of random data
+ * @param dataSize - the number of bytes to generate
+ */
+export function getRandomBytes(dataSize: number): Promise<Buffer> {
+    return new Promise<Buffer>((resolveBytes, reject) => {
+        randomBytes(dataSize, (randomErr: Error, randomData: Buffer) => {
+            if (randomErr != null) {
+                reject(randomErr);
+                return;
+            }
+            resolveBytes(randomData);
+        });
+    });
+}
+
 
 export enum CMD_TYPE {
     JSON, // only  with the json flag

--- a/packages/rest/__tests__/client/RestClient.test.ts
+++ b/packages/rest/__tests__/client/RestClient.test.ts
@@ -15,6 +15,7 @@ import { ProcessUtils } from "../../../utilities";
 import { MockHttpRequestResponse } from "./__model__/MockHttpRequestResponse";
 import { CustomRestClient } from "./__model__/CustomRestClient";
 import { CustomRestClientWithProcessError, EXPECTED_REST_ERROR } from "./__model__/CustomRestClientWithProcessError";
+import { getRandomBytes } from "../../../../__tests__/src/TestUtil";
 
 /**
  * RestClient is already tested vie the AbstractRestClient test, so we will extend RestClient
@@ -126,6 +127,78 @@ describe("RestClient tests", () => {
         }
         expect(error).toBeDefined();
         expect(error.message).toContain(EXPECTED_REST_ERROR.msg);
+    });
+
+    it("should be able to return a buffer from various types of requests", async () => {
+
+        const randomByteLength = 40;
+        let randomBytes1 = await getRandomBytes(randomByteLength);
+        let randomBytes2 = await getRandomBytes(randomByteLength);
+        const emitter = new MockHttpRequestResponse();
+        const requestFnc = jest.fn((options, callback) => {
+            ProcessUtils.nextTick(async () => {
+
+                const newEmit = new MockHttpRequestResponse();
+                newEmit.statusCode = "200";
+                callback(newEmit);
+
+                await ProcessUtils.nextTick(() => {
+                    newEmit.emit("data", randomBytes1);
+                });
+
+                await ProcessUtils.nextTick(() => {
+                    newEmit.emit("data", randomBytes2);
+                });
+
+                await ProcessUtils.nextTick(() => {
+                    newEmit.emit("end"); // request is finished
+                });
+            });
+            return emitter;
+        });
+
+        (https.request as any) = requestFnc;
+
+        let error;
+        let response: Buffer;
+        try {
+            response = await CustomRestClient.getExpectBuffer(new Session({hostname: "test"}), "/resource");
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error).toBeUndefined();
+        expect(response).toEqual(Buffer.concat([randomBytes1, randomBytes2]));
+
+        randomBytes1 = await getRandomBytes(randomByteLength);
+        randomBytes2 = await getRandomBytes(randomByteLength);
+        try {
+            response = await CustomRestClient.deleteExpectBuffer(new Session({hostname: "test"}), "/resource");
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error).toBeUndefined();
+        expect(response).toEqual(Buffer.concat([randomBytes1, randomBytes2]));
+
+        randomBytes1 = await getRandomBytes(randomByteLength);
+        randomBytes2 = await getRandomBytes(randomByteLength);
+        try {
+            response = await CustomRestClient.postExpectBuffer(new Session({hostname: "test"}), "/resource");
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error).toBeUndefined();
+        expect(response).toEqual(Buffer.concat([randomBytes1, randomBytes2]));
+
+
+        randomBytes1 = await getRandomBytes(randomByteLength);
+        randomBytes2 = await getRandomBytes(randomByteLength);
+        try {
+            response = await CustomRestClient.putExpectBuffer(new Session({hostname: "test"}), "/resource", [], {});
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error).toBeUndefined();
+        expect(response).toEqual(Buffer.concat([randomBytes1, randomBytes2]));
     });
 
 });

--- a/packages/rest/src/client/RestClient.ts
+++ b/packages/rest/src/client/RestClient.ts
@@ -102,6 +102,76 @@ export class RestClient extends AbstractRestClient {
      * @param {AbstractSession} session - representing connection to this api
      * @param {string} resource - URI for which this request should go against
      * @param {any} reqHeaders - headers to include in the REST request
+     * @returns {Promise<Buffer>} - response body content from http(s) call
+     * @throws  if the request gets a status code outside of the 200 range
+     *          or other connection problems occur (e.g. connection refused)
+     * @memberof RestClient
+     */
+    public static async getExpectBuffer(session: AbstractSession, resource: string, reqHeaders: any[] = []): Promise<Buffer> {
+        const client = new this(session);
+        await client.performRest(resource, HTTP_VERB.GET, reqHeaders);
+        return client.data;
+    }
+
+    /**
+     * REST HTTP PUT operation
+     * @static
+     * @param {AbstractSession} session - representing connection to this api
+     * @param {string} resource - URI for which this request should go against
+     * @param {object[]} reqHeaders - headers to include in the REST request
+     * @param {any} data - payload data
+     * @returns {Promise<Buffer>} - response body content from http(s) call
+     * @throws  if the request gets a status code outside of the 200 range
+     *          or other connection problems occur (e.g. connection refused)
+     * @memberof RestClient
+     */
+    public static async putExpectBuffer(session: AbstractSession, resource: string, reqHeaders: any[] = [], data: any): Promise<Buffer> {
+        const client = new this(session);
+        await client.performRest(resource, HTTP_VERB.PUT, reqHeaders, data);
+        return client.data;
+    }
+
+    /**
+     * REST HTTP POST operation
+     * @static
+     * @param {AbstractSession} session - representing connection to this api
+     * @param {string} resource - URI for which this request should go against
+     * @param {object[]} reqHeaders - headers to include in the REST request
+     * @param {any} data - payload data
+     * @returns {Promise<Buffer>} - response body content from http(s) call
+     * @throws  if the request gets a status code outside of the 200 range
+     *          or other connection problems occur (e.g. connection refused)
+     * @memberof RestClient
+     */
+    public static async postExpectBuffer(session: AbstractSession, resource: string, reqHeaders: any[] = [], data?: any): Promise<Buffer> {
+        const client = new this(session);
+        await client.performRest(resource, HTTP_VERB.POST, reqHeaders, data);
+        return client.data;
+    }
+
+    /**
+     * REST HTTP DELETE operation
+     * @static
+     * @param {AbstractSession} session - representing connection to this api
+     * @param {string} resource - URI for which this request should go against
+     * @param {any} reqHeaders - headers to include in the REST request
+     * @returns {Promise<Buffer>} - response body content from http(s) call
+     * @throws  if the request gets a status code outside of the 200 range
+     *          or other connection problems occur (e.g. connection refused)
+     * @memberof RestClient
+     */
+    public static async deleteExpectBuffer(session: AbstractSession, resource: string, reqHeaders: any[] = []): Promise<Buffer> {
+        const client = new this(session);
+        await client.performRest(resource, HTTP_VERB.DELETE, reqHeaders);
+        return client.data;
+    }
+
+    /**
+     * REST HTTP GET operation
+     * @static
+     * @param {AbstractSession} session - representing connection to this api
+     * @param {string} resource - URI for which this request should go against
+     * @param {any} reqHeaders - headers to include in the REST request
      * @returns {Promise<string>} - response body content from http(s) call
      * @throws  if the request gets a status code outside of the 200 range
      *          or other connection problems occur (e.g. connection refused)


### PR DESCRIPTION
Add expectBuffer methods to the RestClient in the 1.0.0 branch so that binary download in zowe CLI can be fixed

These methods are already present in master added in #4  but weren't ported to 1.0.0 until now 