### PR TITLE
Command processor fixes

### DIFF
--- a/__tests__/src/packages/cmd/SyntaxValidator.integration.test.ts
+++ b/__tests__/src/packages/cmd/SyntaxValidator.integration.test.ts
@@ -362,7 +362,8 @@ describe("Imperative should provide advanced syntax validation rules", function 
                         helpGenerator,
                         profileManagerFactory: new BasicProfileManagerFactory(TEST_HOME,
                             DUMMY_PROFILE_TYPE_CONFIG),
-                        rootCommandName: "fake"
+                        rootCommandName: "fake",
+                        commandLine: "fake"
                     }).invoke({ arguments: { "_": ["banana"], "$0": "", "my-number": "banana" }, silent: true, responseFormat: "json" }).then(
                         (completedResponse: ICommandResponse) => {
                             // Command should have failed
@@ -390,7 +391,8 @@ describe("Imperative should provide advanced syntax validation rules", function 
                         helpGenerator,
                         profileManagerFactory: new BasicProfileManagerFactory(TEST_HOME,
                             DUMMY_PROFILE_TYPE_CONFIG),
-                        rootCommandName: "fake"
+                        rootCommandName: "fake",
+                        commandLine: "fake"
                     }).invoke({ arguments: { "_": ["banana"], "$0": "", "my-number": "123546" }, silent: true, responseFormat: "json" }).then(
                         (completedResponse: ICommandResponse) => {
                             expect(completedResponse.success).toEqual(true);

--- a/packages/cmd/__tests__/CommandProcessor.test.ts
+++ b/packages/cmd/__tests__/CommandProcessor.test.ts
@@ -252,7 +252,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
     });
 
@@ -276,7 +277,8 @@ describe("Command Processor", () => {
                 definition: undefined,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
         } catch (e) {
             error = e;
@@ -294,7 +296,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION,
                 helpGenerator: undefined,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
         } catch (e) {
             error = e;
@@ -312,7 +315,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: undefined,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
         } catch (e) {
             error = e;
@@ -330,7 +334,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: undefined
+                rootCommandName: undefined,
+                commandLine: ""
             });
         } catch (e) {
             error = e;
@@ -348,7 +353,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: ""
+                rootCommandName: "",
+                commandLine: ""
             });
         } catch (e) {
             error = e;
@@ -366,7 +372,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
         } catch (e) {
             error = e;
@@ -382,7 +389,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
         expect(processor.definition).toEqual(SAMPLE_COMMAND_DEFINITION);
     });
@@ -393,7 +401,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
         expect(processor.envVariablePrefix).toEqual(ENV_VAR_PREFIX);
     });
@@ -404,7 +413,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
         expect(processor.rootCommand).toEqual(SAMPLE_ROOT_COMMAND);
     });
@@ -415,7 +425,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
         expect(processor.fullDefinition).toEqual(SAMPLE_COMMAND_DEFINITION);
     });
@@ -426,7 +437,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
         expect(processor.helpGenerator).toEqual(FAKE_HELP_GENERATOR);
     });
@@ -437,7 +449,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
         expect(processor.profileFactory).toEqual(FAKE_PROFILE_MANAGER_FACTORY);
     });
