### PR TITLE
[json-config-next] Fix #487

### DIFF
--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_config_create.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_config_create.sh
@@ -4,7 +4,7 @@ baseUser=$1
 basePass=$2
 
 # First create a base profile
-imperative-test-cli config init --ci
+imperative-test-cli config init --prompt false
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global.sh
@@ -4,7 +4,7 @@ baseUser=$1
 basePass=$2
 
 # First create a base profile
-imperative-test-cli config init --ci --global
+imperative-test-cli config init --prompt false --global
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global_user.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global_user.sh
@@ -4,7 +4,7 @@ baseUser=$1
 basePass=$2
 
 # First create a base profile
-imperative-test-cli config init --ci --global --user
+imperative-test-cli config init --prompt false --global --user
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local.sh
@@ -4,7 +4,7 @@ baseUser=$1
 basePass=$2
 
 # First create a base profile
-imperative-test-cli config init --ci
+imperative-test-cli config init --prompt false
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local_user.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local_user.sh
@@ -4,7 +4,7 @@ baseUser=$1
 basePass=$2
 
 # First create a base profile
-imperative-test-cli config init --ci --user
+imperative-test-cli config init --prompt false --user
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_create_config.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_create_config.sh
@@ -5,7 +5,7 @@ baseUser=$2
 basePass=$3
 
 # First create a base profile
-imperative-test-cli config init --ci
+imperative-test-cli config init --prompt false
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_create_config_timeout.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_create_config_timeout.sh
@@ -4,7 +4,7 @@ baseUser=$1
 basePass=$2
 
 # First create a base profile
-imperative-test-cli config init --ci
+imperative-test-cli config init --prompt false
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_show_token_config.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_show_token_config.sh
@@ -4,7 +4,7 @@ baseUser=$1
 basePass=$2
 
 # First create a base profile
