### PR TITLE
Fix unexpected behavior after default profile is deleted

### DIFF
--- a/__tests__/src/packages/profiles/__snapshots__/CliProfileManager.credentials.spec.ts.snap
+++ b/__tests__/src/packages/profiles/__snapshots__/CliProfileManager.credentials.spec.ts.snap
@@ -7,7 +7,9 @@ Profile \\"profile-name\\" of type \\"username-password\\" does not exist.
 `;
 
 exports[`Cli Profile Manager Default Credential Management Generic Failure Scenarios should fail if the Credential Manager is unable to find the profile 2`] = `
-"Profile \\"profile-name\\" of type \\"username-password\\" successfully deleted.
+"Your default profile named profile-name of type username-password was successfully deleted.
+Because you deleted it, the default profile for type username-password has been cleared.
+To set a new default profile, run \\"zowe profiles set-default username-password <profileName>\\".
 "
 `;
 
@@ -31,13 +33,17 @@ Resolutions:
 `;
 
 exports[`Cli Profile Manager Default Credential Management Generic Failure Scenarios should fail if the Credential Manager is unable to retrieve a password 2`] = `
-"Profile \\"profile-name\\" of type \\"username-password\\" successfully deleted.
+"Your default profile named profile-name of type username-password was successfully deleted.
+Because you deleted it, the default profile for type username-password has been cleared.
+To set a new default profile, run \\"zowe profiles set-default username-password <profileName>\\".
 "
 `;
 
 exports[`Cli Profile Manager Default Credential Management Generic Success Scenarios should update a password 1`] = `""`;
 
 exports[`Cli Profile Manager Default Credential Management Generic Success Scenarios should update a password 2`] = `
-"Profile \\"profile-name\\" of type \\"username-password\\" successfully deleted.
+"Your default profile named profile-name of type username-password was successfully deleted.
+Because you deleted it, the default profile for type username-password has been cleared.
+To set a new default profile, run \\"zowe profiles set-default username-password <profileName>\\".
 "
 `;

--- a/packages/cmd/src/profiles/CommandProfileLoader.ts
+++ b/packages/cmd/src/profiles/CommandProfileLoader.ts
@@ -222,7 +222,7 @@ export class CommandProfileLoader {
             const response = await this.factory.getManager(load.type).load({
                 loadDefault: load.loadDefault,
                 name: load.name,
-                failNotFound: false
+                failNotFound: !load.optional
             });
 
             // This is an exceptional case - the manager did not do it's job properly, but we will ensure

--- a/packages/cmd/src/profiles/CommandProfileLoader.ts
+++ b/packages/cmd/src/profiles/CommandProfileLoader.ts
@@ -222,7 +222,7 @@ export class CommandProfileLoader {
             const response = await this.factory.getManager(load.type).load({
                 loadDefault: load.loadDefault,
                 name: load.name,
-                failNotFound: true
+                failNotFound: false
             });
 
             // This is an exceptional case - the manager did not do it's job properly, but we will ensure

--- a/packages/cmd/src/profiles/CommandProfileLoader.ts
+++ b/packages/cmd/src/profiles/CommandProfileLoader.ts
@@ -222,7 +222,7 @@ export class CommandProfileLoader {
             const response = await this.factory.getManager(load.type).load({
                 loadDefault: load.loadDefault,
                 name: load.name,
-                failNotFound: !load.optional
+                failNotFound: true
             });
 
             // This is an exceptional case - the manager did not do it's job properly, but we will ensure

--- a/packages/imperative/src/profiles/handlers/NewDeleteProfilesHandler.ts
+++ b/packages/imperative/src/profiles/handlers/NewDeleteProfilesHandler.ts
@@ -22,11 +22,12 @@ export default class NewDeleteProfilesHandler {
             name: profileName,
             rejectIfDependency: !commandParameters.arguments.force || false
         });
-        commandParameters.response.console.log(`Profile "${profileName}" of type "${profileType}" successfully deleted.`);
-        if (deleted.defaultCleared) {
-            commandParameters.response.console.log(`"${profileName}" was the default profile for type "${profileType}".\nBecause you deleted it, ` +
-                `the default profile for type "${profileType}" has been cleared.\nTo set a new default profile, run "zowe profiles set-default ` +
-                `${profileType} <profileName>".`);
+        if (!deleted.defaultCleared) {
+            commandParameters.response.console.log(`Your profile named ${profileName} of type ${profileType} was successfully deleted.`);
+        } else {
+            commandParameters.response.console.log(`Your default profile named ${profileName} of type ${profileType} was successfully deleted.\n` +
+                `Because you deleted it, the default profile for type ${profileType} has been cleared.\nTo set a new default profile, run "zowe ` +
+                `profiles set-default ${profileType} <profileName>".`);
         }
     }
 }

--- a/packages/imperative/src/profiles/handlers/NewDeleteProfilesHandler.ts
+++ b/packages/imperative/src/profiles/handlers/NewDeleteProfilesHandler.ts
@@ -23,5 +23,10 @@ export default class NewDeleteProfilesHandler {
             rejectIfDependency: !commandParameters.arguments.force || false
         });
         commandParameters.response.console.log(`Profile "${profileName}" of type "${profileType}" successfully deleted.`);
