### PR TITLE
Disable integration test that hangs on Windows

### DIFF
--- a/__tests__/__integration__/cmd/__tests__/integration/cli/prompting/cli.prompting.integration.test.ts
+++ b/__tests__/__integration__/cmd/__tests__/integration/cli/prompting/cli.prompting.integration.test.ts
@@ -28,7 +28,8 @@ describe("cmd-cli profile mapping", () => {
         require("rimraf").sync(join(TEST_ENVIRONMENT.workingDir, "profiles"));
     });
 
-    it("should prompt the user for a value when the default prompt phrase is specified", (done: any) => {
+    // Skip this test on Windows until https://github.com/microsoft/node-pty/issues/437 is fixed
+    (process.platform !== "win32" ? it : it.skip)("should prompt the user for a value when the default prompt phrase is specified", (done: any) => {
 
         const myColor = "army green";
         // for some reason, node-pty won't find "sh" on Windows unless you add .exe

--- a/__tests__/__integration__/imperative/package.json
+++ b/__tests__/__integration__/imperative/package.json
@@ -45,7 +45,7 @@
     "js-yaml": "3.13.1",
     "jsonfile": "4.0.0",
     "jsonschema": "1.1.1",
-    "keytar": "5.0.0",
+    "keytar": "6.0.1",
     "levenshtein": "1.0.5",
     "lodash": "4.17.19",
     "log4js": "6.1.0",


### PR DESCRIPTION
Temporarily disable node-pty test on Windows until https://github.com/microsoft/node-pty/issues/437 is fixed.

Also update Keytar dependency in Imperative test CLI to support Node 14.