### PR TITLE
Escape special characters when generating Markdown, fix #202

### DIFF
--- a/packages/cmd/__tests__/help/DefaultHelpGenerator.test.ts
+++ b/packages/cmd/__tests__/help/DefaultHelpGenerator.test.ts
@@ -40,6 +40,12 @@ describe("Default Help Generator", () => {
         produceMarkdown: false
     };
 
+    const PARMS_GENERATE_MARKDOWN: IHelpGeneratorFactoryParms = {
+        primaryHighlightColor: chalkColor,
+        rootCommandName: "test-help",
+        produceMarkdown: true
+    };
+
     const EXAMPLE_APPLE_OPTION: ICommandOptionDefinition = {
         name: "is-apple-tasty",
         aliases: ["iat"],
@@ -85,6 +91,16 @@ describe("Default Help Generator", () => {
             EXAMPLE_STRAWBERRY_OPTION,
             EXAMPLE_PICK_OPTION],
         experimental: true
+    };
+
+    const COMMAND_WITH_MARKDOWN_SPECIAL_CHRACTERS: ICommandDefinition = {
+        name: "an-example-command",
+        aliases: ["aec"],
+        type: "command",
+        description: "This is a command with Markdown special characters in the description # * -. " + LOREM,
+        options: [EXAMPLE_APPLE_OPTION,
+            EXAMPLE_STRAWBERRY_OPTION,
+            EXAMPLE_PICK_OPTION]
     };
 
     const EXAMPLE_TREE: ICommandDefinition = {
@@ -466,6 +482,12 @@ describe("Default Help Generator", () => {
                 fullCommandTree: expParent
             });
             expect(experimental.getExperimentalCommandSection()).toMatchSnapshot();
+        });
+
+        it("should escape Markdown special characters in the description when markdown is rendered",  () => {
+            const helpGen: DefaultHelpGenerator = new DefaultHelpGenerator(PARMS_GENERATE_MARKDOWN,
+                { commandDefinition: COMMAND_WITH_MARKDOWN_SPECIAL_CHRACTERS, fullCommandTree: fakeParent });
+            expect(helpGen.buildDescriptionSection()).toMatchSnapshot();
         });
     });
 });

--- a/packages/cmd/__tests__/help/__snapshots__/DefaultHelpGenerator.test.ts.snap
+++ b/packages/cmd/__tests__/help/__snapshots__/DefaultHelpGenerator.test.ts.snap
@@ -391,3 +391,15 @@ exports[`Default Help Generator help text builder should construct multiple tabl
 
 "
 `;
+
+exports[`Default Help Generator help text builder should escape Markdown special characters in the description when markdown is rendered 1`] = `
+"This is a command with Markdown special characters in the description \\\\# \\\\* \\\\-\\\\.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua\\\\. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat\\\\.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+fugiat nulla pariatur\\\\. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum\\\\.
+
+"
+`;

--- a/packages/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/cmd/src/help/DefaultHelpGenerator.ts
@@ -346,7 +346,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         let description = this.mCommandDefinition.description
             || this.mCommandDefinition.summary;
         if (this.mProduceMarkdown) {
-            description = description.replace(/\*/g, "&ast;");  // escape literal asterisks
+            description = description.replace(/([\*\#\-\`\_\[\]\+\.\!])/g, "\\$1");  // escape Markdown special characters
         }
         descriptionForHelp += TextUtils.wordWrap(description,
             undefined,


### PR DESCRIPTION
It turns out there are a bunch of special characters that need escaping when generating Markdown.  This fix slightly over-escapes e.g. periods only need escaping when following a number. However, it's still corrrect and without implementing half a Markdown parser I think it's tricky to do better.