@@ -452,7 +465,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock the process write
@@ -475,7 +489,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         let error;
@@ -496,7 +511,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         const validateResponse: ICommandValidatorResponse = await processor.validate({
@@ -514,7 +530,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         let error;
@@ -535,7 +552,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         let error;
@@ -560,7 +578,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         let error;
@@ -581,7 +600,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         let error;
@@ -602,7 +622,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         let error;
@@ -624,7 +645,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         let error;
@@ -646,7 +668,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         const parms: any = {arguments: {_: ["banana"], $0: "", valid: false}, responseFormat: "json", silent: true};
@@ -668,7 +691,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         const parms: any = {
@@ -693,7 +717,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         const parms: any = {
@@ -714,7 +739,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         const parms: any = {arguments: {_: [], $0: "", syntaxThrow: true}, responseFormat: "json", silent: true};
@@ -732,7 +758,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -763,7 +790,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_DEFINITION,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -774,7 +802,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -807,7 +835,8 @@ describe("Command Processor", () => {
             definition: commandDef,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -818,7 +847,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -857,7 +886,8 @@ describe("Command Processor", () => {
             definition: commandDef,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -868,7 +898,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -916,7 +946,8 @@ describe("Command Processor", () => {
             definition: commandDef,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -927,7 +958,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -957,7 +988,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -968,7 +1000,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -998,7 +1030,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1009,7 +1042,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1038,7 +1071,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1049,7 +1083,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1087,7 +1121,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1098,7 +1133,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1127,7 +1162,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1138,7 +1174,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1167,7 +1203,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1178,7 +1215,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1204,7 +1241,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER_WITH_OPT,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1215,7 +1253,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     return;
                 }
             };
@@ -1251,7 +1289,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER_WITH_DEFAULT_OPT,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1262,7 +1301,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     return;
                 }
             };
@@ -1295,7 +1334,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER_WITH_POS_OPT,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1306,7 +1346,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     return;
                 }
             };
@@ -1342,7 +1382,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER_WITH_POS_OPT,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1353,7 +1394,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     return;
                 }
             };
@@ -1390,7 +1431,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER_WITH_OPT,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY_WITH_PROPS,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1401,7 +1443,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     return;
                 }
             };
@@ -1439,7 +1481,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1450,7 +1493,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1477,7 +1520,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMPLEX_COMMAND,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
         const commandResponse: ICommandResponse = await processor.help(new CommandResponse({silent: true}));
         expect(commandResponse).toBeDefined();
