### PR TITLE
Remove LTS-incremental @brightside/core service

### DIFF
--- a/packages/security/src/DefaultCredentialManager.ts
+++ b/packages/security/src/DefaultCredentialManager.ts
@@ -58,23 +58,6 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
   public static readonly SVC_NAME = "Zowe";
 
   /**
-   * Alternative services under which we will look for credentials.
-   * Do not change the order of the alternative services.
-   * When adding, removing or modifying the alternative services,
-   * double check the loadCredentials function.
-   */
-  private readonly ALTERNATIVE_SERVICES = ["@brightside/core", "@zowe/cli", "Zowe-Plugin"];
-
-  /**
-   * This variable indicates which service should be used when loading
-   * secure properties in the case of a conflict
-   * lts-incremental --> @brightside/core
-   * latest -----------> @zowe/cli
-   */
-  private readonly SERVICE_VER_PREFERENCE: string = "latest";
-
-
-  /**
    * Reference to the lazily loaded keytar module.
    */
   private keytar: typeof keytar;
@@ -114,12 +97,27 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
     // the abstract class initialization in the future.
     super(service, displayName);
 
-    // Gather all services
-    this.allServices = JSON.parse(JSON.stringify(this.ALTERNATIVE_SERVICES));
-    if (this.allServices.indexOf(this.service) === -1) {
-      this.allServices.push(this.service);
+    /* Gather all services. We will load secure properties for the first
+     * successful service found in the order that they are placed in this array.
+     */
+    this.allServices = [this.service];
+
+    /* In our current implementation, this.service is always
+     * DefaultCredentialManager.SVC_NAME. We keep the logic below,
+     * in case we re-enable overrides in the future.
+     */
+    if (this.service !== DefaultCredentialManager.SVC_NAME) {
+        this.allServices.push(DefaultCredentialManager.SVC_NAME);
     }
-    this.allServices.push(DefaultCredentialManager.SVC_NAME);
+
+    /* Previous services under which we will look for credentials.
+     * We dropped @brightside/core because we no longer support the
+     * lts-incremental version of the product.
+     */
+    this.allServices.push("@zowe/cli");
+    this.allServices.push("Zowe-Plugin");
+    this.allServices.push("Broadcom-Plugin");
+
   }
 
   /**
@@ -196,38 +194,11 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
       return secureValue;
     };
 
-    // First, check for service that we (the built-in imperative CredMgr) is responsible for.
-    let secValue = await loadHelper(DefaultCredentialManager.SVC_NAME);
-    if (secValue == null) {
-      // We didn't find the account under our built-in service
-      // Let's check if the service name provided is in our list
-      if (this.ALTERNATIVE_SERVICES.indexOf(this.service) === -1) {
-        // Specified service not in our list
-        // Look for the account in this new service that we don't know about
-        secValue = await loadHelper(this.service);
-      }
-    }
-    if (secValue == null) {
-      // The secure value was not found
-      // Let us look for the account in our version-specific services
-      const brightValue = await loadHelper(this.ALTERNATIVE_SERVICES[0]); // @brightside/core
-      const zoweValue = await loadHelper(this.ALTERNATIVE_SERVICES[1]);   // @zowe/cli
-
-      if (brightValue != null && zoweValue == null) {
-        secValue = brightValue; // Only found the account in the brightside service
-      } else if (brightValue == null && zoweValue != null) {
-        secValue = zoweValue; // Only found the account in the zowe service
-      } else if (brightValue != null && zoweValue != null) {
-        // Found the account in both services :'{ We got a conflict }':
-        // Check which credentials should we use based on the constant variable
-        secValue = this.SERVICE_VER_PREFERENCE === "lts-incremental" ? brightValue : zoweValue;
-      }
-    }
-    if (secValue == null) {
-      // We got no value from our version-specific services. Try the remaining known services.
-      for (let svcInx = 2; svcInx < this.ALTERNATIVE_SERVICES.length; svcInx++) {
-        secValue = await loadHelper(this.ALTERNATIVE_SERVICES[svcInx]);
-        if (secValue != null)
+    // load secure properties using the first successful value from our known services
+    let secValue = null;
+    for (const nextService of this.allServices) {
+      secValue = await loadHelper(nextService);
+      if (secValue != null) {
           break;
       }
     }
@@ -239,9 +210,12 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
       });
     }
 
-    const impLogger = Logger.getImperativeLogger();
-    impLogger.info("Successfully loaded secure value for service = '" + this.service +
+    if (secValue != null) {
+      const impLogger = Logger.getImperativeLogger();
+      impLogger.info("Successfully loaded secure value for service = '" + this.service +
         "' account = '" + account + "'");
+    }
+
     return secValue;
   }
 
@@ -352,10 +326,10 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
     }
   }
 
-  private async deleteCredentialsHelper(account: string, keepRequestedSvc?: boolean): Promise<boolean> {
+  private async deleteCredentialsHelper(account: string, keepCurrentSvc?: boolean): Promise<boolean> {
     let wasDeleted = false;
     for (const service of this.allServices) {
-      if (keepRequestedSvc && service === DefaultCredentialManager.SVC_NAME) {
+      if (keepCurrentSvc && service === DefaultCredentialManager.SVC_NAME) {
         continue;
       }
       if (await this.keytar.deletePassword(service, account)) {


### PR DESCRIPTION
As decided in a team meeting we will no longer attempt to read secure properties for the @brightside/core service which was used in the LTS-incremental branch.

Also, directly place services into allServices in the desired order. It seems simpler to follow the logic.