+        if (deleted.defaultCleared) {
+            commandParameters.response.console.log(`"${profileName}" was the default profile for type "${profileType}".\nBecause you deleted it, ` +
+                `the default profile for type "${profileType}" has been cleared.\nTo set a new default profile, run "zowe profiles set-default ` +
+                `${profileType} <profileName>".`);
+        }
     }
 }

--- a/packages/profiles/__tests__/BasicProfileManager.load.test.ts
+++ b/packages/profiles/__tests__/BasicProfileManager.load.test.ts
@@ -81,7 +81,7 @@ describe("Basic Profile Manager Load", () => {
 
         let error;
         try {
-            const rponse = await prof.load({name: "missing_apple"});
+            const response = await prof.load({name: "missing_apple"});
         } catch (e) {
             error = e;
             TestLogger.info(error.message);
@@ -199,6 +199,33 @@ describe("Basic Profile Manager Load", () => {
             TestLogger.info(error.message);
         }
         expect(error).toBeDefined();
+        expect(error.message).toMatchSnapshot();
+    });
+
+    it("should fail the request if no profile name is specified and default profile is set but not found", async () => {
+        const prof = new BasicProfileManager({
+            profileRootDirectory: TEST_PROFILE_ROOT_DIR,
+            typeConfigurations: ONLY_ORANGE,
+            type: ORANGE_PROFILE_TYPE,
+            logger: TestLogger.getTestLogger()
+        });
+
+        // Mock having a default profile set
+        prof.getDefaultProfileName = jest.fn(() => {
+            return "missing_orange";
+        });
+
+        let error;
+        let response: IProfileLoaded;
+        try {
+            response = await prof.load({loadDefault: true, failNotFound: false});
+            TestLogger.info(response.message);
+        } catch (e) {
+            error = e;
+            TestLogger.info(error.message);
+        }
+        expect(error).toBeDefined();
+        expect(error.message).toContain("does not exist");
         expect(error.message).toMatchSnapshot();
     });
 

--- a/packages/profiles/__tests__/__snapshots__/BasicProfileManager.load.test.ts.snap
+++ b/packages/profiles/__tests__/__snapshots__/BasicProfileManager.load.test.ts.snap
@@ -160,6 +160,11 @@ profile requires property \\"color\\"
 
 exports[`Basic Profile Manager Load should fail if the default doesn't exist 1`] = `"No default profile set for type \\"orange\\"."`;
 
+exports[`Basic Profile Manager Load should fail the request if no profile name is specified and default profile is set but not found 1`] = `
+"Your default profile named missing_orange does not exist for type orange.
+To change your default profile, run \\"undefined profiles set-default orange <profileName>\\"."
+`;
+
 exports[`Basic Profile Manager Load should handle a read error 1`] = `"Read error!"`;
 
 exports[`Basic Profile Manager Load should load a profile with one dependency 1`] = `

--- a/packages/profiles/src/abstract/AbstractProfileManager.ts
+++ b/packages/profiles/src/abstract/AbstractProfileManager.ts
@@ -699,6 +699,7 @@ export abstract class AbstractProfileManager<T extends IProfileTypeConfiguration
       if (meta.defaultProfile === parms.name) {
         this.log.debug(`Profile deleted was the default. Clearing the default profile for type "${this.profileType}".`);
         this.clearDefault();
+        response.defaultCleared = true;
       }
     }
 

--- a/packages/profiles/src/abstract/AbstractProfileManager.ts
+++ b/packages/profiles/src/abstract/AbstractProfileManager.ts
@@ -481,7 +481,7 @@ export abstract class AbstractProfileManager<T extends IProfileTypeConfiguration
       } else if (!this.locateExistingProfile(parms.name)) {
         this.log.error(`Default profile "${parms.name}" does not exist for type "${this.profileType}".`);
         throw new ImperativeError({
-          msg: `Default profile "${parms.name}" does not exist for type "${this.profileType}".\n` +
+          msg: `Your default profile named ${parms.name} does not exist for type ${this.profileType}.\n` +
             `To change your default profile, run "${ImperativeConfig.instance.rootCommandName} profiles set-default ${this.profileType} ` +
             `<profileName>".`
         });