@@ -1493,7 +1537,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_WIH_NO_HANDLER,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
         } catch (e) {
             error = e;
@@ -1512,7 +1557,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1523,7 +1569,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1555,7 +1601,8 @@ describe("Command Processor", () => {
             definition: SAMPLE_COMMAND_REAL_HANDLER,
             helpGenerator: FAKE_HELP_GENERATOR,
             profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-            rootCommandName: SAMPLE_ROOT_COMMAND
+            rootCommandName: SAMPLE_ROOT_COMMAND,
+            commandLine: ""
         });
 
         // Mock read stdin
@@ -1566,7 +1613,7 @@ describe("Command Processor", () => {
         // Mock the profile loader
         CommandProfileLoader.loader = jest.fn((args) => {
             return {
-                loadProfiles: (profArgs) => {
+                loadProfiles: (profArgs: any) => {
                     // Nothing to do
                 }
             };
@@ -1635,7 +1682,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
 
             const dummyResponseObject = getDummyResponseObject();
@@ -1660,7 +1708,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
 
             const dummyResponseObject = getDummyResponseObject();
@@ -1685,7 +1734,8 @@ describe("Command Processor", () => {
                 definition: SAMPLE_COMMAND_DEFINITION_WITH_EXAMPLES,
                 helpGenerator: FAKE_HELP_GENERATOR,
                 profileManagerFactory: FAKE_PROFILE_MANAGER_FACTORY,
-                rootCommandName: SAMPLE_ROOT_COMMAND
+                rootCommandName: SAMPLE_ROOT_COMMAND,
+                commandLine: ""
             });
 
             const dummyResponseObject = getDummyResponseObject();

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -264,26 +264,35 @@ export class CommandProcessor {
                 `${CommandProcessor.ERROR_TAG} invoke(): Cannot invoke the handler for command "${this.definition.name}". The handler is blank.`);
         }
 
-        // Log the invoke
-        this.log.info(`Invoking command "${this.definition.name}"...`);
-        this.log.info(`rootCommand issued:\n\n${TextUtils.prettyJson(this.rootCommand)}`);
-        this.log.info(`commandLine issued:\n\n${TextUtils.prettyJson(this.commandLine)}`);
-        this.log.info(`Command issued:\n\n${TextUtils.prettyJson(this.rootCommand + " " + this.commandLine)}`);
+        let commandLine = this.commandLine;
 
-        const edit = this.commandLine;
-        let edit2 = "";
+        // determine if the command has the password option and mask out the password value
         const regEx = /--(password|pass|pw) ([^\s]+)/gi;
-        this.log.info(`edit issued:\n\n${TextUtils.prettyJson(edit)}`);
-        if ((edit.search(regEx)) >= 0) {
-            edit2 = edit.replace(regEx, "--pw ****");
-            // const editArray = edit.split("--");  // ).substr(0, edit.indexOf("--pw"), edit.indexOf(""));
-            // this.log.info(editArray.toString());
-            // const passwordArray =
-            this.log.info(edit2);
+
+        if ((commandLine.search(regEx)) >= 0) {
+            // determine which version of password option used to ensure it's used in the log.
+            let passwordString = "";
+            let regEx2 = /--password /gi;
+            if (commandLine.search(regEx2) >= 0) {
+                passwordString = "password";
+            }
+            regEx2 = /--pass /gi;
+            if (commandLine.search(regEx2) >= 0) {
+                passwordString = "pass";
+            }
+            regEx2 = /--pw /gi;
+            if (commandLine.search(regEx2) >= 0) {
+                passwordString = "pw";
+            }
+
+            commandLine = commandLine.replace(regEx, "--" + passwordString + " ****");
+
         }
 
-        this.log.info(`post edit issued:\n\n${TextUtils.prettyJson(edit2)}`);
-
+        // this.log.info(`post commandLine issued:\n\n${TextUtils.prettyJson(commandLine)}`);
+        // Log the invoke
+        this.log.info(`Invoking command "${this.definition.name}"...`);
+        this.log.info(`Command issued:\n\n${TextUtils.prettyJson(this.rootCommand + " " + commandLine)}`);
         this.log.trace(`Invoke parameters:\n${inspect(params, { depth: null })}`);
         this.log.trace(`Command definition:\n${inspect(this.definition, { depth: null })}`);
 

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -266,7 +266,24 @@ export class CommandProcessor {
 
         // Log the invoke
         this.log.info(`Invoking command "${this.definition.name}"...`);
+        this.log.info(`rootCommand issued:\n\n${TextUtils.prettyJson(this.rootCommand)}`);
+        this.log.info(`commandLine issued:\n\n${TextUtils.prettyJson(this.commandLine)}`);
         this.log.info(`Command issued:\n\n${TextUtils.prettyJson(this.rootCommand + " " + this.commandLine)}`);
+
+        const edit = this.commandLine;
+        let edit2 = "";
+        const regEx = /--(password|pass|pw) ([^\s]+)/gi;
+        this.log.info(`edit issued:\n\n${TextUtils.prettyJson(edit)}`);
+        if ((edit.search(regEx)) >= 0) {
+            edit2 = edit.replace(regEx, "--pw ****");
+            // const editArray = edit.split("--");  // ).substr(0, edit.indexOf("--pw"), edit.indexOf(""));
+            // this.log.info(editArray.toString());
+            // const passwordArray =
+            this.log.info(edit2);
+        }
+
+        this.log.info(`post edit issued:\n\n${TextUtils.prettyJson(edit2)}`);
+
         this.log.trace(`Invoke parameters:\n${inspect(params, { depth: null })}`);
         this.log.trace(`Command definition:\n${inspect(this.definition, { depth: null })}`);
 


### PR DESCRIPTION
Fixed CommandProcessor.test.ts and SyntaxValidator.integration.test.ts to include commandLine in CommandProcessor constructor.

Fixed CommandProcessor.test.ts by adding 'any' to 'profArgs'.

Fixed CommandProcessor to mask password value in log file when included in a command.
  Examples:  '--password abcde' is changed to '--password ****'
                    '--pass abcde' is changed to '--pass ****'
                    '--pw abcde' is changed to '--pw ****'
