### PR TITLE
Don't expect DISPLAY to be defined on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Fix `--help-web` not working on macOS when DISPLAY environment variable is undefined
+
 ## `4.7.2`
 
 - Hide sensitive session properties (user, password, and token value) in log file. Since 4.7.0, only password was hidden.

--- a/packages/utilities/__tests__/ProcessUtils.test.ts
+++ b/packages/utilities/__tests__/ProcessUtils.test.ts
@@ -43,10 +43,10 @@ describe("ProcessUtils tests", () => {
     });
 
     describe("isGuiAvailable", () => {
-        it("should report a GUI on Windows", async () => {
-            if ( process.platform === "win32") {
-                expect(ProcessUtils.isGuiAvailable()).toBe(GuiResult.GUI_AVAILABLE);
-            }
+        (process.platform === "win32" || process.platform === "darwin" ? it : it.skip)
+            ("should report a GUI on Windows or Mac", async () =>
+        {
+            expect(ProcessUtils.isGuiAvailable()).toBe(GuiResult.GUI_AVAILABLE);
         });
 
         it("should report no GUI on an ssh connection", async () => {

--- a/packages/utilities/src/ProcessUtils.ts
+++ b/packages/utilities/src/ProcessUtils.ts
@@ -69,12 +69,12 @@ export class ProcessUtils {
             return GuiResult.NO_GUI_SSH;
         }
 
-        /* On linux (and MAC) the DISPLAY environment variable
-         * indicates that we are in an X-Window environment.
+        /* On linux the DISPLAY environment variable indicates
+         * that we are in an X-Window environment.
          */
-        if ( process.platform !== "win32") {
+        if (process.platform !== "win32" && process.platform !== "darwin") {
             if (typeof process.env.DISPLAY === "undefined" ||
-                process.env.DISPLAY === "" )
+                process.env.DISPLAY === "")
             {
                 return GuiResult.NO_GUI_NO_DISPLAY;
             }


### PR DESCRIPTION
Fixes #322 which is related to https://github.com/zowe/zowe-cli/issues/738

Recent versions of macOS don't define the DISPLAY environment variable: https://stackoverflow.com/questions/31622295/no-x11-display-variable-was-set-on-mac