### PR TITLE
Fix node-pty test hanging on Node 14 + Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Imperative CLI Framework is a command processing system that lets you quickly bu
 
 - [**Install Node.js package manager**](https://nodejs.org/en/download/package-manager) on your computer. Node.js® is a JavaScript runtime environment on which we architected Imperative CLI Framework.
 
-- To build this project from source, you must have Python 2.7 and a C++ Compiler installed (both are required by a dependency named `node-gyp`). To obtain the required software, follow the [instructions in the node-gyp readme](https://github.com/nodejs/node-gyp#installation) specific to your OS. 
-
 - You must have a means to execute ".sh" (bash) scripts to run integration tests. On Windows, you can install "Git Bash", which is bundled with the standard [Git](https://git-scm.com/downloads) installation - (choose the "Use Git and Unix Tools from Windows Command Prompt" installation option). When you run the integration tests on Windows, you must have Administrative authority to enable the integration tests to create symbolic links.
 
 **Note:** Broadcom Inc. does not maintain the prerequisite software that Imperative CLI Framework requires. You are responsible for updating Node.js and other prerequisites on your computer. We recommend that you update Node.js regularly to the latest Long Term Support (LTS) version.
@@ -38,8 +36,6 @@ Issue the following commands to install Imperative CLI Framework as a dependency
 ### Build and Install Imperative CLI Framework from Source
 To build and install the Imperative CLI Framework, follow these steps:
 
-1. Install node-gyp. node-gyp is a tool that you use to build Node.js native addons. For more information, see the node-gyp installation instructions at https://github.com/nodejs/node-gyp.
-**Note:** You can skip to the next step if you installed node-gyp previously.
 1. Clone the `zowe/imperative` project to your PC.
 2. From the command line, issue `cd [relative path]/imperative`
 3. Issue `npm install`

--- a/__tests__/__integration__/cmd/__tests__/integration/cli/prompting/cli.prompting.integration.test.ts
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/prompting/cli.prompting.integration.test.ts
@@ -28,12 +28,12 @@ describe("cmd-cli profile mapping", () => {
         require("rimraf").sync(join(TEST_ENVIRONMENT.workingDir, "profiles"));
     });
 
-    it("should prompt the user for a value when the default prompt phrase is specified", (done: any) => {
+    it("should prompt the user for a value when the default prompt phrase is specified", async () => {
 
         const myColor = "army green";
         // for some reason, node-pty won't find "sh" on Windows unless you add .exe
-        const shProgram = require("os").platform() === "win32" ? "bash.exe" : "bash";
-        const ptyProcess = require("node-pty") // tslint:disable-line
+        const shProgram = process.platform === "win32" ? "bash.exe" : "bash";
+        const ptyProcess = require("node-pty-prebuilt-multiarch") // tslint:disable-line
             .spawn(shProgram, [join(__dirname, "__scripts__", "prompt_for_color.sh")],
                 {
                     name: "xterm-color",
@@ -50,26 +50,25 @@ describe("cmd-cli profile mapping", () => {
         ptyProcess.on("data", (data: string) => {
             output = Buffer.concat([output, Buffer.from(data)]);
             process.stdout.write(data);
-            if (!colorWritten && output.toString().indexOf(":") >= 0) {
+            if (!colorWritten && output.toString().includes(":")) {
                 ptyProcess.write(myColor + "\r\n");
                 colorWritten = true;
                 process.stdout.write("wrote color to prompt\n");
+            } else if (colorWritten && output.toString().includes("undefined")) {
+                ptyProcess.kill();
             }
         });
 
         // node-pty crashes on the Jenkins server but works locally on windows and linux
         // we allow an error to be encountered as long as we still saw the expected output
         // since this is the only package that gets us close to an automated test of prompting
-        ptyProcess.on("error", (error: any) => {
-            process.stdout.write("prompting process encountered an error: " + error);
-            expect(output.toString()).toContain("Color: " + myColor);
-            ptyProcess.destroy();
-            done();
-        });
-        ptyProcess.on("end", () => {
-            process.stdout.write("prompting process ended");
-            expect(output.toString()).toContain("Color: " + myColor);
-            done();
+        await new Promise((resolve: any) => {
+            ptyProcess.on("exit", (result: any) => {
+                process.stdout.write("prompting process ended with exit code " + result.exitCode);
+                expect(output.toString()).toContain("Color: " + myColor);
+                ptyProcess.destroy();
+                resolve();
+            });
         });
 
     });

--- a/__tests__/__integration__/cmd/__tests__/integration/cli/prompting/cli.prompting.integration.test.ts
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/prompting/cli.prompting.integration.test.ts
@@ -66,7 +66,9 @@ describe("cmd-cli profile mapping", () => {
             ptyProcess.on("exit", (result: any) => {
                 process.stdout.write("prompting process ended with exit code " + result.exitCode);
                 expect(output.toString()).toContain("Color: " + myColor);
-                ptyProcess.destroy();
+                try {
+                    ptyProcess.destroy();
+                } catch { /* Do nothing */ }
                 resolve();
             });
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9846,13 +9846,14 @@
         "which": "^1.3.0"
       }
     },
-    "node-pty": {
+    "node-pty-prebuilt-multiarch": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.9.0.tgz",
-      "integrity": "sha512-MBnCQl83FTYOu7B4xWw10AW77AAh7ThCE1VXEv+JeWj8mSpGo+0bwgsV+b23ljBFwEM9OmsOv3kM27iUPPm84g==",
+      "resolved": "https://registry.npmjs.org/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.9.0.tgz",
+      "integrity": "sha512-n5LkPEuBwI+S2GgDk+IEByoVZClYFQGfp1b6dbMMEln7e43ikF8LZVi3vxpLXVq1rnS8t54YOnMB7HSB4jw8Tg==",
       "dev": true,
       "requires": {
-        "nan": "^2.14.0"
+        "nan": "^2.14.0",
+        "prebuild-install": "^5.2.5"
       }
     },
     "node-releases": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "jstree": "^3.3.8",
     "keytar": "^6.0.1",
     "madge": "^3.6.0",
-    "node-pty": "^0.9.0",
+    "node-pty-prebuilt-multiarch": "^0.9.0",
     "scroll-into-view-if-needed": "^2.2.22",
     "shebang-regex": "^2.0.0",
     "split.js": "^1.5.11",


### PR DESCRIPTION
⚠️ Don't merge yet, this worked locally but is still hanging in pipeline.

* Resolves #453. The only solution I could find was to kill the `node-pty` process before the "exit" event is emitted, otherwise it will hang indefinitely on Node 14 + Windows. Also changed test to listen for "exit" event instead of "error" and "end", which are undocumented and I couldn't get to work.
* Replaces dev dep `node-pty` with `node-pty-prebuilt-multiarch`. This package includes prebuilt native code like Keytar does, and makes `node-gyp` unnecessary for most users.