### PR TITLE
Fixing prompting in ConnectionPropsForSessCfg

### DIFF
--- a/packages/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -136,12 +136,14 @@ export class ConnectionPropsForSessCfg {
                 promptForValues.push("port");
             }
 
-            if (ConnectionPropsForSessCfg.propHasValue(finalSessCfg.user)=== false) {
-                promptForValues.push("user");
-            }
+            if (ConnectionPropsForSessCfg.propHasValue(finalSessCfg.tokenValue)=== false) {
+                if (ConnectionPropsForSessCfg.propHasValue(finalSessCfg.user)=== false) {
+                    promptForValues.push("user");
+                }
 
-            if (ConnectionPropsForSessCfg.propHasValue(finalSessCfg.password)=== false) {
-                promptForValues.push("password");
+                if (ConnectionPropsForSessCfg.propHasValue(finalSessCfg.password)=== false) {
+                    promptForValues.push("password");
+                }
             }
 
             // put all the needed properties in an array and call the external function


### PR DESCRIPTION
This is a small fix.

The issue is that in function `ConnectionPropsForSessCfg`, if the username/password were missing, the user would be prompted for these values even if a token was present.

Now user/pass are only prompted if the token is missing.