### PR TITLE
Don't load secure profile fields when deleting profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/imperative",
-  "version": "4.4.8",
+  "version": "4.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cmd/src/doc/profiles/parms/ICliLoadAllProfiles.ts
+++ b/packages/cmd/src/doc/profiles/parms/ICliLoadAllProfiles.ts
@@ -9,23 +9,13 @@
 *
 */
 
+import { ILoadAllProfiles } from "../../../../../profiles";
+
 /**
  * Optional parameters to profile manager load all profiles
  * @export
  * @interface ICliLoadAllProfiles
+ * @extends ILoadAllProfiles
  */
-export interface ICliLoadAllProfiles {
-    /**
-     * If true, do not load secure fields
-     * @type {boolean}
-     * @memberof ICliLoadAllProfiles
-     */
-    noSecure?: boolean;
-    /**
-     * If true, loads only the profiles of the current instance of the profile
-     * managers "type" - specified when allocating the profile manager.
-     * @type {boolean}
-     * @memberof ICliLoadAllProfiles
-     */
-    typeOnly?: boolean;
-}
+// tslint:disable-next-line:no-empty-interface
+export interface ICliLoadAllProfiles extends ILoadAllProfiles {}

--- a/packages/cmd/src/doc/profiles/parms/ICliLoadProfile.ts
+++ b/packages/cmd/src/doc/profiles/parms/ICliLoadProfile.ts
@@ -11,12 +11,23 @@
 
 import { ILoadProfile } from "../../../../../profiles";
 
-export interface ICliILoadProfile extends ILoadProfile {
-    /**
-     * If true, fields that indicate "secure" are not loaded. The properties will still be present in the profiles
-     * loaded with a value of "securely_stored".
-     * @type {boolean}
-     * @memberof ILoadProfile
-     */
-    noSecure?: boolean;
-}
+/**
+ * Profile Manager "loadProfile" input parameters. Indicates which profile to load (named or default) and if
+ * not finding the profile should be considered and error, etc.
+ * @export
+ * @deprecated - Use ICliLoadProfile instead because it is spelled correctly
+ * @interface ICliILoadProfile
+ * @extends ILoadProfile
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface ICliILoadProfile extends ILoadProfile {}
+
+/**
+ * Profile Manager "loadProfile" input parameters. Indicates which profile to load (named or default) and if
+ * not finding the profile should be considered and error, etc.
+ * @export
+ * @interface ICliLoadProfile
+ * @extends ILoadProfile
+ */
+// tslint:disable-next-line:no-empty-interface
+export interface ICliLoadProfile extends ILoadProfile {}

--- a/packages/cmd/src/profiles/CliProfileManager.ts
+++ b/packages/cmd/src/profiles/CliProfileManager.ts
@@ -34,7 +34,7 @@ import { ICommandProfileProperty } from "../doc/profiles/definition/ICommandProf
 import { CredentialManagerFactory } from "../../../security";
 import { IDeleteProfile, IProfileDeleted, IProfileLoaded } from "../../../profiles/src/doc";
 import { SecureOperationFunction } from "../types/SecureOperationFunction";
-import { ICliILoadProfile } from "../doc/profiles/parms/ICliLoadProfile";
+import { ICliLoadProfile } from "../doc/profiles/parms/ICliLoadProfile";
 import { ICliLoadAllProfiles } from "../doc/profiles/parms/ICliLoadAllProfiles";
 import { CliUtils } from "../../../utilities/src/CliUtils";
 
@@ -186,10 +186,10 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
      * Overridden loadProfile functionality
      * After the BasicProfileManager loads the profile, we process the secured properties for the CLi to use
      *
-     * @param {ICliILoadProfile} parms - Load control params - see the interface for full details
+     * @param {ICliLoadProfile} parms - Load control params - see the interface for full details
      * @returns {Promise<IProfileLoaded>} - Promise that is fulfilled when complete (or rejected with an Imperative Error)
      */
