### PR TITLE
Add Bearer type for Session in rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Add Bearer token in rest Session
+
 ## `4.5.6`
 
 - Fix allowable values not exactly matching input

--- a/packages/rest/__tests__/client/AbstractRestClient.test.ts
+++ b/packages/rest/__tests__/client/AbstractRestClient.test.ts
@@ -594,4 +594,38 @@ describe("AbstractRestClient tests", () => {
         restOptions.dataToReturn.forEach((property) => expect(data[`${property}`]).toBeDefined());
         listOfClientProperties.forEach((property) => expect(data[`${property}`]).not.toBeDefined());
     });
+
+    it("should create buildOptions according to input parameter options", async () => {
+
+        const httpsRequestFnc = jest.fn((options, callback) => {
+            expect(options).toMatchSnapshot();
+            const emitter = new MockHttpRequestResponse();
+            ProcessUtils.nextTick(() => {
+                callback(new EventEmitter());
+                ProcessUtils.nextTick(() => {
+                    emitter.emit("error", "value");
+                });
+            });
+            return emitter;
+        });
+
+        (https.request as any) = httpsRequestFnc;
+
+        let error;
+        try {
+            await RestClient.getExpectString(
+                new Session({
+                    hostname: "test",
+                    port: 8080,
+                    protocol: "https",
+                    basePath: "baseURL",
+                    type: "bearer",
+                    tokenValue: "someToken"
+                }),
+                "/resource");
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(httpsRequestFnc).toBeCalled();
+    });
 });

--- a/packages/rest/__tests__/client/__snapshots__/AbstractRestClient.test.ts.snap
+++ b/packages/rest/__tests__/client/__snapshots__/AbstractRestClient.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AbstractRestClient tests should create buildOptions according to input parameter options 1`] = `
+Object {
+  "headers": Object {
+    "Authorization": "Bearer someToken",
+  },
+  "hostname": "test",
+  "method": "GET",
+  "path": "/baseURL/resource",
+  "port": 8080,
+  "rejectUnauthorized": true,
+}
+`;
+
 exports[`AbstractRestClient tests should error when chunking JSON data that does not parse 1`] = `
 "The get request appeared to succeed, but the response was not in the expected format:
 Unexpected end of JSON input"

--- a/packages/rest/__tests__/session/Session.test.ts
+++ b/packages/rest/__tests__/session/Session.test.ts
@@ -93,6 +93,51 @@ describe("Session tests", () => {
         expect(session.ISession).toMatchSnapshot();
     });
 
