### PR TITLE
Fix error when optional secure fields in profile are missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/imperative",
-  "version": "4.4.8",
+  "version": "4.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cmd/__tests__/profiles/CliProfileManager.credentials.test.ts
+++ b/packages/cmd/__tests__/profiles/CliProfileManager.credentials.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../profiles/__tests__/TestConstants";
 import { CredentialManagerFactory, DefaultCredentialManager } from "../../../security";
 import { BasicProfileManager } from "../../../profiles/src/BasicProfileManager";
-import { ProfilesConstants } from "../../../profiles";
+import { ProfilesConstants, ISaveProfile } from "../../../profiles";
 
 jest.mock("../../../profiles/src/utils/ProfileIO");
 jest.mock("../../../security/src/DefaultCredentialManager");
@@ -108,7 +108,7 @@ describe("Cli Profile Manager", () => {
                     }
                 };
 
-                jest.spyOn(BasicProfileManager.prototype, "saveProfile" as any).mockImplementation((tParms) => {
+                jest.spyOn(BasicProfileManager.prototype, "saveProfile" as any).mockImplementation((tParms: ISaveProfile) => {
                     return {
                         overwritten: tParms.overwrite,
                         profile: tParms.profile
@@ -159,7 +159,7 @@ describe("Cli Profile Manager", () => {
                     }
                 };
 
-                jest.spyOn(BasicProfileManager.prototype, "saveProfile" as any).mockImplementation((tParms) => {
+                jest.spyOn(BasicProfileManager.prototype, "saveProfile" as any).mockImplementation((tParms: ISaveProfile) => {
                     return {
                         overwritten: tParms.overwrite,
                         profile: tParms.profile
@@ -221,7 +221,7 @@ describe("Cli Profile Manager", () => {
                 dummyManager.save = jest.fn();
                 Object.defineProperty(CredentialManagerFactory, "manager", {get: jest.fn().mockReturnValue(dummyManager)});
 
-                jest.spyOn(BasicProfileManager.prototype, "saveProfile" as any).mockImplementation((tParms) => {
+                jest.spyOn(BasicProfileManager.prototype, "saveProfile" as any).mockImplementation((tParms: ISaveProfile) => {
                     return {
                         overwritten: tParms.overwrite,
                         profile: tParms.profile
@@ -299,7 +299,7 @@ describe("Cli Profile Manager", () => {
 
             it("should load credentials from a profile with constant string values for secure properties", async () => {
                 const dummyManager = new DefaultCredentialManager("dummy");
-                dummyManager.load = jest.fn((propKey: string) => {
+                dummyManager.load = jest.fn(async (propKey: string) => {
                     let ret = null;
                     if (propKey.indexOf("myCode") >= 0) {
                         ret = code;
@@ -352,7 +352,7 @@ describe("Cli Profile Manager", () => {
 
             it("should not load credentials from a profile if noSecure is specified", async () => {
                 const dummyManager = new DefaultCredentialManager("dummy");
-                dummyManager.load = jest.fn((propKey: string) => {
+                dummyManager.load = jest.fn(async (propKey: string) => {
                     let ret = null;
                     if (propKey.indexOf("myCode") >= 0) {
                         ret = code;
@@ -403,7 +403,7 @@ describe("Cli Profile Manager", () => {
 
             it("should not attempt to load secure fields if no credential manager is present", async () => {
                 const dummyManager = new DefaultCredentialManager("dummy");
-                dummyManager.load = jest.fn((propKey: string) => {
+                dummyManager.load = jest.fn(async (propKey: string) => {
                     let ret = null;
                     if (propKey.indexOf("myCode") >= 0) {
                         ret = code;

--- a/packages/cmd/src/profiles/CliProfileManager.ts
+++ b/packages/cmd/src/profiles/CliProfileManager.ts
@@ -201,7 +201,7 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
              * @param {string} propertyNamePath - The path to the property
              * @return {Promise<string>}
              */
-            securelyLoadValue = async (propertyNamePath: string): Promise<any> => {
+            securelyLoadValue = async (propertyNamePath: string, _: any, optional?: boolean): Promise<any> => {
                 let ret;
                 try {
                     this.log.debug(
@@ -210,7 +210,8 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
                     );
                     // Use the Credential Manager to store the credentials
                     ret = await CredentialManagerFactory.manager.load(
-                        ProfileUtils.getProfilePropertyKey(this.profileType, parms.name, propertyNamePath)
+                        ProfileUtils.getProfilePropertyKey(this.profileType, parms.name, propertyNamePath),
+                        optional
                     );
                 } catch (err) {
                     this.log.error(
@@ -353,7 +354,7 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
             this.log.debug("Setting profile field %s from command line option %s", propNamePath, optionName);
             if (secureOp && prop.secure) {
                 this.log.debug("Performing secure operation on property %s", propNamePath);
-                return secureOp(propNamePath, propValue);
+                return secureOp(propNamePath, propValue, !prop.optionDefinition.required);
             }
             return propValue;
         }

--- a/packages/cmd/src/types/SecureOperationFunction.ts
+++ b/packages/cmd/src/types/SecureOperationFunction.ts
@@ -18,6 +18,7 @@ export type SecureOperationFunction =
   /**
    * @param {string} propNamePath - The path to a child property
    * @param {*} propValue - The value of said property
+   * @param {boolean} optional - Set to true if failure to find credentials should be ignored
    * @return {Promise<any>} - The processed value after the secure operation function runs
    */
-  (propNamePath: string, propValue?: any) => Promise<any>;
+  (propNamePath: string, propValue?: any, optional?: boolean) => Promise<any>;

--- a/packages/security/__tests__/DefaultCredentialManager.test.ts
+++ b/packages/security/__tests__/DefaultCredentialManager.test.ts
@@ -150,7 +150,7 @@ describe("DefaultCredentialManager", () => {
           expect(keytar.getPassword).toHaveBeenLastCalledWith(privateManager.service, values.account);
         });
 
-        it("should throw an error", async () => {
+        it("should throw an error when required credential fails to load", async () => {
           let caughtError: ImperativeError;
 
           (keytar.getPassword as jest.Mock).mockReturnValueOnce(null);
@@ -164,6 +164,22 @@ describe("DefaultCredentialManager", () => {
           expect(caughtError.message).toEqual("Unable to load credentials.");
           expect((caughtError as ImperativeError).additionalDetails).toContain(values.account);
           expect((caughtError as ImperativeError).additionalDetails).toContain(service);
+        });
+
+        it("should not throw an error when optional credential fails to load", async () => {
+          let result;
+          let caughtError: ImperativeError;
+
+          (keytar.getPassword as jest.Mock).mockReturnValueOnce(null);
+
+          try {
+            result = await privateManager.loadCredentials(values.account, true);
+          } catch (error) {
+            caughtError = error;
+          }
+
+          expect(result).toBeNull();
+          expect(caughtError).toBeUndefined();
         });
       });
 

--- a/packages/security/__tests__/abstract/AbstractCredentialManager.test.ts
+++ b/packages/security/__tests__/abstract/AbstractCredentialManager.test.ts
@@ -66,10 +66,46 @@ describe("AbstractCredentialManager", () => {
       const actualValue = await manager.load(account);
 
       expect(privateManager.loadCredentials).toHaveBeenCalledTimes(1);
-      expect(privateManager.loadCredentials).toHaveBeenCalledWith(account);
+      expect(privateManager.loadCredentials).toHaveBeenCalledWith(account, undefined);
 
       // Check that the decode happened
       expect(actualValue).toEqual(credentials.username + ":" + credentials.password);
+    });
+
+    it("should throw an error when required credential fails to load", async () => {
+      // Override credential loader to fail
+      privateManager.loadCredentials.mockReturnValueOnce(null);
+      let result;
+      let error;
+
+      try {
+        result = await manager.load(account, false);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(result).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(privateManager.loadCredentials).toHaveBeenCalledTimes(1);
+      expect(privateManager.loadCredentials).toHaveBeenCalledWith(account, false);
+    });
+
+    it("should not throw an error when optional credential fails to load", async () => {
+      // Override credential loader to fail
+      privateManager.loadCredentials.mockReturnValueOnce(null);
+      let result;
+      let error;
+
+      try {
+        result = await manager.load(account, true);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(result).toBeNull();
+      expect(error).toBeUndefined();
+      expect(privateManager.loadCredentials).toHaveBeenCalledTimes(1);
+      expect(privateManager.loadCredentials).toHaveBeenCalledWith(account, true);
     });
   });
 

--- a/packages/security/src/DefaultCredentialManager.ts
+++ b/packages/security/src/DefaultCredentialManager.ts
@@ -129,16 +129,17 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
      * account passed to the function by Imperative.
      *
      * @param {string} account The account for which to get credentials
+     * @param {boolean} optional Set to true if failure to find credentials should be ignored
      * @returns {Promise<SecureCredential>} A promise containing the credentials stored in keytar.
      *
      * @throws {@link ImperativeError} if keytar is not defined.
      * @throws {@link ImperativeError} when keytar.getPassword returns null or undefined.
      */
-    protected async loadCredentials(account: string): Promise<SecureCredential> {
+    protected async loadCredentials(account: string, optional?: boolean): Promise<SecureCredential> {
         this.checkForKeytar();
         const password: string = await this.keytar.getPassword(this.service, account);
 
-        if (password == null) {
+        if (password == null && !optional) {
             throw new ImperativeError({
                 msg: "Unable to load credentials.",
                 additionalDetails: this.getMissingEntryMessage(account)

--- a/packages/security/src/InvalidCredentialManager.ts
+++ b/packages/security/src/InvalidCredentialManager.ts
@@ -35,7 +35,7 @@ export class InvalidCredentialManager extends AbstractCredentialManager {
         throw new BadCredentialManagerError(this.causeError);
     }
 
-    protected async loadCredentials(account: string): Promise<SecureCredential> {
+    protected async loadCredentials(account: string, optional?: boolean): Promise<SecureCredential> {
         throw new BadCredentialManagerError(this.causeError);
     }
 

--- a/packages/security/src/abstract/AbstractCredentialManager.ts
+++ b/packages/security/src/abstract/AbstractCredentialManager.ts
@@ -96,11 +96,16 @@ export abstract class AbstractCredentialManager {
    * Load credentials for an account managed by the credential manager.
    *
    * @param {string} account The account (or profile identifier) associated with credentials
+   * @param {boolean} optional Set to true if failure to find credentials should be ignored
    *
    * @returns {Promise<string>} The username and password associated with the account.
    */
-  public async load(account: string): Promise<string> {
-    const encodedString = await this.loadCredentials(account);
+  public async load(account: string, optional?: boolean): Promise<string> {
+    const encodedString = await this.loadCredentials(account, optional);
+
+    if (optional && encodedString == null) {
+      return null;
+    }
 
     return Buffer.from(encodedString, "base64").toString();
   }
@@ -142,12 +147,13 @@ export abstract class AbstractCredentialManager {
    * Called by Imperative to load the credentials of a profile.
    *
    * @param {string} account - A user account (or profile identifier)
+   * @param {boolean} optional - Set to true if failure to find credentials should be ignored
    *
    * @returns {Promise<SecureCredential>} - A base64 encoded username:password string
    *
    * @throws {ImperativeError} - when the get operation failed. The error object should have details about what failed.
    */
-  protected abstract async loadCredentials(account: string): Promise<SecureCredential>;
+  protected abstract async loadCredentials(account: string, optional?: boolean): Promise<SecureCredential>;
 
   /**
    * Called by Imperative to save the credentials for a profile.


### PR DESCRIPTION
This is part of the fix for the issue https://github.com/zowe/imperative/issues/364. (The other part of the fix is the PR https://github.com/zowe/zowe-cli-scs-plugin/pull/11.)

Adds a boolean param `optional` to methods that load credentials. If set to true, the secure field being loaded is considered optional, meaning that failure to load it will be ignored.