--- a/packages/profiles/src/abstract/AbstractProfileManager.ts
+++ b/packages/profiles/src/abstract/AbstractProfileManager.ts
@@ -455,9 +455,9 @@ export abstract class AbstractProfileManager<T extends IProfileTypeConfiguration
     ImperativeExpect.toNotBeNullOrUndefined(parms, `Profile load requested for type "${this.profileType}", but no parameters supplied.`);
 
     // Set defaults if not present
-    parms.loadDefault = (isNullOrUndefined(parms.loadDefault)) ? false : parms.loadDefault;
-    parms.failNotFound = (isNullOrUndefined(parms.failNotFound)) ? true : parms.failNotFound;
-    parms.loadDependencies = (isNullOrUndefined(parms.loadDependencies)) ? true : parms.loadDependencies;
+    parms.loadDefault = (parms.loadDefault == null) ? false : parms.loadDefault;
+    parms.failNotFound = (parms.failNotFound == null) ? true : parms.failNotFound;
+    parms.loadDependencies = (parms.loadDependencies == null) ? true : parms.loadDependencies;
 
     // Log the API call
     this.log.info(`Loading profile "${parms.name || "default"}" of type "${this.profileType}"...`);
@@ -471,7 +471,7 @@ export abstract class AbstractProfileManager<T extends IProfileTypeConfiguration
       this.log.debug(`The default profile for type "${this.profileType}" is "${parms.name}".`);
 
       // If we don't find the default name and we know fail not found is false, then return here
-      if (isNullOrUndefined(parms.name)) {
+      if (parms.name == null) {
         if (!parms.failNotFound) {
           return this.failNotFoundDefaultResponse("default was requested");
         } else {
@@ -488,7 +488,7 @@ export abstract class AbstractProfileManager<T extends IProfileTypeConfiguration
       }
     }
 
-    // Attempt to protect agaisnt circular dependencies - if the load count increases to 2 for the same type/name
+    // Attempt to protect against circular dependencies - if the load count increases to 2 for the same type/name
     // Then some profile in the chain attempted to re-load this profile.
     const mapKey: string = ProfileUtils.getProfileMapKey(this.profileType, parms.name);
     let count = this.loadCounter.get(mapKey);

--- a/packages/profiles/src/doc/response/IProfileDeleted.ts
+++ b/packages/profiles/src/doc/response/IProfileDeleted.ts
@@ -27,4 +27,10 @@ export interface IProfileDeleted {
      * @memberof IProfileDeleted
      */
     message: string;
+    /**
+     * Specifies whether the default profile was cleared.
+     * @type {boolean}
+     * @memberof IProfileDeleted
+     */
+    defaultCleared?: boolean;
 }


### PR DESCRIPTION
* Fixes #43 (also [zowe-cli #108](https://github.com/zowe/zowe-cli/issues/108), [zowe-cli #541](https://github.com/zowe/zowe-cli/issues/541), [zowe-cli-cics-plugin #15](https://github.com/zowe/zowe-cli-cics-plugin/issues/15) once their Imperative dependency is updated)
* When attempting to load a default profile, if it cannot be loaded, instead of "Cannot read property 'host' of undefined" the following message will be shown:
![image](https://user-images.githubusercontent.com/50887074/66831221-23811000-ef25-11e9-8c38-b98bdb70d490.png)
* When a profile is deleted, Imperative now checks whether it is the default profile for its type. If so the default profile name for that type is reset to `null`, so that there will be no default profile rather than a non-existent one. This results in a message like the following:
![image](https://user-images.githubusercontent.com/50887074/66831059-df8e0b00-ef24-11e9-954f-b5ab2164b5e9.png)
* If a user manually deletes a profile YAML file, it is still possible for their default profile to become non-existent. Implementing #305 would add a command that allows users to recover from this state.