### PR TITLE
Return only directories from ProfileIO.getAllProfileDirectories (master)

### DIFF
--- a/packages/cmd/__tests__/profiles/CliProfileManager.test.ts
+++ b/packages/cmd/__tests__/profiles/CliProfileManager.test.ts
@@ -40,7 +40,7 @@ describe("Cli Profile Manager", () => {
         return path.indexOf("meta") === -1 ? path : undefined;
     });
 
-    ProfileIO.readMetaFile = jest.fn((fullFilePath: string) => {
+    (ProfileIO.readMetaFile as any) = jest.fn((fullFilePath: string) => {
         return {
             defaultProfile: "mybana",
             configuration: {
@@ -170,7 +170,7 @@ describe("Cli Profile Manager", () => {
         "the handler should be called and the resulting profile should have the created fields in it.", async () => {
         const configs = getTypeConfigurations();
 
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
 
@@ -199,7 +199,7 @@ describe("Cli Profile Manager", () => {
         "the handler should be called and the resulting profile should have the created fields in it.", async () => {
         const configs = getTypeConfigurations();
         const oldSum = 55;
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.readProfileFile = jest.fn((fullFilePath: string, type: "string") => {
@@ -228,7 +228,7 @@ describe("Cli Profile Manager", () => {
         "the profile handler does not add a field required by the schema, " +
         "we should get a validation error", async () => {
         const configs = getTypeConfigurations();
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.writeProfile = jest.fn((fullFilePath: string, profile: IProfile) => {
@@ -259,7 +259,7 @@ describe("Cli Profile Manager", () => {
     it("should still create a profile properly without providing args", async () => {
         const configs = getTypeConfigurations();
 
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.writeProfile = jest.fn((fullFilePath: string, profile: IProfile) => {
@@ -285,7 +285,7 @@ describe("Cli Profile Manager", () => {
     it("should still fail profile validation on creation if no args are provided ", async () => {
         const configs = getTypeConfigurations();
 
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.writeProfile = jest.fn((fullFilePath: string, profile: IProfile) => {
@@ -314,7 +314,7 @@ describe("Cli Profile Manager", () => {
     it("should still fail profile validation on update if no args are provided ", async () => {
         const configs = getTypeConfigurations();
 
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.writeProfile = jest.fn((fullFilePath: string, profile: IProfile) => {
@@ -342,7 +342,7 @@ describe("Cli Profile Manager", () => {
     it("If we provide a non existent handler to create a profile from command line arguments, " +
         "we should get a helpful error.", async () => {
         const configs = getTypeConfigurations();
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         configs[0].createProfileFromArgumentsHandler = __dirname + "/profileHandlers/fakearooni";
@@ -369,7 +369,7 @@ describe("Cli Profile Manager", () => {
     it("If we provide a non existent handler to update a profile from command line arguments, " +
         "we should get a helpful error.", async () => {
         const configs = getTypeConfigurations();
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         configs[0].updateProfileFromArgumentsHandler = __dirname + "/profileHandlers/fakearooni";
@@ -465,7 +465,7 @@ describe("Cli Profile Manager", () => {
     });
     it("should create a profile with dependencies if the proper command line arguments are provided",
         async () => {
-            ProfileIO.exists = jest.fn(() => {
+            (ProfileIO.exists as any) = jest.fn(() => {
                 return true; // pretend the dependent profile already exists
             });
             const configs = getTypeConfigurations();
@@ -503,7 +503,7 @@ describe("Cli Profile Manager", () => {
         "the handler should be called and the resulting profile should have the created fields in it.", async () => {
         const configs = getTypeConfigurations();
         const oldSum = 55;
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.readProfileFile = jest.fn((fullFilePath: string, type: "string") => {
@@ -519,7 +519,8 @@ describe("Cli Profile Manager", () => {
         const a = 1;
         const b = 2;
         const profileName = "myprofile";
-        const saveResult = await manager.update({name: profileName, type: profileTypeOne, profile: {}, args: {_: [], $0: "test", a, b}
+        const saveResult = await manager.update({
+            name: profileName, type: profileTypeOne, profile: {}, args: {_: [], $0: "test", a, b}
         });
         testLogger.info("Save profile result: " + inspect(saveResult));
         expect(saveResult.profile.sum).toEqual(a + b);
@@ -529,7 +530,7 @@ describe("Cli Profile Manager", () => {
         "profile fields on update", async () => {
         const configs = getTypeConfigurations();
         const oldSum = 55;
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.readProfileFile = jest.fn((fullFilePath: string,
@@ -570,7 +571,7 @@ describe("Cli Profile Manager", () => {
         "profile fields on creation", async () => {
         const configs = getTypeConfigurations();
         const oldSum = 55;
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any) = jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.readProfileFile = jest.fn((fullFilePath: string,
@@ -613,7 +614,7 @@ describe("Cli Profile Manager", () => {
         "while updating", async () => {
         const configs = getTypeConfigurations();
         const oldSum = 55;
-        ProfileIO.exists = jest.fn(() => {
+        (ProfileIO.exists as any)= jest.fn(() => {
             return true; // pretend the profile already exists
         });
         ProfileIO.readProfileFile = jest.fn((fullFilePath: string,
@@ -649,8 +650,7 @@ describe("Cli Profile Manager", () => {
                     myGrandChild: "johnny"
                 }
             });
-        }
-        catch (e) {
+        } catch (e) {
             expect(e.message).toContain(errMessage);
             expect(e.message).toContain("profile");
             return;
@@ -695,8 +695,7 @@ describe("Cli Profile Manager", () => {
         ProfileIO.readProfileFile = jest.fn((filePath: string, type: string) => {
             if (type === PROFILE_TYPE.STRAWBERRY) {
                 return profileA;
-            }
-            else {
+            } else {
                 return {
                     type: "apple",
                     name: "thing"
@@ -780,8 +779,7 @@ describe("Cli Profile Manager", () => {
         ProfileIO.readProfileFile = jest.fn((filePath: string, type: string) => {
             if (type === PROFILE_TYPE.STRAWBERRY) {
                 return profileA;
-            }
-            else {
+            } else {
                 return {
                     type: "apple",
                     name: "thing"

--- a/packages/profiles/src/utils/ProfileIO.ts
+++ b/packages/profiles/src/utils/ProfileIO.ts
@@ -50,7 +50,7 @@ export class ProfileIO {
         } catch (err) {
             throw new ImperativeError({
                 msg: `An error occurred creating profile directory: "${path}". ` +
-                `Error Details: ${err.message}`,
+                    `Error Details: ${err.message}`,
                 additionalDetails: err
             }, {tag: ProfileIO.ERROR_ID});
         }
@@ -141,7 +141,7 @@ export class ProfileIO {
             } else {
                 throw new ImperativeError({
                     msg: `An unexpected profile delete error occurred for profile "${name}". ` +
-                    `Error Details: ${deleteErr.message}.`,
+                        `Error Details: ${deleteErr.message}.`,
                     additionalDetails: deleteErr
                 }, {tag: ProfileIO.ERROR_ID});
             }
@@ -182,7 +182,7 @@ export class ProfileIO {
         } catch (e) {
             throw new ImperativeError({
                 msg: `An error occurred converting and writing the meta profile to "${path}". ` +
-                `Error Details: ${e.message}`,
+                    `Error Details: ${e.message}`,
                 additionalDetails: e
             }, {tag: ProfileIO.ERROR_ID});
         }
@@ -214,10 +214,15 @@ export class ProfileIO {
         let names: string[] = [];
         try {
             names = fs.readdirSync(profileRootDirectory);
+            names = names.filter((name) => {
+                // only return directories, not files
+                const stats = fs.statSync(pathPackage.join(profileRootDirectory, name));
+                return stats.isDirectory();
+            });
         } catch (e) {
             throw new ImperativeError({
                 msg: `An error occurred attempting to read all profile directories from "${profileRootDirectory}". ` +
-                `Error Details: ${e.message}`,
+                    `Error Details: ${e.message}`,
                 additionalDetails: e
             }, {tag: ProfileIO.ERROR_ID});
         }
@@ -250,7 +255,7 @@ export class ProfileIO {
         } catch (e) {
             throw new ImperativeError({
                 msg: `An error occurred attempting to read all profile names from "${profileTypeDir}". ` +
-                `Error Details: ${e.message}`,
+                    `Error Details: ${e.message}`,
                 additionalDetails: e
             }, {tag: ProfileIO.ERROR_ID});
         }


### PR DESCRIPTION
Avoids an issue where files placed in the profiles directory causes errors in the VS Code Zowe extension. Affects the loadAll API from Profile Managers. Tested by linking into the VSCode extension