### PR TITLE
Update jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -542,7 +542,7 @@ pipeline {
                     // this should be the same as our current commit since concurrency builds are turned
                     // off for that branch
                     sh "git reset --hard HEAD"
-                    sh "git checkout ${DEV_BRANCH.master}"
+                    sh "git checkout ${BRANCH_NAME}"
 
                     // Make sure that the revision of the build and the current revision of the DEV_BRANCH.master match
                     script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,14 +17,20 @@ def UNIT_RESULTS = "${TEST_RESULTS_FOLDER}/unit"
 def INTEGRATION_RESULTS = "${TEST_RESULTS_FOLDER}/integration"
 
 /**
- * The name of the master branch
- */
-def MASTER_BRANCH = "master"
+* Development branches considered for release purposes
+*/ 
+def DEV_BRANCH = [
+    master: "master",
+    beta: "beta",
+    latest: "latest",
+    incremental: "lts-incremental",
+    stable: "lts-stable",
+]
 
 /**
-* Is this a release branch? Temporary workaround that won't break everything horribly if we merge.
+* List of release branches
 */ 
-def RELEASE_BRANCH = false
+def RELEASE_BRANCHES = [DEV_BRANCH.master, DEV_BRANCH.beta, DEV_BRANCH.latest, DEV_BRANCH.incremental, DEV_BRANCH.stable]
 
 /**
  * List of people who will get all emails for master builds
@@ -81,12 +87,11 @@ def ARTIFACTORY_CREDENTIALS_ID = 'GizaArtifactory'
  */
 def ARTIFACTORY_EMAIL = GIT_USER_EMAIL
 
-
 // Setup conditional build options. Would have done this in the options of the declarative pipeline, but it is pretty
 // much impossible to have conditional options based on the branch :/
 def opts = []
 
-if (BRANCH_NAME == MASTER_BRANCH) {
+if (RELEASE_BRANCHES.contains(BRANCH_NAME)) {
     // Only keep 20 builds
     opts.push(buildDiscarder(logRotator(numToKeepStr: '20')))
 
@@ -95,9 +100,6 @@ if (BRANCH_NAME == MASTER_BRANCH) {
     // twice in quick succession
     opts.push(disableConcurrentBuilds())
 } else {
-    if (BRANCH_NAME.equals("1.0.0")){
-        RELEASE_BRANCH = true   
-    }
     // Only keep 5 builds on other branches
     opts.push(buildDiscarder(logRotator(numToKeepStr: '5')))
 }
@@ -491,7 +493,7 @@ pipeline {
          * EXECUTION CONDITIONS
          * --------------------
          * - SHOULD_BUILD is true
-         * - The current branch is the MASTER_BRANCH
+         * - The current branch is the DEV_BRANCH.master
          * - The build is still successful and not unstable
          *
          * DESCRIPTION
@@ -528,7 +530,7 @@ pipeline {
                         return currentBuild.resultIsBetterOrEqualTo(BUILD_SUCCESS)
                     }
                     expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH) && !RELEASE_BRANCH   
+                        return BRANCH_NAME.equals(DEV_BRANCH.master) || BRANCH_NAME.equals(DEV_BRANCH.beta)
                     }
                 }
             }
