### PR TITLE
Prevent truncation of last character of cookie element.

### DIFF
--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -210,7 +210,7 @@ export abstract class AbstractSession {
                 // if we match requested token type, save it off for its length
                 if (element.indexOf(this.mISession.tokenType) === 0) {
                     // parse off token value, minus LtpaToken2= (as an example)
-                    this.ISession.tokenValue = element.substr(0, element.length - 1);
+                    this.ISession.tokenValue = element.substr(0, element.length);
                 }
             });
         });


### PR DESCRIPTION
REST API was failing to reuse the existing session. Discovered that the Cookie header contained a value that was truncated on the right by a a single character. Removing the "- 1" in the substr() fixed the problem.