### PR TITLE
Render emails as HTML

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -735,6 +735,7 @@ pipeline {
                                     subject: subject,
                                     to: recipients,
                                     body: "${details} ${consoleOutput}",
+                                    mimeType: "text/html",
                                     recipientProviders: [[$class: 'DevelopersRecipientProvider'],
                                                          [$class: 'UpstreamComitterRecipientProvider'],
                                                          [$class: 'CulpritsRecipientProvider'],


### PR DESCRIPTION
It's about time we use all this formatting that exists in the jenkinsfile. Who knew that we just were missing the mime type :cat: