### PR TITLE
Export HTTPVerb from rest package

### DIFF
--- a/packages/rest/index.ts
+++ b/packages/rest/index.ts
@@ -9,6 +9,7 @@
 *
 */
 
+export * from "./src/client/types/HTTPVerb";
 export * from "./src/client/doc/IHeaderContent";
 export * from "./src/client/Headers";
 export * from "./src/client/AbstractRestClient";


### PR DESCRIPTION
This type is used in a method that can be overridden in the RestClient but wasn't exported until this PR 