### PR TITLE
Prevent truncation of last character of cookie element.

### DIFF
--- a/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
+++ b/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
@@ -101,7 +101,7 @@ Object {
   "secureProtocol": "SSLv23_method",
   "strictSSL": true,
   "tokenType": "LtpaToken2",
-  "tokenValue": "LtpaToken2=7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9nl1ubUvcK0hPgWmKH4xCOf1EoNafu40XaiLoO8wZnCo/rHmP2/h7MzSJV1te8dP4VM6NFdQCruuxtcgddTiDXU8gYZERFTnvtYhUuvk1Nne8xwo++sDAmEFVwvJbyg6Z0zT1RAGPIXd6hx8YPNXydAifoQhqI9CaoyZNptByyx2H7uJ0vt0HTNqrdgZclOQkDNMm65ETpdo1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkq",
+  "tokenValue": "LtpaToken2=7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9nl1ubUvcK0hPgWmKH4xCOf1EoNafu40XaiLoO8wZnCo/rHmP2/h7MzSJV1te8dP4VM6NFdQCruuxtcgddTiDXU8gYZERFTnvtYhUuvk1Nne8xwo++sDAmEFVwvJbyg6Z0zT1RAGPIXd6hx8YPNXydAifoQhqI9CaoyZNptByyx2H7uJ0vt0HTNqrdgZclOQkDNMm65ETpdo1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE",
   "type": "token",
   "user": "user",
 }

--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -210,7 +210,7 @@ export abstract class AbstractSession {
                 // if we match requested token type, save it off for its length
                 if (element.indexOf(this.mISession.tokenType) === 0) {
                     // parse off token value, minus LtpaToken2= (as an example)
-                    this.ISession.tokenValue = element.substr(0, element.length - 1);
+                    this.ISession.tokenValue = element.substr(0, element.length);
                 }
             });
         });


### PR DESCRIPTION
REST API was failing to reuse the existing session. Discovered that the Cookie header contained a value that was truncated on the right by a single character. Removing the "- 1" in the substr() fixed the problem.

Signed-off-by: Paul Scott <paulscott@phoenixsoftware.com>