### PR TITLE
Allow a blank file to be written with IO.writeFileAsync

### DIFF
--- a/packages/io/__tests__/__snapshots__/IO.test.ts.snap
+++ b/packages/io/__tests__/__snapshots__/IO.test.ts.snap
@@ -24,11 +24,11 @@ exports[`IO tests should get an error for no input on readFileSync 1`] = `"Expec
 
 exports[`IO tests should get an error for no input on writeFile 1`] = `"Expect Error: Required parameter 'file' must not be blank"`;
 
-exports[`IO tests should get an error for no input on writeFile second parm 1`] = `"Expect Error: content"`;
+exports[`IO tests should get an error for no input on writeFile second parm 1`] = `"Expect Error: Content to write to the file must not be null or undefined"`;
 
 exports[`IO tests should get an error for no input on writeFileAsync 1`] = `"Expect Error: Required parameter 'file' must not be blank"`;
 
-exports[`IO tests should get an error for no input on writeFileAsync second parm 1`] = `"Expect Error: Required object must be defined"`;
+exports[`IO tests should get an error for no input on writeFileAsync second parm 1`] = `"Expect Error: Content to write to the file must not be null or undefined"`;
 
 exports[`IO tests should get an error for no input on writeObject 1`] = `"Expect Error: Required parameter 'configFile' must not be blank"`;
 

--- a/packages/io/src/IO.ts
+++ b/packages/io/src/IO.ts
@@ -287,7 +287,7 @@ export class IO {
      */
     public static writeFileAsync(file: string, content: string) {
         ImperativeExpect.toBeDefinedAndNonBlank(file, "file");
-        ImperativeExpect.toBeDefinedAndNonBlank(content, "content");
+        ImperativeExpect.toNotBeNullOrUndefined(content, "Content to write to the file must not be null or undefined");
         return new Promise<void>((resolve, reject: ImperativeReject) => {
             try {
                 fs.writeFile(file, content, IO.UTF8, (err) => {
@@ -312,7 +312,7 @@ export class IO {
      */
     public static writeFile(file: string, content: Buffer) {
         ImperativeExpect.toBeDefinedAndNonBlank(file, "file");
-        ImperativeExpect.toNotBeNullOrUndefined(content, "content");
+        ImperativeExpect.toNotBeNullOrUndefined(content, "Content to write to the file must not be null or undefined");
         IO.createFileSync(file);
         fs.writeFileSync(file, content);
     }
@@ -412,16 +412,16 @@ export class IO {
             }
         } catch (ioExcept) {
             throw new ImperativeError({
-                msg: "Failed to delete the symbolic link '" + symLinkPath +
-                    "'\nReason: " + ioExcept.message + "\n" +
-                    "Full exception: " + ioExcept
+                    msg: "Failed to delete the symbolic link '" + symLinkPath +
+                        "'\nReason: " + ioExcept.message + "\n" +
+                        "Full exception: " + ioExcept
                 }
             );
         }
 
         throw new ImperativeError({
-            msg: "The specified symlink '" + symLinkPath +
-                "' already exists and is not a symbolic link. So, we did not delete it."
+                msg: "The specified symlink '" + symLinkPath +
+                    "' already exists and is not a symbolic link. So, we did not delete it."
             }
         );
     }


### PR DESCRIPTION
In certain contexts such as https://github.com/zowe/zowe-cli/issues/218, writing a blank file is valid.  When this change is published and consumed from Zowe CLI, this issue will be fixed