### PR TITLE
[json-config-next] Dynamically build zowe.config.json template

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -10,6 +10,7 @@
 */
 
 export * from "./src/Config";
+export * from "./src/ConfigSchema";
 export * from "./src/doc/IConfig";
 export * from "./src/doc/IConfigLayer";
 export * from "./src/doc/IConfigOpts";

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -351,12 +351,27 @@ export class Config {
             layer.properties.secure = Array.from(new Set(layer.properties.secure.concat([path])));
     }
 
-    public setSchema(value: string) {
+    /**
+     * Sets the $schema value at the top of the config JSON, and saves the
+     * schema to disk if an object is provided.
+     * @param uri The URI of JSON schema
+     * @param schemaObj Schema object to write to disk (if URI is a local path)
+     */
+    public setSchema(uri: string, schemaObj?: any) {
         const layer = this.layerActive();
         delete layer.properties.$schema;
-        layer.properties = { $schema: value, ...layer.properties };
+        layer.properties = { $schema: uri, ...layer.properties };
+
+        if (schemaObj != null) {
+            const filePath = node_path.resolve(node_path.dirname(layer.path), uri);
+            fs.writeFileSync(filePath, JSON.stringify(schemaObj, null, Config.INDENT));
+        }
     }
 
+    /**
+     * Adds a property path to the secure array in the config JSON.
+     * @param path The property path to be secured
+     */
     public addSecure(path: string) {
         const layer = this.layerActive();
         if (!layer.properties.secure.includes(path)) {

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -29,7 +29,7 @@ enum layers {
 };
 
 export class Config {
-    private static readonly IDENT: number = 4;
+    private static readonly INDENT: number = 4;
     private static readonly SECURE_ACCT = "secure_config_props";
 
     private _app: string;
@@ -250,7 +250,7 @@ export class Config {
 
                     // Write the layer
                     try {
-                        fs.writeFileSync(layer.path, JSON.stringify(layer.properties, null, Config.IDENT));
+                        fs.writeFileSync(layer.path, JSON.stringify(layer.properties, null, Config.INDENT));
                     } catch (e) {
                         throw new ImperativeError({ msg: `error writing "${layer.path}": ${e.message}` });
                     }
@@ -349,6 +349,19 @@ export class Config {
 
         if (opts.secure)
             layer.properties.secure = Array.from(new Set(layer.properties.secure.concat([path])));
+    }
+
+    public setSchema(value: string) {
+        const layer = this.layerActive();
+        delete layer.properties.$schema;
+        layer.properties = { $schema: value, ...layer.properties };
+    }
+
+    public addSecure(path: string) {
+        const layer = this.layerActive();
+        if (!layer.properties.secure.includes(path)) {
+            layer.properties.secure.push(path);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/packages/config/src/ConfigSchema.ts
+++ b/packages/config/src/ConfigSchema.ts
@@ -27,6 +27,9 @@ export class ConfigSchema {
                 properties[k].description = (v as any).optionDefinition.description;
                 properties[k].default = (v as any).optionDefinition.defaultValue;
             }
+            if (v.secure) {
+                properties[k].secure = true;
+            }
         }
         return {
             type: schema.type,

--- a/packages/config/src/ConfigSchema.ts
+++ b/packages/config/src/ConfigSchema.ts
@@ -12,12 +12,18 @@
 import { IProfileSchema, IProfileTypeConfiguration } from "../../profiles";
 
 export class ConfigSchema {
+    /**
+     * JSON schema URI used by our custom schemas
+     * @readonly
+     * @memberof ConfigSchema
+     */
     private static readonly JSON_SCHEMA = "https://json-schema.org/draft/2019-09/schema#";
 
     /**
      * Transform an Imperative profile schema to a JSON schema. Removes any
      * non-JSON-schema properties and translates anything useful.
      * @param schema The Imperative profile schema
+     * @returns JSON schema for profile properties
      */
     private static transformSchema(schema: IProfileSchema): any {
         const properties: { [key: string]: any } = {};
@@ -41,8 +47,9 @@ export class ConfigSchema {
     }
 
     /**
-     * Dynamically build the config schema
-     * @param schemas The schemas specified for this CLI
+     * Dynamically builds the config schema for this CLI.
+     * @param profiles The profiles supported by this CLI
+     * @returns JSON schema for all supported profile types
      */
     public static buildSchema(profiles: IProfileTypeConfiguration[]): any {
         const entries: any[] = [];

--- a/packages/config/src/ConfigSchema.ts
+++ b/packages/config/src/ConfigSchema.ts
@@ -1,0 +1,105 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { IProfileSchema, IProfileTypeConfiguration } from "../../profiles";
+
+export class ConfigSchema {
+    private static readonly JSON_SCHEMA = "https://json-schema.org/draft/2019-09/schema#";
+
+    /**
+     * Transform an Imperative profile schema to a JSON schema. Removes any
+     * non-JSON-schema properties and translates anything useful.
+     * @param schema The Imperative profile schema
+     */
+    private static transformSchema(schema: IProfileSchema): any {
+        const properties: { [key: string]: any } = {};
+        for (const [k, v] of Object.entries(schema.properties)) {
+            properties[k] = { type: v.type };
+            if ((v as any).optionDefinition != null) {
+                properties[k].description = (v as any).optionDefinition.description;
+                properties[k].default = (v as any).optionDefinition.defaultValue;
+            }
+        }
+        return {
+            type: schema.type,
+            title: schema.title,
+            description: schema.description,
+            properties,
+            required: schema.required
+        };
+    }
+
+    /**
+     * Dynamically build the config schema
+     * @param schemas The schemas specified for this CLI
+     */
+    public static buildSchema(profiles: IProfileTypeConfiguration[]): any {
+        const entries: any[] = [];
+        profiles.forEach((profile: { type: string, schema: IProfileSchema }) => {
+            entries.push({
+                if: { properties: { type: { const: profile.type } } },
+                then: { properties: { properties: this.transformSchema(profile.schema) } },
+            });
+        });
+        return {
+            $schema: ConfigSchema.JSON_SCHEMA,
+            type: "object",
+            description: "config",
+            properties: {
+                profiles: {
+                    type: "object",
+                    description: "named profiles config",
+                    patternProperties: {
+                        "^\\S*$": {
+                            type: "object",
+                            description: "a profile",
+                            properties: {
+                                type: {
+                                    description: "the profile type",
+                                    type: "string"
+                                },
+                                properties: {
+                                    description: "the profile properties",
+                                    type: "object"
+                                },
+                                profiles: {
+                                    description: "additional sub-profiles",
+                                    type: "object",
+                                    $ref: "#/properties/profiles"
+                                }
+                            },
+                            allOf: entries
+                        }
+                    }
+
+                },
+                defaults: {
+                    type: "object",
+                    description: "default profiles config",
+                    patternProperties: {
+                        "^\\S*$": {
+                            type: "string",
+                            description: "the type"
+                        }
+                    }
+                },
+                secure: {
+                    type: "array",
+                    description: "secure properties",
+                    items: {
+                        type: "string",
+                        description: "path to a property"
+                    }
+                }
+            }
+        };
+    }
+}

--- a/packages/config/src/doc/IConfig.ts
+++ b/packages/config/src/doc/IConfig.ts
@@ -12,6 +12,7 @@
 import { IConfigProfile } from "./IConfigProfile";
 
 export interface IConfig {
+    $schema?: string;
     defaults: { [key: string]: string };
     profiles: { [key: string]: IConfigProfile };
     plugins: string[];

--- a/packages/imperative/src/config/cmd/init/init.definition.ts
+++ b/packages/imperative/src/config/cmd/init/init.definition.ts
@@ -74,6 +74,12 @@ export const initDefinition: ICommandDefinition = {
             description: "when profiles are created, set them as the default.",
             type: "boolean",
             defaultValue: false
+        },
+        {
+            name: "ci",
+            description: "don't prompt for secure values.",
+            type: "boolean",
+            defaultValue: false
         }
     ]
 };

--- a/packages/imperative/src/config/cmd/init/init.definition.ts
+++ b/packages/imperative/src/config/cmd/init/init.definition.ts
@@ -58,6 +58,7 @@ export const initDefinition: ICommandDefinition = {
             type: "string",
         },
         {
+            // TODO Should this be removed if it is unused?
             name: "template",
             description: "apply a type as a template to guide creation.",
             type: "string"

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -20,6 +20,8 @@ import { IProfileProperty } from "../../../../../profiles";
  * Init config
  */
 export default class InitHandler implements ICommandHandler {
+    private static readonly DEFAULT_ROOT_PROFILE_NAME = "my_profiles";
+
     // Prompt timeout......
     private static readonly TIMEOUT: number = 900;
 
@@ -145,14 +147,15 @@ export default class InitHandler implements ICommandHandler {
         const schema = ConfigSchema.buildSchema(ImperativeConfig.instance.loadedConfig.profiles);
         config.setSchema("./schema.json", schema);
 
-        const baseProfileType = ImperativeConfig.instance.loadedConfig.baseProfile?.type;
+        const baseProfileType: string = ImperativeConfig.instance.loadedConfig.baseProfile?.type;
+        const rootProfileName: string = ImperativeConfig.instance.loadedConfig.templateProfileName ?? InitHandler.DEFAULT_ROOT_PROFILE_NAME;
         const secureProps: { [key: string]: any } = {};
         for (const profile of ImperativeConfig.instance.loadedConfig.profiles) {
             // Construct profile path
             let profilePath = `my_${profile.type}`;
             if (baseProfileType && profile.type !== baseProfileType) {
                 // Path should have two levels for non-base profiles
-                profilePath = `my_profiles.${profile.type}`;
+                profilePath = `${rootProfileName}.${profile.type}`;
             }
 
             // Don't overwrite existing profile with same path
@@ -196,7 +199,7 @@ export default class InitHandler implements ICommandHandler {
             config.set(propPath, propValue, { secure: true });
         }
         // Hoist duplicate default properties
-        config.api.profiles.set("my_profiles", this.hoistTemplateProperties(config.properties.profiles.my_profiles));
+        config.api.profiles.set(rootProfileName, this.hoistTemplateProperties(config.properties.profiles[rootProfileName]));
     }
 
     /**

--- a/packages/imperative/src/config/cmd/schema/schema.handler.ts
+++ b/packages/imperative/src/config/cmd/schema/schema.handler.ts
@@ -10,13 +10,14 @@
 */
 
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
+import { ConfigSchema } from "../../../../../config";
 import { ImperativeConfig } from "../../../../../utilities";
 
 /**
  * The get command group handler for cli configuration settings.
  */
 export default class SchemaHandler implements ICommandHandler {
-    private static readonly IDENT: number = 4;
+    private static readonly INDENT: number = 4;
 
     /**
      * Process the command and input.
@@ -26,90 +27,7 @@ export default class SchemaHandler implements ICommandHandler {
      * @throws {ImperativeError}
      */
     public async process(params: IHandlerParameters): Promise<void> {
-        const entries: { type: string, schema: any }[] = [];
-        ImperativeConfig.instance.loadedConfig.profiles.forEach((profile) => {
-            entries.push({
-                type: profile.type,
-                schema: profile.schema
-            });
-        });
-        params.response.console.log(JSON.stringify(this.schema(entries), null, SchemaHandler.IDENT));
-    }
-
-    /**
-     * Dynamically build the config schema
-     * @param schemas The schemas specified for this CLI
-     */
-    private schema(schemas?: { type: string, schema: any }[]): any {
-        schemas = schemas || [];
-        const entries: any[] = [];
-        schemas.forEach((schema: { type: string, schema: any }) => {
-            // Remove any non-JSON-schema properties and translate anything useful
-            for (const [_, v] of Object.entries(schema.schema.properties)) {
-                if ((v as any).optionDefinition != null) {
-                    if ((v as any).optionDefinition.description)
-                        (v as any).description = (v as any).optionDefinition.description;
-                }
-                delete (v as any).secure
-                delete (v as any).optionDefinition;
-            }
-
-            entries.push({
-                if: { properties: { type: { const: schema.type } } },
-                then: { properties: { properties: schema.schema } },
-            });
-        });
-        return {
-            $schema: "https://json-schema.org/draft/2019-09/schema#",
-            type: "object",
-            description: "config",
-            properties: {
-                profiles: {
-                    type: "object",
-                    description: "named profiles config",
-                    patternProperties: {
-                        "^\\S*$": {
-                            type: "object",
-                            description: "a profile",
-                            properties: {
-                                type: {
-                                    description: "the profile type",
-                                    type: "string"
-                                },
-                                properties: {
-                                    description: "the profile properties",
-                                    type: "object"
-                                },
-                                profiles: {
-                                    description: "additional sub-profiles",
-                                    type: "object",
-                                    $ref: "#/properties/profiles"
-                                }
-                            },
-                            allOf: entries
-                        }
-                    }
-
-                },
-                defaults: {
-                    type: "object",
-                    description: "default profiles config",
-                    patternProperties: {
-                        "^\\S*$": {
-                            type: "string",
-                            description: "the type"
-                        }
-                    }
-                },
-                secure: {
-                    type: "array",
-                    description: "secure properties",
-                    items: {
-                        type: "string",
-                        description: "path to a property"
-                    }
-                }
-            }
-        };
+        const schema = ConfigSchema.buildSchema(ImperativeConfig.instance.loadedConfig.profiles);
+        params.response.console.log(JSON.stringify(schema, null, SchemaHandler.INDENT));
     }
 }

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -16,6 +16,8 @@ import { CredentialManagerFactory } from "../../../../../security";
 import { CliUtils, ImperativeConfig } from "../../../../../utilities";
 
 export default class SecureHandler implements ICommandHandler {
+    // Prompt timeout......
+    private static readonly TIMEOUT: number = 900;
 
     /**
      * Process the command and input.
@@ -56,7 +58,8 @@ export default class SecureHandler implements ICommandHandler {
 
         // Prompt for values designated as secure
         for (const propName of secureProps) {
-            const propValue = CliUtils.promptForInput(`Please enter ${propName}: `);
+            const propValue = await CliUtils.promptWithTimeout(`Please enter ${propName}: `, true,
+                SecureHandler.TIMEOUT);
             // Save the value in the config securely
             if (propValue) {
                 config.set(propName, propValue, { secure: true });

--- a/packages/imperative/src/doc/IImperativeConfig.ts
+++ b/packages/imperative/src/doc/IImperativeConfig.ts
@@ -175,6 +175,13 @@ export interface IImperativeConfig {
     authGroupConfig?: IImperativeAuthGroupConfig;
 
     /**
+     * Specify the name to use in the config template for the root profile that contains all supported profiles.
+     * @type {string}
+     * @memberof IImperativeConfig
+     */
+    templateProfileName?: string;
+
+    /**
      * If you specify a list of profile configurations, you can set this to true to
      * automatically add a set of commands to your CLI to create, update, delete, and otherwise
      * manage user profiles.

--- a/packages/profiles/src/doc/definition/IProfileProperty.ts
+++ b/packages/profiles/src/doc/definition/IProfileProperty.ts
@@ -31,4 +31,10 @@ export interface IProfileProperty {
    */
   secure?: boolean;
 
+  /**
+   * Should this property be defined in a new config JSON template?
+   * @type {boolean}
+   * @memberof IProfileProperty
+   */
+  includeInTemplate?: boolean;
 }


### PR DESCRIPTION
This PR alters `zowe config init` to generate the desired config template.
- Two profiles are created at top level: a base profile `my_base` and another profile `my_profiles` that wraps service profiles
- The name `my_profiles` can be overridden by the value of `IImperativeConfig.templateProfileName` (e.g., `lpar1` for Zowe CLI)
- Plain text profile properties with `IProfileProperty.includeInTemplate` set to true are added with their default value
- Secure profile properties with `IProfileProperty.includeInTemplate` set to true are added to the `secure` array
- Profile properties with the same value across multiple service profiles (e.g., `"host": ""`) are "hoisted" up to `my_profiles`
- Secure property values are prompted for and saved to credential vault unless the `--ci` argument is specified
- The command `zowe config init` can be run repeatedly to add profile templates without overwriting existing profiles
- A schema is referenced in the config template and built and saved in `schema.json` alongside `zowe.config.json`
- The schema has "default" and "secure" attributes added to it which provide more information about profile properties

<details>
<summary>Click the arrow to expand and view the template produced for Zowe CLI</summary>
<pre>
{
    "$schema": "./schema.json",
    "profiles": {
        "lpar1": {
            "properties": {
                "host": ""
            },
            "profiles": {
                "zosmf": {
                    "type": "zosmf",
                    "properties": {
                        "port": 443
                    }
                },
                "tso": {
                    "type": "tso",
                    "properties": {
                        "account": ""
                    }
                },
                "ssh": {
                    "type": "ssh",
                    "properties": {
                        "port": 22
                    }
                }
            }
        },
        "my_base": {
            "type": "base",
            "properties": {
                "rejectUnauthorized": true
            }
        }
    },
    "defaults": {
        "zosmf": "lpar1.zosmf",
        "tso": "lpar1.tso",
        "ssh": "lpar1.ssh",
        "base": "my_base"
    },
    "plugins": [],
    "secure": [
        "profiles.my_base.properties.user",
        "profiles.my_base.properties.password"
    ]
}
</pre>
</details>