### PR TITLE
Prevent TypeError because getFileName() return null and other unexpected problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ __tests__/src/plugins/suites/sample-plugin.json
 /__tests__/__integration__/imperative/node_modules/
 /__tests__/__integration__/imperative/__tests__/__results__/
 /__tests__/__results__/
+someHome/
 
 ## Including imperative symbolic link for testing purposes
 !/__tests__/src/packages/imperative/plugins/test_cli/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## `4.9.1`
+## Recent Changes
 
 - BugFix: Fixed an issue when `TypeError` has been raised by `Logger.getCallerFileAndLineTag()` when there was not filename for a stack frame. [#449](https://github.com/zowe/imperative/issues/449)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## `4.9.1`
+
+- BugFix: Fixed an issue when `TypeError` has been raised by `Logger.getCallerFileAndLineTag()` when there was not filename for a stack frame. [#449](https://github.com/zowe/imperative/issues/449)
+
 ## `4.9.0`
 
 - BugFix: Updated `opener` dependency due to command injection vulnerability on Windows - [GHSL-2020-145](https://securitylab.github.com/advisories/GHSL-2020-145-domenic-opener)

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -352,15 +352,19 @@ export class Logger {
      * @returns {string} - file and line number
      */
     private getCallerFileAndLineTag(): string {
-        const frame: StackTrace.StackFrame[] = StackTrace.parse(new Error());
-        let callerStackIndex = 1;
-        while (frame[callerStackIndex].getFileName().indexOf(path.basename(__filename)) >= 0) {
-            // go up the stack until we're outside of the BrightsideLogger file
-            callerStackIndex += 1;
+        try {
+            const frame: StackTrace.StackFrame[] = StackTrace.parse(new Error());
+            let callerStackIndex = 1;
+            while (!frame[callerStackIndex].getFileName() || (frame[callerStackIndex].getFileName().indexOf(path.basename(__filename)) >= 0)) {
+                // go up the stack until we're outside of the BrightsideLogger file
+                callerStackIndex += 1;
+            }
+            const filename = path.basename(frame[callerStackIndex].getFileName());
+            const lineNumber = frame[callerStackIndex].getLineNumber();
+            return format("[%s:%s] ", filename, lineNumber);
+        } catch(e) {
+            return "[<unknown>] ";
         }
-        const filename = path.basename(frame[callerStackIndex].getFileName());
-        const lineNumber = frame[callerStackIndex].getLineNumber();
-        return format("[%s:%s] ", filename, lineNumber);
     }
 
     /**


### PR DESCRIPTION
Resolves #449

It is important for z/OSMF performance test development. This exception masks a real exception.