### PR TITLE
Add JSDoc to web help

### DIFF
--- a/packages/cmd/src/help/doc/IWebHelpManager.ts
+++ b/packages/cmd/src/help/doc/IWebHelpManager.ts
@@ -1,5 +1,3 @@
-import { IHandlerResponseApi } from "../../doc/response/api/handler/IHandlerResponseApi";
-
 /*
 * This program and the accompanying materials are made available under the terms of the
 * Eclipse Public License v2.0 which accompanies this distribution, and is available at
@@ -11,6 +9,8 @@ import { IHandlerResponseApi } from "../../doc/response/api/handler/IHandlerResp
 *
 */
 
+import { IHandlerResponseApi } from "../../doc/response/api/handler/IHandlerResponseApi";
+
 /**
  * Web help manager API that handles launching of web help and generating it if necessary.
  * @export
@@ -18,14 +18,16 @@ import { IHandlerResponseApi } from "../../doc/response/api/handler/IHandlerResp
  */
 export interface IWebHelpManager {
     /**
-     * Launches root help page in browser.
+     * Launch root help page in browser.
+     * @param {IHandlerResponseApi} cmdResponse - Command response object to use for output
      * @memberof IWebHelpManager
      */
     openRootHelp(cmdResponse: IHandlerResponseApi): void;
 
     /**
-     * Launches help page for specific group/command in browser.
-     * @param {string} inContext - Name of the page to load, passed as a URL param
+     * Launch help page for specific group/command in browser.
+     * @param {string} inContext - Name of page for group/command to jump to
+     * @param {IHandlerResponseApi} cmdResponse - Command response object to use for output
      * @memberof IWebHelpManager
      */
     openHelp(inContext: string, cmdResponse: IHandlerResponseApi): void;

--- a/packages/cmd/src/help/doc/IWebHelpPackageMetadata.ts
+++ b/packages/cmd/src/help/doc/IWebHelpPackageMetadata.ts
@@ -1,0 +1,32 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * Object containing metadata about a CLI package or plugin
+ * @export
+ * @interface IWebHelpPackageMetadata
+ */
+export interface IWebHelpPackageMetadata {
+
+    /**
+     * Name of package
+     * @type {string}
+     * @memberof IWebHelpPackageMetadata
+     */
+    name: string;
+
+    /**
+     * Version string of package
+     * @type {string}
+     * @memberof IWebHelpPackageMetadata
+     */
+    version: string;
+}

--- a/packages/cmd/src/help/doc/IWebHelpTreeNode.ts
+++ b/packages/cmd/src/help/doc/IWebHelpTreeNode.ts
@@ -1,0 +1,39 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * Recursive object containing data for a node of web help command tree
+ * @export
+ * @interface IWebHelpTreeNode
+ */
+export interface IWebHelpTreeNode {
+
+    /**
+     * Name of HTML file corresponding to the node
+     * @type {string}
+     * @memberof IWebHelpTreeNode
+     */
+    id: string;
+
+    /**
+     * Display name for the node which includes full name and aliases
+     * @type {string}
+     * @memberof IWebHelpTreeNode
+     */
+    text: string;
+
+    /**
+     * List of child nodes
+     * @type {IWebHelpTreeNode[]}
+     * @memberof IWebHelpTreeNode
+     */
+    children?: IWebHelpTreeNode[];
+}

--- a/web-help/docs.ts
+++ b/web-help/docs.ts
@@ -12,16 +12,23 @@
 const isInIframe: boolean = window.location !== window.parent.location;
 const links: any = document.getElementsByTagName("a");
 
-// Open absolute links in new tab and add handler for relative links
+// Process all <a> tags on page
 for (const link of links) {
     const url = link.getAttribute("href");
     if (url.indexOf("://") > 0 || url.indexOf("//") === 0) {
+        // If link is absolute, assume it points to external site and open it in new tab
         link.setAttribute("target", "_blank");
     } else if (isInIframe) {
+        // If link is relative and page is inside an iframe, then send signal to command tree when link is clicked to make it update selected node
         link.setAttribute("onclick", "window.parent.postMessage(this.href, '*'); return true;");
     }
 }
 
+/**
+ * Show tooltip next to copy button that times out after 1 sec
+ * @param btn - Button element the tooltip will show next to
+ * @param message - Message to show in the tooltip
+ */
 function setTooltip(btn: any, message: string) {
     btn.setAttribute("aria-label", message);
     btn.setAttribute("data-balloon-visible", "");


### PR DESCRIPTION
* Resolves #275 by adding JSDoc to web help code in the folders `packages/cmd/src/help` and `web-help`
* Also fixes #283 ("Web help search only finds highest result in tree")
