### PR TITLE
Update log4js version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
 - Update log4js to improve Webpack compatibility for extenders
 
 ## `4.6.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+- Update log4js to improve Webpack compatibility for extenders
+
 ## `4.6.2`
 
 - Fix vulnerabilities by updating yargs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/imperative",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3502,9 +3502,9 @@
       "dev": true
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
     "flatten": {
       "version": "1.0.3",
@@ -6794,15 +6794,15 @@
       }
     },
     "log4js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.1.0.tgz",
-      "integrity": "sha512-fSCHMYsMJbHwfNTuMlopVVcfkKwIRLh5mpNZGB2oBbnSmr3yUTo4tL4xGBA0/q29xowlu96eTXGghJFNhPXMnA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
       "requires": {
         "date-format": "^3.0.0",
         "debug": "^4.1.1",
         "flatted": "^2.0.1",
         "rfdc": "^1.1.4",
-        "streamroller": "^2.2.3"
+        "streamroller": "^2.2.4"
       }
     },
     "loose-envify": {
@@ -9429,9 +9429,9 @@
       }
     },
     "streamroller": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
-      "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
       "requires": {
         "date-format": "^2.1.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jsonschema": "1.1.1",
     "levenshtein": "1.0.5",
     "lodash-deep": "2.0.0",
-    "log4js": "6.1.0",
+    "log4js": "6.3.0",
     "marked": "0.8.0",
     "moment": "2.20.1",
     "mustache": "2.3.0",


### PR DESCRIPTION
This PR updates log4js because there is a fix to its FileSync appender. With the current version being pulled in (6.1.0), logging does not work when Zowe Imperative is used in a Webpacked extension. Upgrading to log4js 6.3.0 should allow logging to work when the extension uses Webpack.

The change will be used to help bring [Webpack into Zowe Explorer](https://github.com/zowe/vscode-extension-for-zowe/issues/74).