### PR TITLE
Change wording on changelog for 4.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## `Recent Changes`
+## Recent Changes
 
-- BugFix: Update `opener` dependency due to command injection vulnerability in Windows - [GHSL-2020-145](https://securitylab.github.com/advisories/GHSL-2020-145-domenic-opener)
+- BugFix: Updated `opener` dependency due to command injection vulnerability on Windows - [GHSL-2020-145](https://securitylab.github.com/advisories/GHSL-2020-145-domenic-opener)
 
 ## `4.8.1`
 


### PR DESCRIPTION
Note to self: The changelog should not have quotes on the recent changes header.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>