### PR TITLE
Add Print button to web help pages

### DIFF
--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -195,8 +195,8 @@ export class WebHelpGenerator {
             cmdTreeHtml += this.buildCmdTreeHtml(node);
         });
         cmdTreeHtml += "</ul>";
-        cmdTreeHtml = `<div class="print-only"><h4>Table of Contents</h4>\n${cmdTreeHtml}</div>\n`;
-        const insertIndex = this.singlePageHtml.indexOf("<hr>");
+        cmdTreeHtml = `<div class="page-break print-only"><h4>Table of Contents</h4>\n${cmdTreeHtml}</div>\n`;
+        const insertIndex = this.singlePageHtml.indexOf("<hr ");
         this.singlePageHtml = this.singlePageHtml.slice(0, insertIndex) + cmdTreeHtml + this.singlePageHtml.slice(insertIndex);
         fs.writeFileSync(path.join(this.mDocsDir, "all.html"), this.singlePageHtml);
 
@@ -279,9 +279,10 @@ export class WebHelpGenerator {
      * @param {string} htmlContent
      */
     private appendToSinglePageHtml(definition: ICommandDefinition, rootCommandName: string, fullCommandName: string, htmlContent: string) {
-        // Separate with horizontal line if start of a new top level group
+        // Add horizontal line/page break at start of a new top level group
         if (fullCommandName.indexOf("_") === -1) {
-            this.singlePageHtml += "<hr>\n";
+            this.singlePageHtml += "<hr class=\"no-print\">\n";
+            htmlContent = htmlContent.replace(/<h2/, "<h2 class=\"page-break\"");
         }
 
         // Generate HTML anchor in front of header

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -227,7 +227,7 @@ export class WebHelpGenerator {
      */
     private genDocsFooter(): string {
         return `</article>
-<div id="btn-print-wrapper"><button id="btn-print" class="no-print" onclick="window.print();" title="Print">🖶</button></div>
+<div id="btn-print-wrapper"><button id="btn-print" class="no-print" onclick="window.print();" title="Print">🖨️</button></div>
 <script src="../js/bundle-docs.js"></script>
 <script src="../js/docs.js"></script>
 `;

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -246,7 +246,7 @@ export class WebHelpGenerator {
             crumbs.push(`<a href="${hrefPrefix}${linkText}.html">${linkText}</a>`);
             hrefPrefix += `${linkText}_`;
         });
-        return crumbs.join(" → ");
+        return crumbs.join(" › ");
     }
 
     /**
@@ -329,7 +329,7 @@ export class WebHelpGenerator {
 
         // Add Copy buttons after command line examples
         htmlContent = htmlContent.replace(/<code>\$\s*(.*?)<\/code>/g,
-            "<code>$1</code> <button class=\"btn-copy\" data-balloon-pos=\"right\" data-clipboard-text=\"$1\">Copy</button>");
+            "<code>$1</code> <button class=\"btn-copy no-print\" data-balloon-pos=\"right\" data-clipboard-text=\"$1\">Copy</button>");
 
         // Sanitize references to user's home directory
         if (this.sanitizeHomeDir) {

--- a/web-help/dist/css/docs.css
+++ b/web-help/dist/css/docs.css
@@ -47,6 +47,10 @@
         display: none;
     }
 
+    .page-break {
+        page-break-before: always;
+    }
+
     .print-only {
         display: block;
     }

--- a/web-help/dist/css/docs.css
+++ b/web-help/dist/css/docs.css
@@ -23,8 +23,33 @@
     }
 }
 
+#btn-print {
+    font-size: x-large;
+}
+
+#btn-print-wrapper {
+    bottom: 20px;
+    display: none;
+    position: fixed;
+    right: 20px;
+}
+
 .btn-copy {
     font-size: small;
+}
+
+.print-only {
+    display: none;
+}
+
+@media print {
+    .no-print {
+        display: none;
+    }
+
+    .print-only {
+        display: block;
+    }
 }
 
 [aria-label] {

--- a/web-help/dist/css/docs.css
+++ b/web-help/dist/css/docs.css
@@ -11,6 +11,7 @@
 
 .markdown-body {
     box-sizing: border-box;
+    font-family: 'Roboto', sans-serif;
     margin: 0 auto;
     max-width: 980px;
     min-width: 200px;
@@ -24,14 +25,17 @@
 }
 
 #btn-print {
-    font-size: x-large;
+    background: none;
+    border: none;
+    font-size: large;
+    padding: 0;
 }
 
 #btn-print-wrapper {
-    bottom: 20px;
     display: none;
-    position: fixed;
-    right: 20px;
+    left: calc(797px + (100% - 767px) / 2);
+    position: absolute;
+    top: 60px;
 }
 
 .btn-copy {

--- a/web-help/dist/css/main.css
+++ b/web-help/dist/css/main.css
@@ -13,6 +13,10 @@ html, body {
     height: 100%;
 }
 
+body {
+    font-family: 'Roboto', sans-serif;
+}
+
 #cmd-tree {
     flex: 1;
     height: 100%;

--- a/web-help/docs.ts
+++ b/web-help/docs.ts
@@ -26,6 +26,14 @@ for (const link of links) {
     }
 }
 
+// Show Print button if inside iframe
+if (isInIframe) {
+    const printBtn = document.getElementById("btn-print-wrapper");
+    if (printBtn) {
+        printBtn.style.display = "block";
+    }
+}
+
 /**
  * Show tooltip next to copy button that times out after 1 sec
  * @param btn - Button element the tooltip will show next to


### PR DESCRIPTION
Adds a Print button at the top of the docs page for each CLI command.

Before:
![image](https://user-images.githubusercontent.com/50887074/67409171-34b2c800-f588-11e9-8264-9ce52da87dd3.png)
After:
![image](https://user-images.githubusercontent.com/50887074/67409240-4c8a4c00-f588-11e9-85f0-6ba09189c87d.png)

This makes possible a new method for generating the CLI reference PDF. In the flattened view of web help, it is now possible to print the HTML page as a PDF and a table of contents will be inserted.