### PR TITLE
Remove build hacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- Remove temporary build modifications that were used to enable zowe-cli to build with an unpublished imperative.
 - Fix tests for interactive prompting.
 - Add the --dd flag to profile creation to allow the profile to be created without the default values specified for that profile.
 - Use a token for authentication if a token is present in the underlying REST session object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- Remove temporary build modifications that were used to enable zowe-cli to build with an unpublished imperative.
 - Fix tests for interactive prompting.
 - Add the --dd flag to profile creation to allow the profile to be created without the default values specified for that profile.
 - Use a token for authentication if a token is present in the underlying REST session object.
-- Add a new CredsForSessCfg.addCredsOrPrompt function that places credentials (including a possible token) into a session configuration object.
+- Add a new ConnectionPropsForSessCfg.addPropsOrPrompt function that places credentials (including a possible token) into a session configuration object.
     - Credentials are obtained from the command line, environment variables, or a profile.
     - If no credentials are available, it will prompt for a user name and password.
     - Any prompt will timeout after 30 seconds so that it will not hang an automated script.

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
   "typings": "lib/index.d.ts",
   "scripts": {
     "audit:public": "npm audit --registry https://registry.npmjs.org/",
-    "remove:gitinstall": "echo Remember to remove 'remove:gitinstall' and 'prepare' scripts before publishing to NPM.",
-    "prepare": "npm run build",
-    "build:packages": "gulp build && npm run build:webHelp && npm run browserify && npm run remove:gitinstall",
+    "build:packages": "gulp build && npm run build:webHelp && npm run browserify",
     "build": "npm run build:packages",
     "postbuild": "gulp build:install-all-cli-dependencies && gulp build:all-clis && npm run checkTestsCompile",
     "checkTestsCompile": "echo \"Checking that test source compiles\" && tsc --noEmit -p tsconfig-tests.json",


### PR DESCRIPTION
Remove temporary build modifications that were used to enable zowe-cli to build with an unpublished imperative.

The token-enabled version of Zowe-CLI will not be able to build until:
        - This PR is merged into the "tokens" branch
        - The "tokens" branch is merged into the "master" branch
        - And imperative is published to NPM.