### PR TITLE
Fix prompt tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- Fix tests for interactive prompting.
 - Add the --dd flag to profile creation to allow the profile to be created without the default values specified for that profile.
 - Use a token for authentication if a token is present in the underlying REST session object.
 - Add a new CredsForSessCfg.addCredsOrPrompt function that places credentials (including a possible token) into a session configuration object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7193,12 +7193,6 @@
       "integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
       "dev": true
     },
-    "mock-stdin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mock-stdin/-/mock-stdin-1.0.0.tgz",
-      "integrity": "sha512-tukRdb9Beu27t6dN+XztSRHq9J0B/CoAOySGzHfn8UTfmqipA5yNT/sDUEyYdAV3Hpka6Wx6kOMxuObdOex60Q==",
-      "dev": true
-    },
     "module-definition": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-3.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "jstree": "^3.3.8",
     "keytar": "^5.0.0",
     "madge": "^3.6.0",
-    "mock-stdin": "^1.0.0",
     "node-pty": "^0.9.0",
     "popper.js": "^1.16.0",
     "scroll-into-view-if-needed": "^2.2.22",

--- a/packages/rest/__tests__/session/CredsForSessCfg.test.ts
+++ b/packages/rest/__tests__/session/CredsForSessCfg.test.ts
@@ -141,6 +141,11 @@ describe("CredsForSessCfg tests", () => {
     });
 
     it("timeout waiting for user name", async() => {
+        const sleepReal = CliUtils.sleep;
+        CliUtils.sleep = jest.fn();
+        const promptWithTimeoutReal = CliUtils.promptWithTimeout;
+        CliUtils.promptWithTimeout = jest.fn(() => null);
+
         const intialSessCfg = {
             hostname: "SomeHost",
             port: 11,
@@ -150,21 +155,8 @@ describe("CredsForSessCfg tests", () => {
             password: "FakePassword",
         };
 
-        /* Jest hangs forever when you request data from stdin.
-         * mock-stdin should let you supply data. We could not make that work.
-         * At least with mock-stdin we only get our expected 30 second timout.
-         */
-        const mockStdIn = require("mock-stdin").stdin();
-        mockStdIn.send("FakeUser\n");   // this does not work
-        mockStdIn.end();
-
-        /* jest redirects stdin and we could not override it.
-         * So we catch the timeout error.
-         */
         let sessCfgWithCreds: ISession;
         let caughtError;
-        const sleepReal = CliUtils.sleep;
-        CliUtils.sleep = jest.fn();
         try {
             sessCfgWithCreds = await CredsForSessCfg.addCredsOrPrompt<ISession>(
                 intialSessCfg, args
@@ -173,11 +165,17 @@ describe("CredsForSessCfg tests", () => {
             caughtError = thrownError;
         }
         CliUtils.sleep = sleepReal;
+        CliUtils.promptWithTimeout = promptWithTimeoutReal;
         expect(caughtError instanceof ImperativeError).toBe(true);
         expect(caughtError.message).toBe("We timed-out waiting for user name.");
     });
 
     it("timeout waiting for password", async() => {
+        const sleepReal = CliUtils.sleep;
+        CliUtils.sleep = jest.fn();
+        const promptWithTimeoutReal = CliUtils.promptWithTimeout;
+        CliUtils.promptWithTimeout = jest.fn(() => null);
+
         const intialSessCfg = {
             hostname: "SomeHost",
             port: 11,
@@ -187,21 +185,8 @@ describe("CredsForSessCfg tests", () => {
             user: "FakeUser",
         };
 
-        /* Jest hangs forever when you request data from stdin.
-         * mock-stdin should let you supply data. We could not make that work.
-         * At least with mock-stdin we only get our expected 30 second timout.
-         */
-        const mockStdIn = require("mock-stdin").stdin();
-        mockStdIn.send("FakePassword\n");   // this does not work
-        mockStdIn.end();
-
-        /* jest redirects stdin and we could not override it.
-         * So we catch the timeout error.
-         */
         let sessCfgWithCreds: ISession;
         let caughtError;
-        const sleepReal = CliUtils.sleep;
-        CliUtils.sleep = jest.fn();
         try {
             sessCfgWithCreds = await CredsForSessCfg.addCredsOrPrompt<ISession>(
                 intialSessCfg, args
@@ -210,6 +195,7 @@ describe("CredsForSessCfg tests", () => {
             caughtError = thrownError;
         }
         CliUtils.sleep = sleepReal;
+        CliUtils.promptWithTimeout = promptWithTimeoutReal;
         expect(caughtError instanceof ImperativeError).toBe(true);
         expect(caughtError.message).toBe("We timed-out waiting for password.");
     });

--- a/packages/rest/__tests__/session/CredsForSessCfg.test.ts
+++ b/packages/rest/__tests__/session/CredsForSessCfg.test.ts
@@ -140,6 +140,74 @@ describe("CredsForSessCfg tests", () => {
         expect(sessCfgWithCreds.tokenValue).toBeUndefined();
     });
 
+    it("get user name from prompt", async() => {
+        const userFromPrompt = "FakeUser";
+        const passFromArgs = "FakePassword";
+
+        const sleepReal = CliUtils.sleep;
+        CliUtils.sleep = jest.fn();
+        const promptWithTimeoutReal = CliUtils.promptWithTimeout;
+        CliUtils.promptWithTimeout = jest.fn(() => {
+            return userFromPrompt;
+        });
+
+        const intialSessCfg = {
+            hostname: "SomeHost",
+            port: 11,
+            rejectUnauthorized: true,
+        };
+        const args = {
+            password: passFromArgs,
+        };
+
+        let sessCfgWithCreds: ISession;
+        sessCfgWithCreds = await CredsForSessCfg.addCredsOrPrompt<ISession>(
+            intialSessCfg, args
+        );
+        CliUtils.sleep = sleepReal;
+        CliUtils.promptWithTimeout = promptWithTimeoutReal;
+
+        expect(sessCfgWithCreds.type).toBe(SessConstants.AUTH_TYPE_BASIC);
+        expect(sessCfgWithCreds.user).toBe(userFromPrompt);
+        expect(sessCfgWithCreds.password).toBe(passFromArgs);
+        expect(sessCfgWithCreds.tokenType).toBeUndefined();
+        expect(sessCfgWithCreds.tokenValue).toBeUndefined();
+    });
+
+    it("get password from prompt", async() => {
+        const userFromArgs = "FakeUser";
+        const passFromPrompt = "FakePassword";
+
+        const sleepReal = CliUtils.sleep;
+        CliUtils.sleep = jest.fn();
+        const promptWithTimeoutReal = CliUtils.promptWithTimeout;
+        CliUtils.promptWithTimeout = jest.fn(() => {
+            return passFromPrompt;
+        });
+
+        const intialSessCfg = {
+            hostname: "SomeHost",
+            port: 11,
+            rejectUnauthorized: true,
+        };
+        const args = {
+            user: userFromArgs,
+        };
+
+        let sessCfgWithCreds: ISession;
+        sessCfgWithCreds = await CredsForSessCfg.addCredsOrPrompt<ISession>(
+            intialSessCfg, args
+        );
+        CliUtils.sleep = sleepReal;
+        CliUtils.promptWithTimeout = promptWithTimeoutReal;
+
+        expect(sessCfgWithCreds.type).toBe(SessConstants.AUTH_TYPE_BASIC);
+        expect(sessCfgWithCreds.user).toBe(userFromArgs);
+        expect(sessCfgWithCreds.password).toBe(passFromPrompt);
+        expect(sessCfgWithCreds.tokenType).toBeUndefined();
+        expect(sessCfgWithCreds.tokenValue).toBeUndefined();
+    });
+
     it("timeout waiting for user name", async() => {
         const sleepReal = CliUtils.sleep;
         CliUtils.sleep = jest.fn();


### PR DESCRIPTION
Removed mock-stdin which fails in pipeline. Used alternate approach instead.
Added tests for prompting for user name and password.

Once this PR is merged into the 'tokens' branch, the pipeline for the 'tokens' branch should once again run successfully.