### PR TITLE
add summary to config group for shorter top level help

### DIFF
--- a/packages/imperative/src/config/ConfigManagementFacility.ts
+++ b/packages/imperative/src/config/ConfigManagementFacility.ts
@@ -70,6 +70,7 @@ export class ConfigManagementFacility {
         ImperativeConfig.instance.addCmdGrpToLoadedConfig({
             name: "config",
             type: "group",
+            summary: "Manage configuration and overrides.",
             description: "Manage configuration and overrides. To see all set-able options use \"list\" command.",
             children: [
                 // require("./cmd/get/get.definition").getDefinition,


### PR DESCRIPTION
On a CLI's root level help, make the config group help shorter. The user can see the full help on `clinamehere config --help` 
 (master only -- this isn't in LTS incremental)