-    protected async loadProfile(parms: ICliILoadProfile): Promise<IProfileLoaded> {
+    protected async loadProfile(parms: ICliLoadProfile): Promise<IProfileLoaded> {
         const loadedProfile = await super.loadProfile(parms);
         const profile = loadedProfile.profile;
 

--- a/packages/profiles/src/abstract/AbstractProfileManager.ts
+++ b/packages/profiles/src/abstract/AbstractProfileManager.ts
@@ -32,7 +32,8 @@ import {
   ISaveProfile,
   IUpdateProfile,
   IValidateProfile,
-  IValidateProfileWithSchema
+  IValidateProfileWithSchema,
+  ILoadAllProfiles
 } from "../doc/";
 import { ProfileIO, ProfileUtils } from "../utils";
 import { ImperativeConfig } from "../../../utilities";
@@ -670,7 +671,7 @@ export abstract class AbstractProfileManager<T extends IProfileTypeConfiguration
     if (parms.rejectIfDependency) {
       this.log.trace(`Reject if dependency was specified, loading all profiles to check if "${parms.name}" of type ` +
         `"${this.profileType}" is a dependency.`);
-      const allProfiles = await this.loadAll();
+      const allProfiles = await this.loadAll({ noSecure: true });
       this.log.trace(`All profiles loaded (for dependency check).`);
       const flatten = ProfileUtils.flattenDependencies(allProfiles);
       const dependents: IProfile[] = this.isDependencyOf(flatten, parms.name);
@@ -853,7 +854,7 @@ export abstract class AbstractProfileManager<T extends IProfileTypeConfiguration
    * @returns {Promise<IProfileLoaded[]>} - The list of profiles when the promise is fulfilled or rejected with an ImperativeError.
    * @memberof AbstractProfileManager
    */
-  public abstract async loadAll(): Promise<IProfileLoaded[]>;
+  public abstract async loadAll(parms?: ILoadAllProfiles): Promise<IProfileLoaded[]>;
 
   /**
    * Save profile - performs the profile save according to the implementation - invoked when all parameters are valid

--- a/packages/profiles/src/doc/parms/ILoadAllProfiles.ts
+++ b/packages/profiles/src/doc/parms/ILoadAllProfiles.ts
@@ -1,0 +1,31 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * Optional parameters to profile manager load all profiles
+ * @export
+ * @interface ILoadAllProfiles
+ */
+export interface ILoadAllProfiles {
+    /**
+     * If true, do not load secure fields
+     * @type {boolean}
+     * @memberof ILoadAllProfiles
+     */
+    noSecure?: boolean;
+    /**
+     * If true, loads only the profiles of the current instance of the profile
+     * managers "type" - specified when allocating the profile manager.
+     * @type {boolean}
+     * @memberof ILoadAllProfiles
+     */
+    typeOnly?: boolean;
+}

--- a/packages/profiles/src/doc/parms/ILoadProfile.ts
+++ b/packages/profiles/src/doc/parms/ILoadProfile.ts
@@ -45,4 +45,11 @@ export interface ILoadProfile {
      * @memberof ILoadProfile
      */
     loadDependencies?: boolean;
+    /**
+     * If true, fields that indicate "secure" are not loaded. The properties will still be present in the profiles
+     * loaded with a value of "securely_stored".
+     * @type {boolean}
+     * @memberof ILoadProfile
+     */
+    noSecure?: boolean;
 }

--- a/packages/profiles/src/doc/parms/index.ts
+++ b/packages/profiles/src/doc/parms/index.ts
@@ -10,6 +10,7 @@
 */
 
 export * from "./IDeleteProfile";
+export * from "./ILoadAllProfiles";
 export * from "./ILoadProfile";
 export * from "./IProfileManager";
 export * from "./IProfileManagerInit";


### PR DESCRIPTION
This is part of the fix for the issue https://github.com/zowe/zowe-cli/issues/665. (The other part of the fix is the PR https://github.com/zowe/zowe-cli-scs-plugin/pull/7.)

* Sets "noSecure = true" during loading of all profiles in `AbstractProfileManager.delete` to check for profile dependencies. This prevents fields that may or may not be secure from being loaded unnecessarily.
* Adds `ILoadAllProfiles` type, which was referenced in a comment but not defined
* Redefines `ICliLoadAllProfiles` and `ICliLoadProfile` types to mirror the types `ILoadAllProfiles` and `ILoadProfile`, since they no longer have additional properties of their own.