### PR TITLE
Process secure properties only once on profile update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Fix update profile API storing secure fields incorrectly when called without CLI args
+
 ## `4.7.2`
 
 - Hide sensitive session properties (user, password, and token value) in log file. Since 4.7.0, only password was hidden.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/imperative",
-  "version": "4.7.1",
+  "version": "4.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/imperative",
-  "version": "4.7.2",
+  "version": "4.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cmd/src/profiles/CliProfileManager.ts
+++ b/packages/cmd/src/profiles/CliProfileManager.ts
@@ -176,7 +176,6 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
             validationParms.readyForValidation = true;
             validationParms.profile = updated.profile;
             await this.validateProfile(validationParms);
-            updated.profile = await this.processSecureProperties(parms.name, updated.profile);
         }
 
         return updated;


### PR DESCRIPTION
* Fixed #379 where "managed by &lt;CredentialManager&gt;" was stored in credential vault instead of the actual value. This only happened when `CliProfileManager.updateProfile` was called with a profile object and no CLI args.
  `CliProfileManager.processSecureProperties` should be called only once in the `saveProfile` method. It was being called twice, in both `saveProfile` and `updateProfile`.
* Removed test that was duplicate of another test in the same suite. It is still [here](https://github.com/zowe/imperative/blob/fix-379/packages/cmd/__tests__/profiles/CliProfileManager.test.ts#L198-L199).