### PR TITLE
AbstractSession.storeCookie() support for run-time defined cookie names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+- Updated AbstractSession.storeCookie() to process cookie names not fully known at build-time.
+
 ## `4.7.4`
 
 - Fix update profile API storing secure fields incorrectly when called without CLI args

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## `4.7.5`
+
 - Updated AbstractSession.storeCookie() to process cookie names not fully known at build-time.
 
 ## `4.7.4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the Imperative package will be documented in this file.
 
 - Updated AbstractSession.storeCookie() to process cookie names not fully known at build-time.
 
+## `4.7.5`
+
+- Add allowableValues support for array
+
 ## `4.7.4`
 
 - Fix update profile API storing secure fields incorrectly when called without CLI args

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## Recent Changes
-
-- Updated AbstractSession.storeCookie() to process cookie names not fully known at build-time.
-
 ## `4.7.5`
 
 - Add allowableValues support for array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## Recent Changes
+## `4.7.6`
 
 - Updated AbstractSession.storeCookie() to process cookie names not fully known at build-time.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Updated AbstractSession.storeCookie() to process cookie names not fully known at build-time.
+
 ## `4.7.5`
 
 - Add allowableValues support for array

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## `4.7.5`
+## Recent Changes
 
 - Updated AbstractSession.storeCookie() to process cookie names not fully known at build-time.
 

--- a/packages/rest/__tests__/session/Session.test.ts
+++ b/packages/rest/__tests__/session/Session.test.ts
@@ -24,6 +24,17 @@ describe("Session tests", () => {
         expect(session.ISession).toMatchSnapshot();
     });
 
