### PR TITLE
[json-config-next] Fixes for Config secure load

### DIFF
--- a/packages/config/__tests__/Config.test.ts
+++ b/packages/config/__tests__/Config.test.ts
@@ -120,10 +120,11 @@ describe("Config tests", () => {
 
         it("should not fail if secure load fails", async () => {
             jest.spyOn(fs, "existsSync").mockReturnValue(false);
-            jest.spyOn(Config.prototype as any, "secureLoad").mockImplementationOnce(() => {
+            const badLoadSpy = jest.spyOn(Config.prototype as any, "secureLoad").mockImplementationOnce(() => {
                 throw new Error("secure load failed");
             });
             const config = await Config.load(MY_APP);
+            expect(badLoadSpy).toHaveBeenCalled();
             expect(config.properties).toMatchSnapshot();
             expect(config.properties.defaults).toEqual({});
             expect(config.properties.profiles).toEqual({});

--- a/packages/config/__tests__/Config.test.ts
+++ b/packages/config/__tests__/Config.test.ts
@@ -117,6 +117,19 @@ describe("Config tests", () => {
             expect(error.message).toContain(__dirname + "/__resources__");
             expect(error instanceof ImperativeError).toBe(true);
         });
+
+        it("should not fail if secure load fails", async () => {
+            jest.spyOn(fs, "existsSync").mockReturnValue(false);
+            jest.spyOn(Config.prototype as any, "secureLoad").mockImplementationOnce(() => {
+                throw new Error("secure load failed");
+            });
+            const config = await Config.load(MY_APP);
+            expect(config.properties).toMatchSnapshot();
+            expect(config.properties.defaults).toEqual({});
+            expect(config.properties.profiles).toEqual({});
+            expect(config.properties.plugins).toEqual([]);
+            expect(config.properties.secure).toEqual([]);
+        })
     });
 
     it("should find config that exists if any layers exist", () => {

--- a/packages/config/__tests__/__snapshots__/Config.test.ts.snap
+++ b/packages/config/__tests__/__snapshots__/Config.test.ts.snap
@@ -210,6 +210,15 @@ Object {
 }
 `;
 
+exports[`Config tests load should not fail if secure load fails 1`] = `
+Object {
+  "defaults": Object {},
+  "plugins": Array [],
+  "profiles": Object {},
+  "secure": Array [],
+}
+`;
+
 exports[`Config tests set should add a new layer when one is specified in the set 1`] = `
 Object {
   "fruit": Object {

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -22,6 +22,7 @@ import { IConfigProfile } from "./doc/IConfigProfile";
 import { IConfigOpts } from "./doc/IConfigOpts";
 import { IConfigSecure, IConfigSecureProperties } from "./doc/IConfigSecure";
 import { IConfigVault } from "./doc/IConfigVault";
+import { Logger } from "../../logger";
 
 enum layers {
     project_user = 0,
@@ -140,7 +141,12 @@ export class Config {
 
         ////////////////////////////////////////////////////////////////////////
         // load secure fields
-        await _.secureLoad();
+        try {
+            await _.secureLoad();
+        } catch (err) {
+            // Secure vault is optional since we can prompt for values instead
+            Logger.getImperativeLogger().warn(`Secure vault not enabled. Reason: ${err.message}`);
+        }
 
         ////////////////////////////////////////////////////////////////////////
         // Complete

--- a/packages/security/src/DefaultCredentialManager.ts
+++ b/packages/security/src/DefaultCredentialManager.ts
@@ -136,9 +136,9 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
         // Imperative overrides the value of process.mainModule.filename to point to
         // our calling CLI. Since our caller must supply keytar, we search for keytar
         // within our caller's path.
-        const requireOpts = {};
+        const requireOpts: any = {};
         if (process.mainModule?.filename != null) {
-          process.mainModule.paths = [ process.mainModule.filename ];
+          requireOpts.paths = [ process.mainModule.filename ];
         }
         const keytarPath = require.resolve("keytar", requireOpts);
         // tslint:disable-next-line:no-implicit-dependencies


### PR DESCRIPTION
This is hopefully an easier PR to review than #478 🙂 - will try to keep them smaller

* Don't throw error in `Config.load` when secure vault fails to initialize. We can prompt for values instead.
* Fix Keytar not being found in CLI node_modules folder. Added a test for this as it was a regression since #464.