@@ -540,9 +542,9 @@ pipeline {
                     // this should be the same as our current commit since concurrency builds are turned
                     // off for that branch
                     sh "git reset --hard HEAD"
-                    sh "git checkout ${MASTER_BRANCH}"
+                    sh "git checkout ${DEV_BRANCH.master}"
 
-                    // Make sure that the revision of the build and the current revision of the MASTER_BRANCH match
+                    // Make sure that the revision of the build and the current revision of the DEV_BRANCH.master match
                     script {
                         revision = sh returnStdout: true, script: GIT_REVISION_LOOKUP
 
@@ -559,18 +561,25 @@ pipeline {
 
                     // This script block does the version bump, and a git commit and tag
                     script {
-                        def baseVersion = sh returnStdout: true, script: 'node -e "console.log(require(\'./package.json\').version.split(\'-\')[0])"'
-                        def preReleaseVersion = baseVersion.trim() + "-next." + new Date().format("yyyyMMddHHmm", TimeZone.getTimeZone("UTC")) 
-                        sh "npm version ${preReleaseVersion} -m \"Bumped pre-release version to ${preReleaseVersion} [ci skip]\""
+                        if (BRANCH_NAME.equals(DEV_BRANCH.master)) {
+                            def baseVersion = sh returnStdout: true, script: 'node -e "console.log(require(\'./package.json\').version.split(\'-\')[0])"'
+                            def preReleaseVersion = baseVersion.trim() + "-alpha." + new Date().format("yyyyMMddHHmm", TimeZone.getTimeZone("UTC")) 
+                            sh "npm version ${preReleaseVersion} -m \"Bumped pre-release version to ${preReleaseVersion} [ci skip]\""
+                        }
+                        else if (BRANCH_NAME.equals(DEV_BRANCH.beta)) {
+                            def baseVersion = sh returnStdout: true, script: 'node -e "console.log(require(\'./package.json\').version.split(\'-\')[0])"'
+                            def preReleaseVersion = baseVersion.trim() + "-beta." + new Date().format("yyyyMMddHHmm", TimeZone.getTimeZone("UTC")) 
+                            sh "npm version ${preReleaseVersion} -m \"Bumped pre-release version to ${preReleaseVersion} [ci skip]\""
+                        }
                     }
 
                     // For debugging purposes
-                    echo "Current Status of ${MASTER_BRANCH}"
+                    echo "Current Status of ${DEV_BRANCH.master}"
                     sh "git status"
 
                     // Do the push with credentials from the jenkins server
                     withCredentials([usernameColonPassword(credentialsId: GIT_CREDENTIALS_ID, variable: 'TOKEN')]) {
-                        sh "git push https://${TOKEN}@${GIT_REPO_URL} ${MASTER_BRANCH} --follow-tags"
+                        sh "git push https://${TOKEN}@${GIT_REPO_URL} ${DEV_BRANCH.master} --follow-tags"
                     }
 
                     script {
@@ -594,7 +603,7 @@ pipeline {
          * --------------------
          * - SHOULD_BUILD is true
          * - GIT_SOURCE_UPDATED is true (meaning that we were able to do the bump)
-         * - The current branch is the MASTER_BRANCH
+         * - The current branch is the DEV_BRANCH.master
          * - The build is still successful and not unstable
          *
          * DESCRIPTION
@@ -613,13 +622,10 @@ pipeline {
                         return SHOULD_BUILD == 'true'
                     }
                     expression {
-                        return GIT_SOURCE_UPDATED == 'true' || RELEASE_BRANCH
-                    }
-                    expression {
                         return currentBuild.resultIsBetterOrEqualTo(BUILD_SUCCESS)
                     }
                     expression {
-                        return BRANCH_NAME.equals(MASTER_BRANCH) || RELEASE_BRANCH;   
+                        return GIT_SOURCE_UPDATED == 'true' || RELEASE_BRANCHES.contains(BRANCH_NAME)
                     }
                 }
             }
@@ -633,22 +639,21 @@ pipeline {
                                 script: "node -e \"process.stdout.write(require('./package.json').publishConfig.registry)\""
                         sh "sudo npm config set registry ${npmRegistry.trim()}"
                     }
+                    // Login to the registry before publishing
+                    withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+                        sh "expect -f ./jenkins/npm_login.expect $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\""
+                    }
+
                     script {
-                        if (RELEASE_BRANCH){
-                            withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                sh "expect -f ./jenkins/npm_login.expect $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\""
-                                sh 'npm publish --tag latest'
-                                sh 'npm logout || exit 0'
-                            }
+                        if (BRANCH_NAME.equals(DEV_BRANCH.master)) {
+                            sh 'npm publish --tag daily'
                         }
-                        else{
-                            withCredentials([usernamePassword(credentialsId: ARTIFACTORY_CREDENTIALS_ID, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                sh "expect -f ./jenkins/npm_login.expect $USERNAME $PASSWORD \"$ARTIFACTORY_EMAIL\""
-                                sh 'npm publish --tag beta'
-                                sh 'npm logout || exit 0'
-                            }
+                        else {
+                            sh "npm publish --tag ${BRANCH_NAME}"
                         }
                     }
+
+                    sh 'npm logout || exit 0'
                 }
             }
         }
@@ -664,11 +669,11 @@ pipeline {
          * - It is the first build for a new branch
          * - The build is successful but the previous build was not
          * - The build failed or is unstable
-         * - The build is on the MASTER_BRANCH
+         * - The build is on the DEV_BRANCH.master
          *
          * In the case that an email was sent out, it will send it to individuals
          * who were involved with the build and if broken those involved in
-         * breaking the build. If this build is for the MASTER_BRANCH, then an
+         * breaking the build. If this build is for the DEV_BRANCH.master, then an
          * additional set of individuals will also get an email that the build
          * occurred.
          ************************************************************************/
@@ -703,7 +708,7 @@ pipeline {
                             details = "${details}<p>Build Failure.</p>"
                         }
 
-                        if (BRANCH_NAME == MASTER_BRANCH) {
+                        if (BRANCH_NAME == DEV_BRANCH.master) {
                             recipients = MASTER_RECIPIENTS_LIST
 
                             details = "${details}<p>A build of master has finished.</p>"
@@ -718,7 +723,7 @@ pipeline {
 
                                 <b>Possible causes of this error:</b>
                                 <ul>
-                                    <li>A commit was made to <b>${MASTER_BRANCH}</b> during the current run.</li>
+                                    <li>A commit was made to <b>${DEV_BRANCH.master}</b> during the current run.</li>
                                     <li>The user account tied to the build is no longer valid.</li>
                                     <li>The remote server is experiencing issues.</li>
                                 </ul>

--- a/package.json
+++ b/package.json
@@ -2,11 +2,16 @@
   "name": "@brightside/imperative",
   "version": "2.0.0-next.201901162101",
   "description": "framework for building configurable CLIs",
+  "author": "Broadcom",
   "license": "EPL 2.0",
-  "repository": "https://github.com/gizafoundation/imperative",
-  "author": "CA",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zowe/imperative.git"
+  },
   "keywords": [
-    "CLI"
+    "CLI",
+    "framework",
+    "zowe"
   ],
   "pkg": {
     "scripts": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightside/imperative",
-  "version": "2.0.0-next.201901162101",
+  "version": "2.0.0",
   "description": "framework for building configurable CLIs",
   "author": "Broadcom",
   "license": "EPL 2.0",


### PR DESCRIPTION
This PR accomplishes the following things:
- Update the jenkinsfile with the same changes as master
  - Add support for all release branches
- Updates the version in package.json
  - The use of CI skip is to prevent a failure in the deploy stage as this version (2.0.0 was already published)