-imperative-test-cli config init --ci
+imperative-test-cli config init --prompt false
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/init/cli.imperative-test-cli.config.init.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/init/cli.imperative-test-cli.config.init.integration.test.ts
@@ -46,7 +46,7 @@ describe("imperative-test-cli config init", () => {
     });
     it("should initialize a project config", () => {
         const response = runCliScript(__dirname + "/__scripts__/init_config.sh",
-            TEST_ENVIRONMENT.workingDir, ["--ci"]);
+            TEST_ENVIRONMENT.workingDir, ["--prompt false"]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.schema.json");
         expect(response.output.toString()).toContain(`Saved config template to`);
@@ -59,7 +59,7 @@ describe("imperative-test-cli config init", () => {
     });
     it("should initialize a user project config", () => {
         const response = runCliScript(__dirname + "/__scripts__/init_config.sh",
-            TEST_ENVIRONMENT.workingDir, ["--user --ci"]);
+            TEST_ENVIRONMENT.workingDir, ["--user --prompt false"]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.user.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.schema.json");
         expect(response.output.toString()).toContain(`Saved config template to`);
@@ -71,7 +71,7 @@ describe("imperative-test-cli config init", () => {
     });
     it("should initialize a global config", () => {
         const response = runCliScript(__dirname + "/__scripts__/init_config.sh",
-            TEST_ENVIRONMENT.workingDir, ["--global --ci"]);
+            TEST_ENVIRONMENT.workingDir, ["--global --prompt false"]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.schema.json");
         expect(response.output.toString()).toContain(`Saved config template to`);
@@ -83,7 +83,7 @@ describe("imperative-test-cli config init", () => {
     });
     it("should initialize a user global config", () => {
         const response = runCliScript(__dirname + "/__scripts__/init_config.sh",
-            TEST_ENVIRONMENT.workingDir, ["--global --user --ci"]);
+            TEST_ENVIRONMENT.workingDir, ["--global --user --prompt false"]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.user.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.schema.json");
         expect(response.output.toString()).toContain(`Saved config template to`);
@@ -143,7 +143,7 @@ describe("imperative-test-cli config init", () => {
     });
     // it("should create a profile of a specified name", () => {
     //     const response = runCliScript(__dirname + "/__scripts__/init_config.sh",
-    //         TEST_ENVIRONMENT.workingDir, ["--profile lpar.service --ci"]);
+    //         TEST_ENVIRONMENT.workingDir, ["--profile lpar.service --prompt false"]);
     //     const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.json");
     //     const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.schema.json");
     //     const expectedConfigObject: IConfig = {

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/cli.imperative-test-cli.config.list.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/cli.imperative-test-cli.config.list.integration.test.ts
@@ -31,10 +31,10 @@ describe("imperative-test-cli config list", () => {
             cliHomeEnvVar: "IMPERATIVE_TEST_CLI_CLI_HOME",
             testName: "imperative_test_cli_test_config_list_command"
         });
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--ci"]);
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --ci"]);
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--global --ci"]);
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --global --ci"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--prompt false"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --prompt false"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--global --prompt false"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --global --prompt false"]);
         expectedGlobalUserConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.user.json");
         expectedGlobalProjectConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.json");
         expectedUserConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.user.json");

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/profiles/cli.imperative-test-cli.config.profiles.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/profiles/cli.imperative-test-cli.config.profiles.integration.test.ts
@@ -25,10 +25,10 @@ describe("imperative-test-cli config profiles", () => {
             cliHomeEnvVar: "IMPERATIVE_TEST_CLI_CLI_HOME",
             testName: "imperative_test_cli_test_config_profiles_command"
         });
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--ci"]);
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --ci"]);
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--global --ci"]);
-        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --global --ci"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--prompt false"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --prompt false"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--global --prompt false"]);
+        runCliScript(__dirname + "/../init/__scripts__/init_config.sh", TEST_ENVIRONMENT.workingDir, ["--user --global --prompt false"]);
     });
     it("should display the help", () => {
         const response = runCliScript(__dirname + "/../__scripts__/get_help.sh",

--- a/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
@@ -261,12 +261,12 @@ describe("Configuration Initialization command handler", () => {
         expect(writeFileSyncSpy).toHaveBeenNthCalledWith(2, fakeGblProjUserPath, JSON.stringify(compObj, null, 4)); // Config
     });
 
-    it("should attempt to initialize the project configuration with CI flag", async () => {
+    it("should attempt to initialize the project configuration with prompt flag false", async () => {
         const handler = new InitHandler();
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = false;
-        params.arguments.ci = true;
+        params.arguments.prompt = false;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -349,12 +349,12 @@ describe("Configuration Initialization command handler", () => {
         expect(writeFileSyncSpy).toHaveBeenNthCalledWith(2, fakeProjUserPath, JSON.stringify(compObj, null, 4)); // Config
     });
 
-    it("should attempt to initialize the global project configuration with CI flag", async () => {
+    it("should attempt to initialize the global project configuration with prompt flag false", async () => {
         const handler = new InitHandler();
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = true;
-        params.arguments.ci = true;
+        params.arguments.prompt = false;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return

--- a/packages/imperative/src/config/cmd/init/init.definition.ts
+++ b/packages/imperative/src/config/cmd/init/init.definition.ts
@@ -27,6 +27,7 @@ export const initDefinition: ICommandDefinition = {
         {
             name: "global",
             description: "Target the global config files.",
+            aliases: ["g"],
             type: "boolean",
             defaultValue: false
         },
@@ -76,10 +77,10 @@ export const initDefinition: ICommandDefinition = {
         //     defaultValue: false
         // },
         {
-            name: "ci",
-            description: "don't prompt for secure values.",
+            name: "prompt",
+            description: "Prompt for secure values. Useful for disabling prompting in CI environments.",
             type: "boolean",
-            defaultValue: false
+            defaultValue: true
         }
     ]
 };

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -164,14 +164,14 @@ export default class InitHandler implements ICommandHandler {
     }
 
     /**
-     * Prompts for the value of a property on the CLI. Returns null if `--ci`
+     * Prompts for the value of a property on the CLI. Returns null if `--prompt false`
      * argument is passed, or prompt times out, or a blank value is entered.
      * @param propName The name of the property
      * @param property The profile property definition
      */
     private async promptForProp(propName: string, property: IProfileProperty): Promise<any> {
         // skip prompting in CI environment
-        if (this.arguments.ci) {
+        if (this.arguments.prompt === false) {
             return null;
         }
 

--- a/packages/imperative/src/config/cmd/secure/secure.definition.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.definition.ts
@@ -22,6 +22,7 @@ export const secureDefinition: ICommandDefinition = {
         {
             name: "global",
             description: "Secure properties in global config.",
+            aliases: ["g"],
             type: "boolean",
             defaultValue: false
         },

--- a/packages/imperative/src/config/cmd/set/set.definition.ts
+++ b/packages/imperative/src/config/cmd/set/set.definition.ts
@@ -35,6 +35,7 @@ export const setDefinition: ICommandDefinition = {
         {
             name: "global",
             description: "Set the property in global config.",
+            aliases: ["g"],
             type: "boolean",
             defaultValue: false
         },


### PR DESCRIPTION
Actually fixes #487 this time, adding the -g alias to global and changing --ci to --prompt.