### PR TITLE
Bug copying webhelp dist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/imperative",
-  "version": "4.1.12-alpha.201907231252",
+  "version": "4.2.0-alpha.201907311259",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cmd/__tests__/help/WebHelpGenerator.test.ts
+++ b/packages/cmd/__tests__/help/WebHelpGenerator.test.ts
@@ -93,11 +93,6 @@ describe("WebHelpGenerator", () => {
                 IO.mkdirp(webHelpDocsDirNm);
             }
 
-            // we need find-up to return our imperative directory, for use with a fake process.mainModule.filename
-            const findUp = require("find-up");
-            const realFUpSync = findUp.sync;
-            findUp.sync = jest.fn(() => path.resolve("./"));
-
             const webHelpGen = new WebHelpGenerator(
                 WebHelpManager.instance.fullCommandTree,
                 ImperativeConfig.instance,
@@ -122,8 +117,6 @@ describe("WebHelpGenerator", () => {
             expect(fs.existsSync(webHelpDocsDirNm + "/" + moduleFileNm + "_hello.html")).toBe(true);
             expect(fs.existsSync(webHelpDocsDirNm + "/" + moduleFileNm + "_plugins_install.html")).toBe(true);
             expect(fs.existsSync(webHelpDocsDirNm + "/" + moduleFileNm + "_plugins_uninstall.html")).toBe(true);
-
-            findUp.sync = realFUpSync;
         });
     });
 });

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -16,6 +16,7 @@ import { ICommandDefinition } from "../doc/ICommandDefinition";
 import { ImperativeConfig } from "../../../utilities";
 import { IHandlerResponseApi } from "../doc/response/api/handler/IHandlerResponseApi";
 import { ImperativeError } from "../../../error";
+import { Logger } from "../../../logger";
 
 const marked = require("marked");
 
@@ -121,12 +122,35 @@ export class WebHelpGenerator {
     }
 
     private get webHelpDistDir(): string {
-        const distDir =  path.join(path.dirname(process.mainModule.filename),
+        const runtimeDistDir =  path.join(path.dirname(process.mainModule.filename),
             "..", "node_modules", "@zowe", "imperative", "web-help", "dist");
-        if (!fs.existsSync(distDir)) {
-            throw new ImperativeError({
-                msg: `The web-help distribution directory does not exist:\n    "${distDir}"`
-            });
+        let distDir = runtimeDistDir;
+
+        if (!fs.existsSync(runtimeDistDir)) {
+            const impLogger: Logger = Logger.getImperativeLogger();
+            impLogger.error(
+                "webHelpDistDir: The web-help runtime distribution directory does not exist:\n    " +
+                runtimeDistDir + "\n    " +
+                "To work in a development environment, we will also try a source directory."
+            );
+
+            /* During development we do not have a runtime distribution path,
+             * so fallback to a source directory path.
+             */
+            distDir = path.join(__dirname, "../../../..", "web-help", "dist");
+            if (!fs.existsSync(distDir)) {
+                impLogger.error(
+                    "webHelpDistDir: The web-help source distribution directory does not exist:\n    " +
+                    distDir
+                );
+
+                /* The dev directory was just an in-house fallback.
+                 * If neither exist, just report the runtime directory to our user.
+                 */
+                throw new ImperativeError({
+                    msg: `The web-help distribution directory does not exist:\n    "${runtimeDistDir}"`
+                });
+            }
 
         }
         return distDir;

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -15,6 +15,7 @@ import { DefaultHelpGenerator } from "./DefaultHelpGenerator";
 import { ICommandDefinition } from "../doc/ICommandDefinition";
 import { ImperativeConfig } from "../../../utilities";
 import { IHandlerResponseApi } from "../doc/response/api/handler/IHandlerResponseApi";
+import { ImperativeError } from "../../../error";
 
 const marked = require("marked");
 
@@ -120,8 +121,15 @@ export class WebHelpGenerator {
     }
 
     private get webHelpDistDir(): string {
-        return path.join(path.dirname(process.mainModule.filename),
+        const distDir =  path.join(path.dirname(process.mainModule.filename),
             "..", "node_modules", "@zowe", "imperative", "web-help", "dist");
+        if (!fs.existsSync(distDir)) {
+            throw new ImperativeError({
+                msg: `The web-help distribution directory does not exist:\n    "${distDir}"`
+            });
+
+        }
+        return distDir;
     }
 
     private genDocsHeader(title: string): string {

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -63,8 +63,8 @@ export class WebHelpGenerator {
             fs.mkdirSync(this.mDocsDir);
         }
 
-        // Copy files from dist folder to Imperative dir
-        const distDir: string = path.join(this.imperativeDir, "web-help", "dist");
+        // Copy files from dist folder to .zowe home dir
+        const distDir: string = this.webHelpDistDir;
         const dirsToCopy: string[] = [distDir, path.join(distDir, "css"), path.join(distDir, "js")];
         dirsToCopy.forEach((dir: string) => {
             const destDir = path.join(webHelpDir, path.relative(distDir, dir));
@@ -119,8 +119,9 @@ export class WebHelpGenerator {
         cmdResponse.console.log("done!");
     }
 
-    private get imperativeDir(): string {
-        return require("find-up").sync("imperative", {cwd: process.mainModule.filename, type: "directory"});
+    private get webHelpDistDir(): string {
+        return path.join(path.dirname(process.mainModule.filename),
+            "..", "node_modules", "@zowe", "imperative", "web-help", "dist");
     }
 
     private genDocsHeader(title: string): string {


### PR DESCRIPTION
Resolves #261 : zowe --help-web crashes when installed from a registry

Changed the app to get static help content from a distributed directory instead of a source directory.