+    it("should store partial/dynamic cookie token requested", () => {
+        const cookie: object = ["LtpaToken2=7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9" +
+        "nl1ubUvcK0hPgWmKH4xCOf1EoNafu40XaiLoO8wZnCo/rHmP2/h7MzSJV1te8dP4VM6NFdQCruuxtcgddTiDXU8gYZERFTnvtYhUu" +
+        "vk1Nne8xwo++sDAmEFVwvJbyg6Z0zT1RAGPIXd6hx8YPNXydAifoQhqI9CaoyZNptByyx2H7uJ0vt0HTNqrdgZclOQkDNMm65ETpdo" +
+        "1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE; path=/; domain=ca23; Secure; HttpOnly; Expires=Tue, 19" +
+        " Jan 2038 03:14:07 GMT;"];
+        const session = new Session({hostname: "localhost", type: "token", tokenType: "LtpaToken", user: "user", password: "password"});
+        session.storeCookie(cookie);
+        expect(session.ISession).toMatchSnapshot();
+    });
+
     it("should initialize with basic type and required input data", () => {
         const session = new Session({hostname: "localhost", type: "basic", user: "ibmuser", password: "mypass"});
         expect(session.ISession).toMatchSnapshot();

--- a/packages/rest/__tests__/session/Session.test.ts
+++ b/packages/rest/__tests__/session/Session.test.ts
@@ -25,14 +25,18 @@ describe("Session tests", () => {
     });
 
     it("should store partial/dynamic cookie token requested", () => {
-        const cookie: object = ["LtpaToken2=7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9" +
+        const cookieNameBase = "LtpaToken";
+        const cookieNameFull = cookieNameBase + "74133";
+        const cookieValue = "7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9" +
         "nl1ubUvcK0hPgWmKH4xCOf1EoNafu40XaiLoO8wZnCo/rHmP2/h7MzSJV1te8dP4VM6NFdQCruuxtcgddTiDXU8gYZERFTnvtYhUu" +
         "vk1Nne8xwo++sDAmEFVwvJbyg6Z0zT1RAGPIXd6hx8YPNXydAifoQhqI9CaoyZNptByyx2H7uJ0vt0HTNqrdgZclOQkDNMm65ETpdo" +
-        "1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE; path=/; domain=ca23; Secure; HttpOnly; Expires=Tue, 19" +
-        " Jan 2038 03:14:07 GMT;"];
-        const session = new Session({hostname: "localhost", type: "token", tokenType: "LtpaToken", user: "user", password: "password"});
+        "1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE"; 
+        const cookie: object = [cookieNameFull + "=" + cookieValue +
+        "; path=/; domain=ca23; Secure; HttpOnly; Expires=Tue, 19 Jan 2038 03:14:07 GMT;"];
+        const session = new Session({hostname: "localhost", type: "token", tokenType: cookieNameBase, user: "user", password: "password"});
         session.storeCookie(cookie);
-        expect(session.ISession).toMatchSnapshot();
+        expect(session.ISession.tokenType).toBe(cookieNameFull);
+        expect(session.ISession.tokenValue).toBe(cookieValue);
     });
 
     it("should initialize with basic type and required input data", () => {

--- a/packages/rest/__tests__/session/Session.test.ts
+++ b/packages/rest/__tests__/session/Session.test.ts
@@ -30,7 +30,7 @@ describe("Session tests", () => {
         const cookieValue = "7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9" +
         "nl1ubUvcK0hPgWmKH4xCOf1EoNafu40XaiLoO8wZnCo/rHmP2/h7MzSJV1te8dP4VM6NFdQCruuxtcgddTiDXU8gYZERFTnvtYhUu" +
         "vk1Nne8xwo++sDAmEFVwvJbyg6Z0zT1RAGPIXd6hx8YPNXydAifoQhqI9CaoyZNptByyx2H7uJ0vt0HTNqrdgZclOQkDNMm65ETpdo" +
-        "1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE"; 
+        "1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE";
         const cookie: object = [cookieNameFull + "=" + cookieValue +
         "; path=/; domain=ca23; Secure; HttpOnly; Expires=Tue, 19 Jan 2038 03:14:07 GMT;"];
         const session = new Session({hostname: "localhost", type: "token", tokenType: cookieNameBase, user: "user", password: "password"});

--- a/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
+++ b/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
@@ -128,3 +128,21 @@ Object {
   "user": "user",
 }
 `;
+
+exports[`Session tests should store partial/dynamic cookie token requested 1`] = `
+Object {
+  "base64EncodedAuth": "dXNlcjpwYXNzd29yZA==",
+  "basePath": "",
+  "hostname": "localhost",
+  "password": "password",
+  "port": 443,
+  "protocol": "https",
+  "rejectUnauthorized": true,
+  "secureProtocol": "SSLv23_method",
+  "strictSSL": true,
+  "tokenType": "LtpaToken2",
+  "tokenValue": "7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9nl1ubUvcK0hPgWmKH4xCOf1EoNafu40XaiLoO8wZnCo/rHmP2/h7MzSJV1te8dP4VM6NFdQCruuxtcgddTiDXU8gYZERFTnvtYhUuvk1Nne8xwo++sDAmEFVwvJbyg6Z0zT1RAGPIXd6hx8YPNXydAifoQhqI9CaoyZNptByyx2H7uJ0vt0HTNqrdgZclOQkDNMm65ETpdo1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE",
+  "type": "token",
+  "user": "user",
+}
+`;

--- a/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
+++ b/packages/rest/__tests__/session/__snapshots__/Session.test.ts.snap
@@ -128,21 +128,3 @@ Object {
   "user": "user",
 }
 `;
-
-exports[`Session tests should store partial/dynamic cookie token requested 1`] = `
-Object {
-  "base64EncodedAuth": "dXNlcjpwYXNzd29yZA==",
-  "basePath": "",
-  "hostname": "localhost",
-  "password": "password",
-  "port": 443,
-  "protocol": "https",
-  "rejectUnauthorized": true,
-  "secureProtocol": "SSLv23_method",
-  "strictSSL": true,
-  "tokenType": "LtpaToken2",
-  "tokenValue": "7KM/bf1sE4+4pE5mKgf+slWo9JO6laQF6OOi/POW0C+hRwscFOFjUijI2eWZrMY+jL4F9nl1ubUvcK0hPgWmKH4xCOf1EoNafu40XaiLoO8wZnCo/rHmP2/h7MzSJV1te8dP4VM6NFdQCruuxtcgddTiDXU8gYZERFTnvtYhUuvk1Nne8xwo++sDAmEFVwvJbyg6Z0zT1RAGPIXd6hx8YPNXydAifoQhqI9CaoyZNptByyx2H7uJ0vt0HTNqrdgZclOQkDNMm65ETpdo1u4U7Vd6HPoshHJEQo7p40T9jJfgv7PJ6Bxhp1dAqF5zEkqE",
-  "type": "token",
-  "user": "user",
-}
-`;

--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -220,9 +220,9 @@ export abstract class AbstractSession {
                 // if element begins with tokenType, extract full tokenType and tokenValue.
                 if (element.indexOf(this.mISession.tokenType) === 0) {
                     // parse off token value, splitting element at first "=".
-                    const temp: string[] = element.split("=");
-                    this.ISession.tokenType  = temp[0];
-                    this.ISession.tokenValue = temp[1];
+                    const split = element.indexOf("=");
+                    this.ISession.tokenType  = element.substring(0, split);
+                    this.ISession.tokenValue = element.substring(split + 1);
                 }
             });
         });

--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -217,10 +217,12 @@ export abstract class AbstractSession {
             const authArr = auth.split(";");
             // see each field in the cookie, e/g. Path=/; Secure; HttpOnly; LtpaToken2=...
             authArr.forEach((element: string) => {
-                // if we match requested token type, save it off for its length
+                // if element begins with tokenType, extract full tokenType and tokenValue.
                 if (element.indexOf(this.mISession.tokenType) === 0) {
-                    // parse off token value, minus LtpaToken2= (as an example)
-                    this.ISession.tokenValue = element.substr(this.ISession.tokenType.length + 1, element.length);
+                    // parse off token value, splitting element at first "=".
+                    const ejesCookie: string[] = element.split("=");
+                    this.ISession.tokenType  = ejesCookie[0];
+                    this.ISession.tokenValue = ejesCookie[1];
                 }
             });
         });

--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -218,11 +218,16 @@ export abstract class AbstractSession {
             // see each field in the cookie, e/g. Path=/; Secure; HttpOnly; LtpaToken2=...
             authArr.forEach((element: string) => {
                 // if element begins with tokenType, extract full tokenType and tokenValue.
-                if (element.indexOf(this.mISession.tokenType) === 0) {
+                if (element.indexOf(this.ISession.tokenType) === 0) {
                     // parse off token value, splitting element at first "=".
                     const split = element.indexOf("=");
-                    this.ISession.tokenType  = element.substring(0, split);
-                    this.ISession.tokenValue = element.substring(split + 1);
+                    if (split >= 0) {
+                        this.ISession.tokenType  = element.substring(0, split);
+                        this.ISession.tokenValue = element.substring(split + 1);
+                    }
+                    else {
+                        this.ISession.tokenValue = "";
+                    }
                 }
             });
         });

--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -225,9 +225,6 @@ export abstract class AbstractSession {
                         this.ISession.tokenType  = element.substring(0, split);
                         this.ISession.tokenValue = element.substring(split + 1);
                     }
-                    else {
-                        this.ISession.tokenValue = "";
-                    }
                 }
             });
         });

