### PR TITLE
Expose trim parameter within TextUtils.wordWrap()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Expose `trim` parameter from `wrap-ansi` within `TextUtils.wordWrap()`
+
 ## `4.8.1`
 
 - BugFix: Fixed an issue with `ConnectionPropsForSessCfg` where the user would be prompted for user/password even if a token was present. [#436](https://github.com/zowe/imperative/pull/436)

--- a/packages/utilities/src/TextUtils.ts
+++ b/packages/utilities/src/TextUtils.ts
@@ -218,9 +218,9 @@ export class TextUtils {
      * @returns {string}
      */
     public static wordWrap(text: string, width?: number,
-                           indent: string = "", hardWrap: boolean = false): string {
+                           indent: string = "", hardWrap: boolean = false, trim: boolean = true): string {
         const yargs = require("yargs");
-        const wrappedText = require("wrap-ansi")(text, this.getRecommendedWidth(width), {hard: hardWrap});
+        const wrappedText = require("wrap-ansi")(text, this.getRecommendedWidth(width), {hard: hardWrap, trim});
         return wrappedText.split(/\n/g).map((line: string) => {
             if (line.length === 0) {
                 return line;


### PR DESCRIPTION
When using `TextUtils.wordWrap()` to truncate lines, as in #444, whitespace between columns is removed. This change exposes the `trim` parameter from `wrap-ansi`, in order to prevent this behavior.

This is an optional parameter, and the default value from `wrap-ansi` is kept, so no existing code is affected.