### PR TITLE
Migrate package name to @zowe/imperative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,7 @@ __tests__/src/plugins/suites/sample-plugin.json
 ## Including imperative symbolic link for testing purposes
 !/__tests__/src/packages/imperative/plugins/test_cli/node_modules/
 /__tests__/src/packages/imperative/plugins/test_cli/node_modules/**
-!/__tests__/src/packages/imperative/plugins/test_cli/node_modules/@brightside/
-/__tests__/src/packages/imperative/plugins/test_cli/node_modules/@brightside/**
-!/__tests__/src/packages/imperative/plugins/test_cli/node_modules/@brightside/imperative
+!/__tests__/src/packages/imperative/plugins/test_cli/node_modules/@zowe/
+/__tests__/src/packages/imperative/plugins/test_cli/node_modules/@zowe/**
+!/__tests__/src/packages/imperative/plugins/test_cli/node_modules/@zowe/imperative
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-@brightside:registry=https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/
+@zowe:registry=https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/
 @zowe:registry=https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 @zowe:registry=https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/
-@zowe:registry=https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ node('ca-jenkins-agent') {
     pipeline.publishConfig = [
         email: pipeline.gitConfig.email,
         credentialsId: 'GizaArtifactory',
-        scope: '@brightside'
+        scope: '@zowe'
     ]
 
     pipeline.registryConfig = [

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Within the imperative repository, we provide you with all the tools that you nee
 
 Issue the following commands to install Imperative CLI Framework as a dependency:
 ``` bash
-npm config set @brightside:registry https://api.bintray.com/npm/ca/brightside
-npm install --save @brightside/imperative
+npm config set @zowe:registry https://api.bintray.com/npm/ca/brightside
+npm install --save @zowe/imperative
 ```
 
 ## Get Started

--- a/__tests__/src/packages/imperative/plugins/PluginManagementFacility.spec.ts
+++ b/__tests__/src/packages/imperative/plugins/PluginManagementFacility.spec.ts
@@ -51,7 +51,7 @@ describe("Plugin Management Facility", () => {
          * tree's lib directory. All of the modules then find things where they
          * expect to see them.
          */
-        const namespaceDirPath = join(testCliNodeModulePath, "@brightside");
+        const namespaceDirPath = join(testCliNodeModulePath, "@zowe");
         IO.mkdirp(namespaceDirPath);
         const testCliImpSymLink = join(namespaceDirPath, "imperative");
         IO.createSymlinkToDir(testCliImpSymLink, impLibDir);

