### PR TITLE
[json-config-next] Fixes after restoring app settings and overrides

### DIFF
--- a/__tests__/src/packages/profiles/__snapshots__/CliProfileManager.credentials.spec.ts.snap
+++ b/__tests__/src/packages/profiles/__snapshots__/CliProfileManager.credentials.spec.ts.snap
@@ -19,7 +19,7 @@ Unable to load the secure field \\"username\\" associated with the profile \\"pr
 Error Details:
 Unable to load credentials.
 Could not find an entry in the credential vault for the following:
-  Service = Zowe, @zowe/cli, Zowe-Plugin, Broadcom-Plugin
+  Service = example_with_profiles
   Account = username-password_profile-name-changed_username
 
 Possible Causes:

--- a/packages/config/__tests__/Config.secure.test.ts
+++ b/packages/config/__tests__/Config.secure.test.ts
@@ -34,8 +34,7 @@ describe("Config secure tests", () => {
     let mockSecureSave = jest.fn();
     let mockVault: IConfigVault = {
         load: mockSecureLoad,
-        save: mockSecureSave,
-        name: "fake"
+        save: mockSecureSave
     }
 
     afterEach(() => {
@@ -47,10 +46,16 @@ describe("Config secure tests", () => {
         mockSecureSave = jest.fn();
         mockVault = {
             load: mockSecureLoad,
-            save: mockSecureSave,
-            name: "fake"
+            save: mockSecureSave
         }
-    })
+    });
+
+    it("should set vault if provided for secure load", async () => {
+        const config = new (Config as any)();
+        expect((config as any)._vault).toBeUndefined();
+        await (config as any).secureLoad(mockVault);
+        expect((config as any)._vault).toBe(mockVault);
+    });
 
     it("should skip secure save if there are no secure properties or anything in keytar", async () => {
         const config = new (Config as any)();

--- a/packages/config/__tests__/Config.test.ts
+++ b/packages/config/__tests__/Config.test.ts
@@ -139,20 +139,6 @@ describe("Config tests", () => {
             expect(error.message).toContain(__dirname + "/__resources__");
             expect(error instanceof ImperativeError).toBe(true);
         });
-
-        it("should not fail if secure load fails", async () => {
-            jest.spyOn(fs, "existsSync").mockReturnValue(false);
-            const badLoadSpy = jest.spyOn(Config.prototype as any, "secureLoad").mockImplementationOnce(() => {
-                throw new Error("secure load failed");
-            });
-            const config = await Config.load(MY_APP);
-            expect(badLoadSpy).toHaveBeenCalled();
-            expect(config.properties).toMatchSnapshot();
-            expect(config.properties.defaults).toEqual({});
-            expect(config.properties.profiles).toEqual({});
-            expect(config.properties.plugins).toEqual([]);
-            expect(config.properties.secure).toEqual([]);
-        })
     });
 
     it("should find config that exists if any layers exist", () => {

--- a/packages/config/__tests__/__snapshots__/Config.test.ts.snap
+++ b/packages/config/__tests__/__snapshots__/Config.test.ts.snap
@@ -210,15 +210,6 @@ Object {
 }
 `;
 
-exports[`Config tests load should not fail if secure load fails 1`] = `
-Object {
-  "defaults": Object {},
-  "plugins": Array [],
-  "profiles": Object {},
-  "secure": Array [],
-}
-`;
-
 exports[`Config tests set should add a new layer when one is specified in the set 1`] = `
 Object {
   "fruit": Object {

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -157,12 +157,7 @@ export class Config {
 
         ////////////////////////////////////////////////////////////////////////
         // load secure fields
-        try {
-            await _.secureLoad();
-        } catch (err) {
-            // Secure vault is optional since we can prompt for values instead
-            Logger.getImperativeLogger().warn(`Secure vault not enabled. Reason: ${err.message}`);
-        }
+        await _.secureLoad();
 
         ////////////////////////////////////////////////////////////////////////
         // Complete
@@ -503,7 +498,8 @@ export class Config {
     ////////////////////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
 
-    private async secureLoad() {
+    public async secureLoad(vault?: IConfigVault) {
+        if (vault != null) this._vault = vault;
         if (this._vault == null) return;
 
         // load the secure fields

--- a/packages/config/src/doc/IConfigVault.ts
+++ b/packages/config/src/doc/IConfigVault.ts
@@ -12,6 +12,4 @@
 export interface IConfigVault {
     load: (key: string) => Promise<any>;
     save: (key: string, value: any) => Promise<void>;
-    // TODO Should we remove name since we removed the "managed by " placeholder?
-    name: string;
 };

--- a/packages/imperative/__tests__/Imperative.test.ts
+++ b/packages/imperative/__tests__/Imperative.test.ts
@@ -41,6 +41,8 @@ describe("Imperative", () => {
             jest.doMock("../src/env/EnvironmentalVariableSettings");
             jest.doMock("../src/auth/builders/CompleteAuthGroupBuilder");
             jest.doMock("../src/profiles/builders/CompleteProfilesGroupBuilder");
+            jest.doMock("../../config/src/Config");
+            jest.doMock("../../security/src/CredentialManagerFactory");
 
             const {OverridesLoader} = require("../src/OverridesLoader");
             const {LoggingConfigurer} = require("../src/LoggingConfigurer");
@@ -54,6 +56,8 @@ describe("Imperative", () => {
             const {EnvironmentalVariableSettings} = require("../src/env/EnvironmentalVariableSettings");
             const {CompleteAuthGroupBuilder} = require("../src/auth/builders/CompleteAuthGroupBuilder");
             const {CompleteProfilesGroupBuilder} = require("../src/profiles/builders/CompleteProfilesGroupBuilder");
+            const {Config} = require("../../config/src/Config");
+            const {CredentialManagerFactory} = require("../../security/src/CredentialManagerFactory");
             return {
                 OverridesLoader: {
                     load: OverridesLoader.load as Mock<typeof OverridesLoader.load>
@@ -78,7 +82,11 @@ describe("Imperative", () => {
                 },
                 CompleteProfilesGroupBuilder: {
                     getProfileGroup: CompleteProfilesGroupBuilder.getProfileGroup as Mock<typeof CompleteProfilesGroupBuilder.getProfileGroup>
-                }
+                },
+                Config: {
+                    load: Config.load as Mock<typeof Config.load>
+                },
+                CredentialManagerFactory
             };
         } catch (error) {
             // If we error here, jest silently fails and says the test is empty. So let's make sure
@@ -159,6 +167,7 @@ describe("Imperative", () => {
 
             mocks.ConfigurationLoader.load.mockReturnValue(defaultConfig);
             mocks.OverridesLoader.load.mockReturnValue(new Promise((resolve) => resolve()));
+            mocks.Config.load.mockResolvedValue({});
         });
 
         it("should work when passed with nothing", async () => {
@@ -195,6 +204,42 @@ describe("Imperative", () => {
                 await Imperative.init();
 
                 expect(ConfigManagementFacility.instance.init).toHaveBeenCalledTimes(1);
+            });
+
+            describe("load", () => {
+                beforeEach(() => {
+                    Object.defineProperty(mocks.CredentialManagerFactory, "initialized", { get: () => true });
+                });
+
+                it("should load config JSON layers", async () => {
+                    mocks.Config.load.mockResolvedValue({
+                        secureLoad: jest.fn()
+                    });
+
+                    await Imperative.init();
+
+                    expect(mocks.Config.load).toHaveBeenCalledTimes(1);
+                    expect(mocks.ImperativeConfig.instance.config.secureLoad).toHaveBeenCalledTimes(1);
+                });
+
+                it("should not fail if secure load fails", async () => {
+                    mocks.Config.load.mockResolvedValue({
+                        secureLoad: jest.fn(() => {
+                            throw new Error("secure load failed");
+                        })
+                    });
+                    let caughtError;
+
+                    try {
+                        await Imperative.init();
+                    } catch (error) {
+                        caughtError = error;
+                    }
+
+                    expect(mocks.Config.load).toHaveBeenCalledTimes(1);
+                    expect(mocks.ImperativeConfig.instance.config.secureLoad).toHaveBeenCalledTimes(1);
+                    expect(caughtError).toBeUndefined();
+                });
             });
         });
 

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -14,6 +14,7 @@ import { CredentialManagerFactory } from "../../security";
 import { IImperativeConfig } from "./doc/IImperativeConfig";
 import { isAbsolute, resolve } from "path";
 import { AppSettings } from "../../settings";
+import { ImperativeConfig } from "../../utilities";
 
 /**
  * Imperative-internal class to load overrides
@@ -47,7 +48,7 @@ export class OverridesLoader {
     config: IImperativeConfig,
     packageJson: any
   ): Promise<void> {
-    if (config.overrides.CredentialManager != null) {
+    if (!ImperativeConfig.instance.config.exists) {
       return this.loadCredentialManagerOld(config, packageJson);
     }
 

--- a/packages/imperative/src/plugins/utilities/PMFConstants.ts
+++ b/packages/imperative/src/plugins/utilities/PMFConstants.ts
@@ -107,16 +107,13 @@ export class PMFConstants {
     public readonly PLUGIN_HOME_LOCATION: string;
 
     constructor() {
-        /* todo:plugins - restore PLUGIN_CONFIG and PLUGIN_USING_CONFIG below
-           if we add plugin support in zowe.config.json in the future */
-        // this.PLUGIN_CONFIG = ImperativeConfig.instance.config;
+        this.PLUGIN_CONFIG = ImperativeConfig.instance.config;
         this.NPM_NAMESPACE = "@zowe";
         this.CLI_CORE_PKG_NAME = ImperativeConfig.instance.hostPackageName;
         this.IMPERATIVE_PKG_NAME = ImperativeConfig.instance.imperativePackageName;
         this.PMF_ROOT = join(ImperativeConfig.instance.cliHome, "plugins");
         this.PLUGIN_JSON = join(this.PMF_ROOT, "plugins.json");
-        // this.PLUGIN_USING_CONFIG = ImperativeConfig.instance.config.exists;
-        this.PLUGIN_USING_CONFIG = false;
+        this.PLUGIN_USING_CONFIG = ImperativeConfig.instance.config.exists;
         this.PLUGIN_INSTALL_LOCATION = join(this.PMF_ROOT, "installed");
 
         // Windows format is <prefix>/node_modules

--- a/packages/imperative/src/plugins/utilities/PluginIssues.ts
+++ b/packages/imperative/src/plugins/utilities/PluginIssues.ts
@@ -142,7 +142,10 @@ export class PluginIssues {
         if (PMFConstants.instance.PLUGIN_USING_CONFIG) {
           PMFConstants.instance.PLUGIN_CONFIG.api.plugins.get().forEach((plugin: string) => {
             if (this.installedPlugins[plugin] == null)
-              (this.installedPlugins as any)[plugin] = {};
+              (this.installedPlugins as any)[plugin] = {
+                package: plugin,
+                version: "local"
+              };
           });
         }
       }


### PR DESCRIPTION
If new config does not exist, always fall back to the old implementation of `OverridesLoader.loadCredentialManager`. This fixes an issue where after removing the SCS override, Imperative would fail to read old profiles with plain text credentials.