### PR TITLE
feat: allowable values match whole input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Fix allowable values not exactly matching input
+
 ## `4.5.5`
 
 - Fix absence of default value text when falsy values are used.

--- a/__tests__/__integration__/cmd/__tests__/integration/cli/respond/__snapshots__/Cmd.cli.respond.with-syntax-errors.test.ts.snap
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/respond/__snapshots__/Cmd.cli.respond.with-syntax-errors.test.ts.snap
@@ -119,7 +119,7 @@ You specified:
 hello
 
 The value must match one of the following regular expressions:
-[ 'ABC', '123' ].
+[ '^ABC$', '^123$' ].
 
 Use \\"cmd-cli respond with-syntax-errors --help\\" to view command description, usage, and options.
 "

--- a/__tests__/__integration__/cmd/src/cli/validate/syntax/Syntax.definition.ts
+++ b/__tests__/__integration__/cmd/src/cli/validate/syntax/Syntax.definition.ts
@@ -49,7 +49,7 @@ export const syntaxTestCommand: ICommandDefinition = {
                 name: "option-to-specify-3",
                 description: "Part of must specify one group",
                 type: "string",
-                allowableValues: {values: ["allowableA", "allowableB"], caseSensitive: false}
+                allowableValues: {values: ["allowableA", "allowableB", "^allowableC\\$"], caseSensitive: false}
             },
             {
                 name: "conflicts-with-1",

--- a/__tests__/src/packages/cmd/SyntaxValidator.integration.test.ts
+++ b/__tests__/src/packages/cmd/SyntaxValidator.integration.test.ts
@@ -166,10 +166,34 @@ describe("Imperative should provide advanced syntax validation rules", function 
                     alwaysRequired, false, ["must match"])();
             });
         it("If we specify an option that has a set of allowable string values," +
+            " but specify a value that partially match one of the values, the command should fail ",
+            function () {
+                return Promise.all([
+                    tryOptions.bind(this, "--option-to-specify-3 aallowableAA --absence-implies " +
+                        alwaysRequired, false, ["must match"])(),
+                    tryOptions.bind(this, "--option-to-specify-3 allowableC$C --absence-implies " +
+                        alwaysRequired, false, ["must match"])()
+                ]);
+            });
+        it("If we specify an option that has a set of allowable string values," +
+            " but specify a value that is the regular expression itself, the command should fail ",
+            function () {
+                return Promise.all([
+                    tryOptions.bind(this, "--option-to-specify-3 ^allowableA$ --absence-implies " +
+                        alwaysRequired, false, ["must match"])(),
+                    tryOptions.bind(this, "--option-to-specify-3 ^allowbaleC\\$ --absence-implies " +
+                        alwaysRequired, false, ["must match"])()
+                ]);
+            });
+        it("If we specify an option that has a set of allowable string values," +
             " and specify a value that matches one of the allowable values, the command should succeed ",
             function () {
-                return tryOptions.bind(this, "--option-to-specify-3 allowableA --absence-implies " +
-                    alwaysRequired, true, ["passed"])();
+                return Promise.all([
+                    tryOptions.bind(this, "--option-to-specify-3 allowableA --absence-implies " +
+                        alwaysRequired, true, [])(),
+                    tryOptions.bind(this, "--option-to-specify-3 allowableC$ --absence-implies " +
+                        alwaysRequired, true, [])()
+                ]);
             });
         it("If we don't specify an option, and the absence of that option implies " +
             "the presence of another option, and we omit that option as well, the command should fail ",

--- a/__tests__/src/packages/cmd/ValidationTestCommand.ts
+++ b/__tests__/src/packages/cmd/ValidationTestCommand.ts
@@ -34,7 +34,7 @@ export const ValidationTestCommand: ICommandDefinition = {
                 name: "option-to-specify-3",
                 description: "Part of must specify one group",
                 type: "string",
-                allowableValues: {values: ["allowableA", "allowableB"], caseSensitive: false}
+                allowableValues: {values: ["allowableA", "allowableB", "^allowableC\\$"], caseSensitive: false}
             },
             {
                 name: "conflicts-with-1",

--- a/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
+++ b/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
@@ -126,7 +126,7 @@ exports[`Command Response format APIs formatting should accept a JSON object and
 `;
 
 exports[`Command Response format APIs formatting should accept a JSON object and format a table with a header 1`] = `
-"name   details                       colors
+"name   details                       colors            
 banana A fruit that grows in a bunch yellow,green,black
 "
 `;
@@ -134,7 +134,7 @@ banana A fruit that grows in a bunch yellow,green,black
 exports[`Command Response format APIs formatting should accept a JSON object and prettify 1`] = `
 "name:    banana
 details: A fruit that grows in a bunch
-colors:
+colors: 
   - yellow
   - green
   - black
@@ -191,23 +191,23 @@ apple
 `;
 
 exports[`Command Response format APIs formatting should accept an array of JSON objects and format a list of prettified objects 1`] = `
-"-
+"- 
   name:    banana
   details: A fruit that grows in a bunch
-  colors:
+  colors: 
     - yellow
     - green
     - black
--
+- 
   name:    strawberry
   details: A fruit that grows on vines
-  colors:
+  colors: 
     - white
     - red
--
+- 
   name:    apple
   details: A fruit that grows on trees
-  colors:
+  colors: 
     - red
     - green
 "
@@ -227,24 +227,24 @@ exports[`Command Response format APIs formatting should accept an array of JSON 
 
 exports[`Command Response format APIs formatting should accept an array of JSON objects and format a table 1`] = `
 "banana     A fruit that grows in a bunch yellow,green,black
-strawberry A fruit that grows on vines   white,red
-apple      A fruit that grows on trees   red,green
+strawberry A fruit that grows on vines   white,red         
+apple      A fruit that grows on trees   red,green         
 "
 `;
 
 exports[`Command Response format APIs formatting should accept an array of JSON objects and format a table with a header 1`] = `
-"name       details                       colors
+"name       details                       colors            
 banana     A fruit that grows in a bunch yellow,green,black
-strawberry A fruit that grows on vines   white,red
-apple      A fruit that grows on trees   red,green
+strawberry A fruit that grows on vines   white,red         
+apple      A fruit that grows on trees   red,green         
 "
 `;
 
 exports[`Command Response format APIs formatting should accept an array of JSON objects and format a table with a single column 1`] = `
-"name
-banana
+"name      
+banana    
 strawberry
-apple
+apple     
 "
 `;
 
@@ -292,10 +292,10 @@ exports[`Command Response format APIs formatting should accept an array of objec
 `;
 
 exports[`Command Response format APIs formatting should accept an array of objects and allow filtering for table output 1`] = `
-"name       details
+"name       details                      
 banana     A fruit that grows in a bunch
-strawberry A fruit that grows on vines
-apple      A fruit that grows on trees
+strawberry A fruit that grows on vines  
+apple      A fruit that grows on trees  
 "
 `;
 
@@ -313,56 +313,56 @@ exports[`Command Response format APIs formatting should accept an array of strin
 
 exports[`Command Response format APIs formatting should allow extraction of multiple nested properties and consolidate for a table 1`] = `
 "description.full description.summary attributes.color attributes.rare
-a fruit          fruit               green            true
+a fruit          fruit               green            true           
 "
 `;
 
 exports[`Command Response format APIs formatting should allow extraction of multiple nested properties and keep the property structure 1`] = `
-"description:
+"description: 
   full:    a fruit
   summary: fruit
-attributes:
+attributes: 
   color: green
   rare:  true
 "
 `;
 
 exports[`Command Response format APIs formatting should allow options to override the default for filter 1`] = `
-"name       details                       colors
+"name       details                       colors            
 banana     A fruit that grows in a bunch yellow,green,black
-strawberry A fruit that grows on vines   white,red
-apple      A fruit that grows on trees   red,green
+strawberry A fruit that grows on vines   white,red         
+apple      A fruit that grows on trees   red,green         
 "
 `;
 
 exports[`Command Response format APIs formatting should allow options to override the default for format type 1`] = `
-"-
+"- 
   name:    banana
   details: A fruit that grows in a bunch
-  colors:
+  colors: 
     - yellow
     - green
     - black
--
+- 
   name:    strawberry
   details: A fruit that grows on vines
-  colors:
+  colors: 
     - white
     - red
--
+- 
   name:    apple
   details: A fruit that grows on trees
-  colors:
+  colors: 
     - red
     - green
 "
 `;
 
 exports[`Command Response format APIs formatting should allow options to override the default for header 1`] = `
-"name       details                       colors
+"name       details                       colors            
 banana     A fruit that grows in a bunch yellow,green,black
-strawberry A fruit that grows on vines   white,red
-apple      A fruit that grows on trees   red,green
+strawberry A fruit that grows on vines   white,red         
+apple      A fruit that grows on trees   red,green         
 "
 `;
 

--- a/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
+++ b/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
@@ -28,7 +28,7 @@ Note that the data being formatted was extracted from property \\"name\\" becaus
 
 exports[`Command Response format APIs error checking should handle a circular reference and throw an error 1`] = `
 "Non-formatted output data:
-{ name: 'bad apple', fields: [Circular] }
+<ref *1> { name: 'bad apple', fields: [Circular *1] }
 "
 `;
 

--- a/packages/cmd/src/syntax/SyntaxValidator.ts
+++ b/packages/cmd/src/syntax/SyntaxValidator.ts
@@ -298,13 +298,17 @@ export class SyntaxValidator {
                     const optionDefCopy: ICommandOptionDefinition = JSON.parse(JSON.stringify(optionDef));
                     // Use modified regular expressions for allowable values to check and to generate error
                     optionDefCopy.allowableValues.values = optionDef.allowableValues.values.map((regex) => {
-                        // If user-defined regex already contains ^ and/or $,
-                        // we assume user is aware of the usage and thus keep user's definition.
-                        if (regex.startsWith("^") || regex.endsWith("$")) {
-                            return regex;
+                        // Prepend "^" if not existing
+                        if (!regex.startsWith("^")) {
+                            regex = "^" + regex;
                         }
-                        // Otherwise wrap the regex in order to match the whole input
-                        return `^${regex}$`;
+
+                        // Append "$" if the last char is an escaped "$" or chars other than "$"
+                        if (!regex.endsWith("$") || regex.endsWith("\\$")) {
+                            regex = regex + "$";
+                        }
+
+                        return regex;
                     });
                     if (!this.checkIfAllowable(optionDefCopy.allowableValues, commandArguments[optionName])) {
                         this.invalidOptionError(optionDefCopy, responseObject, commandArguments[optionName]);

--- a/packages/cmd/src/syntax/__tests__/SyntaxValidator.test.ts
+++ b/packages/cmd/src/syntax/__tests__/SyntaxValidator.test.ts
@@ -113,10 +113,34 @@ describe("Imperative should provide advanced syntax validation rules", () => {
                     alwaysRequired, false, ["must match"])();
             });
         it("If we specify an option that has a set of allowable string values," +
+            " but specify a value that partially match one of the values, the command should fail ",
+            function () {
+                return Promise.all([
+                    tryOptions.bind(this, "--option-to-specify-3 aallowableAA --absence-implies " +
+                        alwaysRequired, false, ["must match"])(),
+                    tryOptions.bind(this, "--option-to-specify-3 allowableC$C --absence-implies " +
+                        alwaysRequired, false, ["must match"])()
+                ]);
+            });
+        it("If we specify an option that has a set of allowable string values," +
+            " but specify a value that is the regular expression itself, the command should fail ",
+            function () {
+                return Promise.all([
+                    tryOptions.bind(this, "--option-to-specify-3 ^allowableA$ --absence-implies " +
+                        alwaysRequired, false, ["must match"])(),
+                    tryOptions.bind(this, "--option-to-specify-3 ^allowbaleC\\$ --absence-implies " +
+                        alwaysRequired, false, ["must match"])()
+                ]);
+            });
+        it("If we specify an option that has a set of allowable string values," +
             " and specify a value that matches one of the allowable values, the command should succeed ",
             function () {
-                return tryOptions.bind(this, "--option-to-specify-3 allowableA --absence-implies " +
-                    alwaysRequired, true, [])();
+                return Promise.all([
+                    tryOptions.bind(this, "--option-to-specify-3 allowableA --absence-implies " +
+                        alwaysRequired, true, [])(),
+                    tryOptions.bind(this, "--option-to-specify-3 allowableC$ --absence-implies " +
+                        alwaysRequired, true, [])()
+                ]);
             });
         it("If we don't specify an option, and the absence of that option implies " +
             "the presence of another option, and we omit that option as well, the command should fail ",


### PR DESCRIPTION
Regular expressions defined for allowable values are wrapped with ^ and $ by default in order to match the whole input. Exception is when user already uses ^ or $ in definition.

In my opinion this is a breaking change, although it only affects very few cases.

See idea and discussion in zowe/zowe-cli#692