--- a/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/InstallingPlugins.ts
@@ -142,7 +142,7 @@ describe("Installing Plugins", () => {
     // Now go ahead and install the sample
     result = executeCommandString(this, `${pluginGroup} install ${plugins.normal.location}`);
     expect(result.stderr).toMatch(/npm.*WARN/);
-    expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+    expect(result.stderr).toContain("requires a peer of @zowe/imperative");
     expect(result.stderr).toContain("You must install peer dependencies yourself");
 
     const strippedOutput = T.stripNewLines(result.stdout);
@@ -168,7 +168,7 @@ describe("Installing Plugins", () => {
     // Now check that they install
     result = executeCommandString(this, `${pluginGroup} install ${plugins.normal.location} ${plugins.normal2.location} --registry ${TEST_REGISTRY}`);
     expect(result.stderr).toMatch(/npm.*WARN/);
-    expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+    expect(result.stderr).toContain("requires a peer of @zowe/imperative");
     expect(result.stderr).toContain("You must install peer dependencies yourself");
 
     const strippedOutput = T.stripNewLines(result.stdout);
@@ -190,7 +190,7 @@ describe("Installing Plugins", () => {
     const beforeInstall = executeCommandString(this, "--help");
     let result = executeCommandString(this, `${pluginGroup} install ${plugins.normal.location}`);
     expect(result.stderr).toMatch(/npm.*WARN/);
-    expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+    expect(result.stderr).toContain("requires a peer of @zowe/imperative");
     expect(result.stderr).toContain("You must install peer dependencies yourself");
 
     let strippedOutput = T.stripNewLines(result.stdout);
@@ -209,7 +209,7 @@ describe("Installing Plugins", () => {
     // Try to install it back by using the plugins.json file that should still exist
     result = executeCommandString(this, `${pluginGroup} install`);
     expect(result.stderr).toMatch(/npm.*WARN/);
-    expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+    expect(result.stderr).toContain("requires a peer of @zowe/imperative");
     expect(result.stderr).toContain("You must install peer dependencies yourself");
 
     strippedOutput = T.stripNewLines(result.stdout);
@@ -231,7 +231,7 @@ describe("Installing Plugins", () => {
     // Now go ahead and install the sample
     result = T.executeTestCLICommand(cliBin, this, [pluginGroup, "install", plugins.space_in_path.location]);
     expect(result.stderr).toMatch(/npm.*WARN/);
-    expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+    expect(result.stderr).toContain("requires a peer of @zowe/imperative");
     expect(result.stderr).toContain("You must install peer dependencies yourself");
 
     const strippedOutput = T.stripNewLines(result.stdout);
@@ -359,7 +359,7 @@ describe("Installing Plugins", () => {
       const strippedOutput = T.stripNewLines(result.stdout);
 
       expect(result.stderr).toMatch(/npm.*WARN/);
-      expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+      expect(result.stderr).toContain("requires a peer of @zowe/imperative");
       expect(result.stderr).toContain("You must install peer dependencies yourself");
 
       expect(strippedOutput).toContain(`Installed plugin name = '${plugins.normal.name}'`);
@@ -398,7 +398,7 @@ describe("Installing Plugins", () => {
       );
 
       expect(result.stderr).toMatch(/npm.*WARN/);
-      expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+      expect(result.stderr).toContain("requires a peer of @zowe/imperative");
       expect(result.stderr).toContain("You must install peer dependencies yourself");
 
       expect(result.stdout).toContain(plugins.normal.name);
@@ -416,7 +416,7 @@ describe("Installing Plugins", () => {
       result = executeCommandString(this, `${pluginGroup} install --file ${testFile}`);
 
       expect(result.stderr).toMatch(/npm.*WARN/);
-      expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+      expect(result.stderr).toContain("requires a peer of @zowe/imperative");
       expect(result.stderr).toContain("You must install peer dependencies yourself");
 
       expect(result.stdout).toContain(plugins.normal.name);

--- a/__tests__/src/packages/imperative/plugins/suites/UsingPlugins.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/UsingPlugins.ts
@@ -45,7 +45,7 @@ describe("Using a Plugin", () => {
         let cmd = `plugins install ${installedPlugin}`;
         let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
         expect(result.stderr).toMatch(/npm.*WARN/);
-        expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+        expect(result.stderr).toContain("requires a peer of @zowe/imperative");
         expect(result.stderr).toContain("You must install peer dependencies yourself");
 
         cmd = ``;
@@ -93,7 +93,7 @@ describe("Using a Plugin", () => {
         let cmd = `plugins install ${installedPlugin}`;
         let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
         expect(result.stderr).toMatch(/npm.*WARN/);
-        expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+        expect(result.stderr).toContain("requires a peer of @zowe/imperative");
         expect(result.stderr).toContain("You must install peer dependencies yourself");
 
         cmd = ``;
@@ -152,7 +152,7 @@ describe("Using a Plugin", () => {
         let cmd = `plugins install ${installedPlugin}`;
         let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
         expect(result.stderr).toMatch(/npm.*WARN/);
-        expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+        expect(result.stderr).toContain("requires a peer of @zowe/imperative");
         expect(result.stderr).toContain("You must install peer dependencies yourself");
         let stdout = "";
 
@@ -246,7 +246,7 @@ describe("Using a Plugin", () => {
         let cmd = `plugins install ${installedPlugin}`;
         let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
         expect(result.stderr).toMatch(/npm.*WARN/);
-        expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+        expect(result.stderr).toContain("requires a peer of @zowe/imperative");
         expect(result.stderr).toContain("You must install peer dependencies yourself");
 
         // confirm the plugin summary is displayed from zowe help

--- a/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
@@ -122,7 +122,7 @@ describe("Validate plugin", () => {
                 let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
 
                 expect(result.stderr).toMatch(/npm.*WARN/);
-                expect(result.stderr).toContain("requires a peer of @brightside/imperative");
+                expect(result.stderr).toContain("requires a peer of @zowe/imperative");
                 expect(result.stderr).toContain("You must install peer dependencies yourself");
 
                 expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);

--- a/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
@@ -182,7 +182,7 @@ describe("Validate plugin", () => {
                 result.stderr = removeNewline(result.stderr);
                 expect(result.stdout).toContain(testPlugin);
                 expect(result.stdout).toContain("Warning");
-                expect(result.stdout).toContain("Your '@brightside' dependencies must be contained within a 'peerDependencies' property." +
+                expect(result.stdout).toContain("Your '@zowe' dependencies must be contained within a 'peerDependencies' property." +
                     " That property does not exist in the file");
                 expect(result.stdout).toContain("package.json");
             });

--- a/__tests__/src/packages/imperative/plugins/test_cli/TestConfiguration.ts
+++ b/__tests__/src/packages/imperative/plugins/test_cli/TestConfiguration.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { IImperativeConfig } from "@brightside/imperative";
+import { IImperativeConfig } from "@zowe/imperative";
 import { join } from "path";
 import { TestProfileConfig1 } from "./TestProfileConfig1";
 import { TestProfileConfig2 } from "./TestProfileConfig2";

--- a/__tests__/src/packages/imperative/plugins/test_cli/TestProfileConfig1.ts
+++ b/__tests__/src/packages/imperative/plugins/test_cli/TestProfileConfig1.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandProfileTypeConfiguration } from "@brightside/imperative";
+import { ICommandProfileTypeConfiguration } from "@zowe/imperative";
 
 export const TestProfileConfig1: ICommandProfileTypeConfiguration = {
   type: "TestProfile1",

--- a/__tests__/src/packages/imperative/plugins/test_cli/TestProfileConfig2.ts
+++ b/__tests__/src/packages/imperative/plugins/test_cli/TestProfileConfig2.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandProfileTypeConfiguration } from "@brightside/imperative";
+import { ICommandProfileTypeConfiguration } from "@zowe/imperative";
 
 export const TestProfileConfig2: ICommandProfileTypeConfiguration = {
   type: "TestProfile2",

--- a/__tests__/src/packages/imperative/plugins/test_cli/TestProfileValidationPlan1.ts
+++ b/__tests__/src/packages/imperative/plugins/test_cli/TestProfileValidationPlan1.ts
@@ -14,7 +14,7 @@ import {
   IProfileValidationTask,
   IProfileValidationTaskResult,
   VALIDATION_OUTCOME
-} from "@brightside/imperative";
+} from "@zowe/imperative";
 
 // you can implement the validation plan as a Typescript class
 // or any other way that allows us to  do: new (require("your profile validation plan module file name"))

--- a/__tests__/src/packages/imperative/plugins/test_cli/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_cli/package.json
@@ -2,6 +2,6 @@
   "name": "TestCLI",
   "version": "1.0.2",
   "dependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   }
 }

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_empty_array/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_empty_array/package.json
@@ -14,7 +14,7 @@
     "definitions": []
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_description/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_description/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_handler/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_handler/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_name/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_name/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_type/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_type/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_type_group_without_children/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_type_group_without_children/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/duplicated_base_cli_command/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/duplicated_base_cli_command/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/duplicated_installed_plugin_command/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/duplicated_installed_plugin_command/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/incompatible_imperative_version/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/incompatible_imperative_version/package.json
@@ -31,7 +31,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "author": "",
   "license": "EPL 2.0",

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_command_handler/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_command_handler/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_definitions/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_definitions/package.json
@@ -13,7 +13,7 @@
     "pluginHealthCheck": "./dummy.handler"
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_healthcheck_handler/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_healthcheck_handler/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_pluginBaseCliVersion/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_pluginBaseCliVersion/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_pluginHealthCheck/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_pluginHealthCheck/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_rootCommandDescription/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/missing_rootCommandDescription/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/profile_dup_in_plugin/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/profile_dup_in_plugin/package.json
@@ -10,7 +10,7 @@
     "configurationModule": "./configuration.js"
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/profile_dup_with_cli/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/profile_dup_with_cli/package.json
@@ -10,7 +10,7 @@
     "configurationModule": "./configuration.js"
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/missing_name_plugin/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/missing_name_plugin/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "TestCLI": "1.0.2",
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Defining handler to be use for the 'bar' command.

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 export default class FooHandler implements ICommandHandler {
     public process(params: IHandlerParameters): Promise<void>;
 }

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/lib/sample-plugin/healthCheck.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/lib/sample-plugin/healthCheck.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 export default class HealthCheckHandler implements ICommandHandler {
     public process(params: IHandlerParameters): Promise<void>;

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "TestCLI": "1.0.2",
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_2/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_2/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_3/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_3/package.json
@@ -10,7 +10,7 @@
     "configurationModule": "lib/sample-plugin/configuration.js"
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-apis/imperativeApis.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-apis/imperativeApis.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Defining handler to be use for the 'bar' command.

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-apis/imperativeApis.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-apis/imperativeApis.handler.js
@@ -1,5 +1,5 @@
 "use strict";
-var T = require("@brightside/imperative");
+var T = require("@zowe/imperative");
 
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-config/imperativeConfig.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-config/imperativeConfig.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Defining handler to be use for the 'bar' command.

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-config/imperativeConfig.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-config/imperativeConfig.handler.js
@@ -1,5 +1,5 @@
 "use strict";
-var T = require("@brightside/imperative");
+var T = require("@zowe/imperative");
 
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-error/imperativeError.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-error/imperativeError.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Defining handler to be use for the 'bar' command.

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-error/imperativeError.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-error/imperativeError.handler.js
@@ -1,5 +1,5 @@
 "use strict";
-var ImperativeError = require("@brightside/imperative").ImperativeError;
+var ImperativeError = require("@zowe/imperative").ImperativeError;
 
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-logging/imperativeLogging.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-logging/imperativeLogging.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Defining handler to be use for the 'bar' command.

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-logging/imperativeLogging.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/cmd/imperative-logging/imperativeLogging.handler.js
@@ -1,5 +1,5 @@
 "use strict";
-var T = require("@brightside/imperative");
+var T = require("@zowe/imperative");
 var path = require("path");
 
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/healthCheck.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/lib/sample-plugin/healthCheck.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 export default class HealthCheckHandler implements ICommandHandler {
     public process(params: IHandlerParameters): Promise<void>;

--- a/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/normal_plugin_misc/package.json
@@ -44,7 +44,7 @@
     ]
   },
   "peerDependencies": {
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Defining handler to be use for the 'bar' command.

--- a/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 export default class FooHandler implements ICommandHandler {
     public process(params: IHandlerParameters): Promise<void>;
 }

--- a/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/healthCheck.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/healthCheck.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 export default class HealthCheckHandler implements ICommandHandler {
     public process(params: IHandlerParameters): Promise<void>;

--- a/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/overrides/CredentialManager.override.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/overrides/CredentialManager.override.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { Logger } from "@brightside/imperative";
+import { Logger } from "@zowe/imperative";
 declare const _default: {
     new (service: string): {
         consoleLog: Logger;

--- a/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/overrides/CredentialManager.override.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/lib/sample-plugin/overrides/CredentialManager.override.js
@@ -17,7 +17,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-const imperative_1 = require("@brightside/imperative");
+const imperative_1 = require("@zowe/imperative");
 module.exports = class CredentialManagerOverrides extends imperative_1.AbstractCredentialManager {
     constructor(service, displayName) {
         super(service, displayName);

--- a/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/override_plugin/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "TestCLI": "1.0.2",
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 /**
  * Defining handler to be use for the 'bar' command.

--- a/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 export default class FooHandler implements ICommandHandler {
     public process(params: IHandlerParameters): Promise<void>;
 }

--- a/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/lib/sample-plugin/healthCheck.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/lib/sample-plugin/healthCheck.handler.d.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "@brightside/imperative";
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
 
 export default class HealthCheckHandler implements ICommandHandler {
     public process(params: IHandlerParameters): Promise<void>;

--- a/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/space in path plugin/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "TestCLI": "1.0.2",
-    "@brightside/imperative": "1.0.0"
+    "@zowe/imperative": "1.0.0"
   },
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@brightside/imperative",
+  "name": "@zowe/imperative",
   "version": "3.1.0-alpha.201902272042",
   "description": "framework for building configurable CLIs",
   "author": "Broadcom",

--- a/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
+++ b/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
@@ -126,7 +126,7 @@ describe("Plugin Management Facility", () => {
         npmPackageName: "PluginHasNoNpmPkgName",
         impConfig: basePluginConfig,
         cliDependency: {
-            peerDepName: "@brightside/core",
+            peerDepName: "@zowe/core",
             peerDepVer: "-1"
         },
         impDependency: {
@@ -1221,13 +1221,13 @@ describe("Plugin Management Facility", () => {
                 description: "Some description",
                 imperative: expectedCfgProps.impConfig,
                 peerDependencies: {
-                    "@brightside/coreIsNotInPkgJson": "1.x",
+                    "@zowe/coreIsNotInPkgJson": "1.x",
                     "@zowe/imperative": "1.x"
                 }
             });
 
             // utility functions mocked to return good values
-            mockGetCliPkgName.mockReturnValue("@brightside/core");
+            mockGetCliPkgName.mockReturnValue("@zowe/core");
             mockGetCliCmdName.mockReturnValue("testCliName");
             mockCfgLoad.mockReturnValue(expectedCfgProps.impConfig);
 
@@ -1242,7 +1242,7 @@ describe("Plugin Management Facility", () => {
             expect(pluginIssues.getIssueListForPlugin(pluginName).length).toBe(1);
             const recordedIssue = pluginIssues.getIssueListForPlugin(pluginName)[0];
             expect(recordedIssue.issueSev).toBe(IssueSeverity.WARNING);
-            expect(recordedIssue.issueText).toContain("The property '@brightside/core' does not exist within the 'peerDependencies' property");
+            expect(recordedIssue.issueText).toContain("The property '@zowe/core' does not exist within the 'peerDependencies' property");
         });
 
         it("should return a plugin config when there are no errors", () => {
@@ -1260,13 +1260,13 @@ describe("Plugin Management Facility", () => {
                 description: "Some description",
                 imperative: expectedCfgProps.impConfig,
                 peerDependencies: {
-                    "@brightside/core": "1.x",
+                    "@zowe/core": "1.x",
                     "@zowe/imperative": "1.x"
                 }
             });
 
             // utility functions mocked to return good values
-            mockGetCliPkgName.mockReturnValue("@brightside/core");
+            mockGetCliPkgName.mockReturnValue("@zowe/core");
             mockGetCliCmdName.mockReturnValue("testCliName");
             mockCfgLoad.mockReturnValue(expectedCfgProps.impConfig);
 

--- a/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
+++ b/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
@@ -130,7 +130,7 @@ describe("Plugin Management Facility", () => {
             peerDepVer: "-1"
         },
         impDependency: {
-            peerDepName: "@brightside/imperative",
+            peerDepName: "@zowe/imperative",
             peerDepVer: "-1"
         }
     };
@@ -1222,7 +1222,7 @@ describe("Plugin Management Facility", () => {
                 imperative: expectedCfgProps.impConfig,
                 peerDependencies: {
                     "@brightside/coreIsNotInPkgJson": "1.x",
-                    "@brightside/imperative": "1.x"
+                    "@zowe/imperative": "1.x"
                 }
             });
 
@@ -1261,7 +1261,7 @@ describe("Plugin Management Facility", () => {
                 imperative: expectedCfgProps.impConfig,
                 peerDependencies: {
                     "@brightside/core": "1.x",
-                    "@brightside/imperative": "1.x"
+                    "@zowe/imperative": "1.x"
                 }
             });
 

--- a/packages/imperative/__tests__/plugins/PluginRequireProvider.test.ts
+++ b/packages/imperative/__tests__/plugins/PluginRequireProvider.test.ts
@@ -330,7 +330,7 @@ describe("PluginRequireProvider", () => {
                         "./anything",
                         "this-is-a-test-module",
                         "this-is",
-                        "@brightside/imperative",
+                        "@zowe/imperative",
                         "this-is-a-tests"
                     ]
                 },

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -11,7 +11,7 @@
 
 /**
  * Main class of the Imperative framework, returned when you
- * require("@brightside/imperative") e.g. const imperative =  require("@brightside/imperative");
+ * require("@zowe/imperative") e.g. const imperative =  require("@zowe/imperative");
  */
 import { PerfTiming } from "@zowe/perf-timing";
 

--- a/packages/imperative/src/__mocks__/ImperativeConfig.ts
+++ b/packages/imperative/src/__mocks__/ImperativeConfig.ts
@@ -28,7 +28,7 @@ export class ImperativeConfig {
     private mHostPackageName = "host-package";
 
     // Private so that tests can access and change the result of the get
-    private mImperativePackageName = "@brightside/imperative";
+    private mImperativePackageName = "@zowe/imperative";
 
     public static get instance(): ImperativeConfig {
         if (this.mInstance == null) {

--- a/packages/imperative/src/config/cmd/set/set.definition.ts
+++ b/packages/imperative/src/config/cmd/set/set.definition.ts
@@ -39,8 +39,8 @@ export const setDefinition: ICommandDefinition = {
     ],
     examples: [
         {
-            options: "credential-manager @brightside/keytar",
-            description: "Set the default credential manager to @brightside/keytar"
+            options: "credential-manager my-credential-manager",
+            description: "Set the default credential manager to my-credential-manager"
         }
     ],
 };

--- a/packages/imperative/src/plugins/PluginRequireProvider.ts
+++ b/packages/imperative/src/plugins/PluginRequireProvider.ts
@@ -161,7 +161,7 @@ export class PluginRequireProvider {
          * If modules = ["@zowe/imperative"]
          *    request = "@zowe/imperative/lib/errors"
          */
-         // This regular expression will match /(@brightside\/imperative)/.*/
+         // This regular expression will match /(@zowe\/imperative)/.*/
         /*
          * The ?: check after the group in the regular expression is to explicitly
          * require that a submodule import has to match. This is to account for the

--- a/packages/imperative/src/plugins/PluginRequireProvider.ts
+++ b/packages/imperative/src/plugins/PluginRequireProvider.ts
@@ -158,8 +158,8 @@ export class PluginRequireProvider {
          * It was designed this way to support submodule imports.
          *
          * Example:
-         * If modules = ["@brightside/imperative"]
-         *    request = "@brightside/imperative/lib/errors"
+         * If modules = ["@zowe/imperative"]
+         *    request = "@zowe/imperative/lib/errors"
          */
          // This regular expression will match /(@brightside\/imperative)/.*/
         /*

--- a/packages/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/plugins/cmd/install/install.handler.ts
@@ -98,9 +98,9 @@ export default class InstallHandler implements ICommandHandler {
           "at your own risk. CA Technologies makes no warranties regarding the use of\n" +
           "3rd party plug-ins.\n\n" +
           "Imperative's plugin installation program handles peer dependencies for modules\n" +
-          "in the @brightside namespace and missing package.json file,\n" +
+          "in the @zowe namespace and missing package.json file,\n" +
           "so you can safely ignore NPM warnings about\n" +
-          "missing peer dependencies related to @brightside modules and absent " +
+          "missing peer dependencies related to @zowe modules and absent " +
           join(PMFConstants.instance.PLUGIN_INSTALL_LOCATION, "package.json") + " file."
         );
 

--- a/packages/imperative/src/plugins/utilities/PMFConstants.ts
+++ b/packages/imperative/src/plugins/utilities/PMFConstants.ts
@@ -86,7 +86,7 @@ export class PMFConstants {
     public readonly PLUGIN_NODE_MODULE_LOCATION: string;
 
     constructor() {
-        this.NPM_NAMESPACE = "@brightside";
+        this.NPM_NAMESPACE = "@zowe";
         this.CLI_CORE_PKG_NAME = ImperativeConfig.instance.hostPackageName;
         this.IMPERATIVE_PKG_NAME = ImperativeConfig.instance.imperativePackageName;
         this.PMF_ROOT = join(ImperativeConfig.instance.cliHome, "plugins");

--- a/packages/imperative/src/plugins/utilities/__mocks__/PMFConstants.ts
+++ b/packages/imperative/src/plugins/utilities/__mocks__/PMFConstants.ts
@@ -34,7 +34,7 @@ export class PMFConstants {
   public readonly NPM_NAMESPACE: string;
 
   constructor() {
-    this.NPM_NAMESPACE = "@brightside";
+    this.NPM_NAMESPACE = "@zowe";
     this.CLI_CORE_PKG_NAME = ImperativeConfig.instance.hostPackageName;
     this.IMPERATIVE_PKG_NAME = ImperativeConfig.instance.imperativePackageName;
     this.PMF_ROOT = "/sample-cli/home/plugins/";


### PR DESCRIPTION
Users using the `@daily` version of the package will now need to import `@zowe/imperative` rather than `@brightside/imperative`