--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -220,9 +220,9 @@ export abstract class AbstractSession {
                 // if element begins with tokenType, extract full tokenType and tokenValue.
                 if (element.indexOf(this.mISession.tokenType) === 0) {
                     // parse off token value, splitting element at first "=".
-                    const ejesCookie: string[] = element.split("=");
-                    this.ISession.tokenType  = ejesCookie[0];
-                    this.ISession.tokenValue = ejesCookie[1];
+                    const temp: string[] = element.split("=");
+                    this.ISession.tokenType  = temp[0];
+                    this.ISession.tokenValue = temp[1];
                 }
             });
         });


### PR DESCRIPTION
Commit b1a0fad introduced a breaking change to AbstractSession.storeCookie() for APIs and applications generating cookie names that can't be fully known at build time. The current code assumes the "=" character separating cookie name and cookie value immediately follows the value stored in tokenType. This assumption breaks down when the server generates a cookie name starting with a fixed character string followed by an additional character string generated at run time.

This proposed change continues to support static cookie names as well as dynamically generated cookie names. Imperative's test:unit was run successfully against this change.

Dynamically generated cookie names might be used by APIs and servers that can listen for connections on multiple ports, where the port has some significance to the server. If that server used a fixed character string for the cookie name, it might have difficulty distinguishing the source of a returned cookie. In our case, we have a server that generates cookie names using the string "EJESWEB_" followed by the port number on which the request was accepted.