+    it("should not allow tokenType for 'bearer' type", () => {
+        let error;
+        try {
+            const session = new Session({hostname: "localhost", type: "bearer", tokenValue: "blahblahblah", user: "user", password: "pass", tokenType: "LtpaToken2"});
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error.message).toMatchSnapshot();
+    });
+
+    it("should not allow user for 'bearer' type", () => {
+        let error;
+        try {
+            const session = new Session({hostname: "localhost", type: "bearer", tokenValue: "blahblahblah", user: "user", password: "pass"});
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error.message).toMatchSnapshot();
+    });
+
+    it("should not allow password for 'bearer' type", () => {
+        let error;
+        try {
+            const session = new Session({hostname: "localhost", type: "bearer", tokenValue: "blahblahblah", password: "pass"});
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error.message).toMatchSnapshot();
+    });
+
+    it("should require token for 'bearer' type", () => {
+        let error;
+        try {
+            const session = new Session({hostname: "localhost", type: "bearer"});
+        } catch (thrownError) {
+            error = thrownError;
+        }
+        expect(error.message).toMatchSnapshot();
+    });
+
+    it("should not require user and password for 'bearer' type", () => {
+        const session = new Session({hostname: "localhost", type: "bearer", tokenValue: "blahblahblah"});
+        expect(session.ISession).toMatchSnapshot();
+    });
+
     it("should not fail to initialize with minimum data", () => {
         const session = new Session({hostname: "localhost"});
         expect(session.ISession).toMatchSnapshot();

--- a/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
+++ b/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
@@ -47,9 +47,15 @@ Object {
 }
 `;
 
+exports[`Session tests should not allow password for 'bearer' type 1`] = `"Expect Error: Required parameter 'password' must be undefined"`;
+
 exports[`Session tests should not allow tokenType for 'basic' type 1`] = `"Expect Error: Required parameter 'tokenType' must be undefined"`;
 
+exports[`Session tests should not allow tokenType for 'bearer' type 1`] = `"Expect Error: Required parameter 'tokenType' must be undefined"`;
+
 exports[`Session tests should not allow tokenValue for 'basic' type 1`] = `"Expect Error: Required parameter 'tokenValue' must be undefined"`;
+
+exports[`Session tests should not allow user for 'bearer' type 1`] = `"Expect Error: Required parameter 'user' must be undefined"`;
 
 exports[`Session tests should not fail to initialize with minimum data 1`] = `
 Object {
@@ -61,6 +67,20 @@ Object {
   "secureProtocol": "SSLv23_method",
   "strictSSL": true,
   "type": "none",
+}
+`;
+
+exports[`Session tests should not require user and password for 'bearer' type 1`] = `
+Object {
+  "basePath": "",
+  "hostname": "localhost",
+  "port": 443,
+  "protocol": "https",
+  "rejectUnauthorized": true,
+  "secureProtocol": "SSLv23_method",
+  "strictSSL": true,
+  "tokenValue": "blahblahblah",
+  "type": "bearer",
 }
 `;
 
@@ -81,11 +101,13 @@ Object {
 
 exports[`Session tests should require password for 'basic' type 1`] = `"Must have user & password OR base64 encoded credentials"`;
 
-exports[`Session tests should require password for 'tokenType' type 1`] = `"Expect Error: You must provide a token type to use token authentication"`;
+exports[`Session tests should require password for 'tokenType' type 1`] = `"Expect Error: You must provide a token type to use cookie authentication"`;
 
 exports[`Session tests should require proper protocol 1`] = `"Expect Error: The required entry was NOT found within the input array: 'https','http'"`;
 
-exports[`Session tests should require proper type 1`] = `"Expect Error: The required entry was NOT found within the input array: 'none','basic','token'"`;
+exports[`Session tests should require proper type 1`] = `"Expect Error: The required entry was NOT found within the input array: 'none','basic','token','bearer'"`;
+
+exports[`Session tests should require token for 'bearer' type 1`] = `"Expect Error: Required parameter 'tokenValue' must be defined"`;
 
 exports[`Session tests should require user for 'basic' type 1`] = `"Must have user & password OR base64 encoded credentials"`;
 

--- a/packages/rest/src/client/AbstractRestClient.ts
+++ b/packages/rest/src/client/AbstractRestClient.ts
@@ -456,6 +456,13 @@ export abstract class AbstractRestClient {
                     options.headers[property] = authentication;
                 });
             }
+        } else if (this.session.ISession.type === AbstractSession.TYPE_BEARER) {
+            this.log.trace("Using bearer authentication");
+            const headerKeys: string[] = Object.keys(Headers.BASIC_AUTHORIZATION);
+            const authentication: string = AbstractSession.BEARER_PREFIX + this.session.ISession.tokenValue;
+            headerKeys.forEach((property) => {
+                options.headers[property] = authentication;
+            });
         }
 
         // for all headers passed into this request, append them to our options object

--- a/packages/rest/src/client/RestConstants.ts
+++ b/packages/rest/src/client/RestConstants.ts
@@ -101,4 +101,12 @@ export class RestConstants {
      * @memberof RestConstants
      */
     public static readonly BASIC_PREFIX: string = "Basic ";
+
+    /**
+     * Bearer auth
+     * @static
+     * @type {string}
+     * @memberof RestConstants
+     */
+    public static readonly BEARER_PREFIX: string = "Bearer ";
 }

--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -34,6 +34,14 @@ export abstract class AbstractSession {
     public static readonly BASIC_PREFIX: string = "Basic ";
 
     /**
+     * Bearer auth prefix
+     * @static
+     * @type {string}
+     * @memberof AbstractSession
+     */
+    public static readonly BEARER_PREFIX: string = "Bearer ";
+
+    /**
      * http protocol id
      * @static
      * @memberof AbstractSession
@@ -69,7 +77,14 @@ export abstract class AbstractSession {
     public static readonly TYPE_BASIC = "basic";
 
     /**
-     * Token type id
+     * Bearer type id
+     * @static
+     * @memberof AbstractSession
+     */
+    public static readonly TYPE_BEARER = "bearer";
+
+    /**
+     * type id for token in Cookie
      * @static
      * @memberof AbstractSession
      */
@@ -283,7 +298,8 @@ export abstract class AbstractSession {
         // populatedSession.type = populatedSession.type.toLocaleLowerCase();
 
         ImperativeExpect.keysToBeDefinedAndNonBlank(populatedSession, ["hostname"]);
-        ImperativeExpect.toBeOneOf(populatedSession.type, [AbstractSession.TYPE_NONE, AbstractSession.TYPE_BASIC, AbstractSession.TYPE_TOKEN]);
+        ImperativeExpect.toBeOneOf(populatedSession.type,
+            [AbstractSession.TYPE_NONE, AbstractSession.TYPE_BASIC, AbstractSession.TYPE_TOKEN, AbstractSession.TYPE_BEARER]);
         ImperativeExpect.toBeOneOf(populatedSession.protocol, [AbstractSession.HTTPS_PROTOCOL, AbstractSession.HTTP_PROTOCOL]);
 
         // if basic auth, must have user and password OR base 64 encoded credentials
@@ -292,8 +308,14 @@ export abstract class AbstractSession {
             ImperativeExpect.keysToBeUndefined(populatedSession, ["tokenType", "tokenValue"] );
         }
 
+        // if bearer auth, must have token
+        if (session.type === AbstractSession.TYPE_BEARER) {
+            ImperativeExpect.keysToBeDefinedAndNonBlank(populatedSession, ["tokenValue"] );
+            ImperativeExpect.keysToBeUndefined(populatedSession, ["tokenType", "user", "password"] );
+        }
+
         if (session.type === AbstractSession.TYPE_TOKEN) {
-            ImperativeExpect.keysToBeDefinedAndNonBlank(session, ["tokenType"], "You must provide a token type to use token authentication");
+            ImperativeExpect.keysToBeDefinedAndNonBlank(session, ["tokenType"], "You must provide a token type to use cookie authentication");
 
             // if you dont have a token, we need credentials to retrieve a token
             if (isNullOrUndefined(session.tokenValue)) {

--- a/packages/rest/src/session/doc/ISession.ts
+++ b/packages/rest/src/session/doc/ISession.ts
@@ -70,14 +70,17 @@ export interface ISession {
      * Type of authentication, none is default
      * "none"  - no authorization header is used
      * "basic" - use basic auth for every request
-     * "token" - indicates use token value provided and check for timeout / expiration
+     * "bearer" - use bearer auth for every request.
+     *           Indicates use token value provided.
+     * "token" - use cookie auth for every request.
+     *           Indicates use token value provided and check for timeout / expiration
      *           if not token is provided, basic auth is used and the tokenType is obtained
      *           from the cookie header and stored as a token value to be used on subsequent
      *           requests
      * @type {string}
      * @memberof ISession
      */
-    type?: "none" | "basic" | "token";
+    type?: "none" | "basic" | "bearer" | "token";
 
     /**
      * Base 64 encoded authentication materials created by base 64 encoding:


### PR DESCRIPTION
`ISession.type` originally has these 3 value `"none" | "basic" | "token"`
I add "bearer".

However, I think `token` here should be changed into `cookie` (also `AbstractSession.TYPE_TOKEN` to `AbstractSession.TYPE_COOKIE`). But that would probably break someone who is using it.

This is my first time making changes to imperative. Open to all critics and suggestions :) 