### PR TITLE
Fixes for tokens and secure credential storage

### DIFF
--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global.sh
@@ -27,7 +27,7 @@ then
 fi
 
 # Next login to fruit auth
-imperative-test-cli auth login fruit
+echo y | imperative-test-cli auth login fruit
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global_user.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_global_user.sh
@@ -34,7 +34,7 @@ then
 fi
 
 # Next login to fruit auth
-imperative-test-cli auth login fruit
+echo y | imperative-test-cli auth login fruit
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local.sh
@@ -27,7 +27,7 @@ then
 fi
 
 # Next login to fruit auth
-imperative-test-cli auth login fruit
+echo y | imperative-test-cli auth login fruit
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local_user.sh
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/__scripts__/base_profile_and_auth_login_config_local_user.sh
@@ -34,7 +34,7 @@ then
 fi
 
 # Next login to fruit auth
-imperative-test-cli auth login fruit
+echo y | imperative-test-cli auth login fruit
 CMDRC=$?
 if [ $CMDRC -gt 0 ]
 then

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/init/cli.imperative-test-cli.config.init.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/init/cli.imperative-test-cli.config.init.integration.test.ts
@@ -36,11 +36,15 @@ describe("imperative-test-cli config init", () => {
     it("should display the help", () => {
         const response = runCliScript(__dirname + "/../__scripts__/get_help.sh",
             TEST_ENVIRONMENT.workingDir, ["init"]);
-        expect(response.output.toString()).toContain(`Initialize config files. Defaults to initializing`);
-        expect(response.output.toString()).toContain(`"imperative-test-cli.config.json" in the current working directory unless`);
-        expect(response.output.toString()).toContain(`otherwise specified. Use "--user" to init`);
-        expect(response.output.toString()).toContain(`"imperative-test-cli.config.user.json". Use "--global" to initialize the`);
-        expect(response.output.toString()).toContain(`configuration files your home "~/.zowe" directory.`);
+        const expectedLines = [
+            `Initialize config files. Defaults to initializing`,
+            `"imperative-test-cli.config.json" in the current working directory unless`,
+            `otherwise specified.`,
+            `Use "--user" to init "imperative-test-cli.config.user.json". Use "--global" to`,
+            `initialize the configuration files in your home "~/.zowe" directory.`,
+            `Use "--no-prompt" to skip prompting for values in a CI environment.`
+        ];
+        expectedLines.forEach((line: string) => expect(response.output.toString()).toContain(line));
         expect(response.stderr.toString()).toEqual("");
         expect(response.error).not.toBeDefined();
     });

--- a/packages/config/src/ConfigUtils.ts
+++ b/packages/config/src/ConfigUtils.ts
@@ -1,0 +1,19 @@
+import { ImperativeConfig } from "../../utilities";
+import { ImperativeError } from "../../error";
+
+export function secureSaveError(solution?: string): ImperativeError {
+    let details = `Problem: The Secure Credential feature is not installed. You may need to contact your security administrator to enable this ` +
+        `feature.\n\n`;
+    const displayName = ImperativeConfig.instance.loadedConfig.productDisplayName || ImperativeConfig.instance.loadedConfig.name;
+    if (solution == null) {
+        details += `Solution: Install the prerequisites listed in ${ImperativeConfig.instance.loadedConfig.name} documentation for the Secure ` +
+            `Credential feature, and then reinstall ${displayName}.`;
+    } else {
+        details += `Solutions:\n(1) Install the prerequisites listed in ${ImperativeConfig.instance.loadedConfig.name} documentation for the ` +
+            `Secure Credential feature, and then reinstall ${displayName}.\n(2)${solution}`;
+    }
+    return new ImperativeError({
+        msg: "Unable to save credentials.",
+        additionalDetails: details
+    });
+}

--- a/packages/config/src/ConfigUtils.ts
+++ b/packages/config/src/ConfigUtils.ts
@@ -2,18 +2,15 @@ import { ImperativeConfig } from "../../utilities";
 import { ImperativeError } from "../../error";
 
 export function secureSaveError(solution?: string): ImperativeError {
-    let details = `Problem: The Secure Credential feature is not installed. You may need to contact your security administrator to enable this ` +
-        `feature.\n\n`;
     const displayName = ImperativeConfig.instance.loadedConfig.productDisplayName || ImperativeConfig.instance.loadedConfig.name;
-    if (solution == null) {
-        details += `Solution: Install the prerequisites listed in ${ImperativeConfig.instance.loadedConfig.name} documentation for the Secure ` +
-            `Credential feature, and then reinstall ${displayName}.`;
-    } else {
-        details += `Solutions:\n(1) Install the prerequisites listed in ${ImperativeConfig.instance.loadedConfig.name} documentation for the ` +
-            `Secure Credential feature, and then reinstall ${displayName}.\n(2)${solution}`;
+    let details = `Possible Solutions:\n` +
+        ` 1. Reinstall ${displayName}. On Linux systems, also make sure to install the prerequisites listed in ${displayName} documentation.\n` +
+        ` 2. Ensure ${displayName} can access secure credential storage. ${displayName} needs access to the OS to securely store credentials.`;
+    if (solution != null) {
+        details += ` 3. ${solution}`;
     }
     return new ImperativeError({
-        msg: "Unable to save credentials.",
+        msg: "Unable to securely save credentials.",
         additionalDetails: details
     });
 }

--- a/packages/config/src/ConfigUtils.ts
+++ b/packages/config/src/ConfigUtils.ts
@@ -5,9 +5,9 @@ export function secureSaveError(solution?: string): ImperativeError {
     const displayName = ImperativeConfig.instance.loadedConfig.productDisplayName || ImperativeConfig.instance.loadedConfig.name;
     let details = `Possible Solutions:\n` +
         ` 1. Reinstall ${displayName}. On Linux systems, also make sure to install the prerequisites listed in ${displayName} documentation.\n` +
-        ` 2. Ensure ${displayName} can access secure credential storage. ${displayName} needs access to the OS to securely store credentials.`;
+        ` 2. Ensure ${displayName} can access secure credential storage. ${displayName} needs access to the OS to securely save credentials.`;
     if (solution != null) {
-        details += ` 3. ${solution}`;
+        details += `\n 3. ${solution}`;
     }
     return new ImperativeError({
         msg: "Unable to securely save credentials.",

--- a/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { CommandResponse, IHandlerParameters } from "../../../../..";
+import { IHandlerParameters } from "../../../../..";
 import { Config } from "../../../../../config/src/Config";
 import { CliUtils, ImperativeConfig } from "../../../../../utilities";
 import { IImperativeConfig } from "../../../../src/doc/IImperativeConfig";
@@ -25,7 +25,25 @@ import { CredentialManagerFactory } from "../../../../../security";
 
 const getIHandlerParametersObject = (): IHandlerParameters => {
     const x: any = {
-        response: new (CommandResponse as any)(),
+        response: {
+            data: {
+                setMessage: jest.fn((setMsgArgs) => {
+                    // Nothing
+                }),
+                setObj: jest.fn((setObjArgs) => {
+                    // Nothing
+                })
+            },
+            console: {
+                log: jest.fn((logs) => {
+                    // Nothing
+                }),
+                error: jest.fn((errors) => {
+                    // Nothing
+                }),
+                errorHeader: jest.fn(() => undefined)
+            }
+        },
         arguments: {},
         };
     return x as IHandlerParameters;
@@ -82,7 +100,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = false;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -131,7 +149,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = true;
         params.arguments.global = false;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -175,7 +193,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = true;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -224,7 +242,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = true;
         params.arguments.global = true;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -307,12 +325,12 @@ describe("Configuration Initialization command handler", () => {
         expect(writeFileSyncSpy).toHaveBeenNthCalledWith(2, fakeProjPath, JSON.stringify(compObj, null, 4)); // Config
     });
 
-    it("should attempt to initialize the project user configuration with CI flag", async () => {
+    it("should attempt to initialize the project user configuration with prompting disabled", async () => {
         const handler = new InitHandler();
         const params = getIHandlerParametersObject();
         params.arguments.user = true;
         params.arguments.global = false;
-        params.arguments.ci = true;
+        params.arguments.prompt = false;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -395,12 +413,12 @@ describe("Configuration Initialization command handler", () => {
         expect(writeFileSyncSpy).toHaveBeenNthCalledWith(2, fakeGblProjPath, JSON.stringify(compObj, null, 4)); // Config
     });
 
-    it("should attempt to initialize the global project user configuration with CI flag", async () => {
+    it("should attempt to initialize the global project user configuration with prompting disabled", async () => {
         const handler = new InitHandler();
         const params = getIHandlerParametersObject();
         params.arguments.user = true;
         params.arguments.global = true;
-        params.arguments.ci = true;
+        params.arguments.prompt = false;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -444,7 +462,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = false;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -493,7 +511,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = false;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -542,7 +560,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = false;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -592,7 +610,7 @@ describe("Configuration Initialization command handler", () => {
         const params = getIHandlerParametersObject();
         params.arguments.user = false;
         params.arguments.global = false;
-        params.arguments.ci = false;
+        params.arguments.prompt = true;
 
         existsSyncSpy.mockReturnValue(false); // No files exist
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
@@ -635,5 +653,44 @@ describe("Configuration Initialization command handler", () => {
         // Secure value supplied during prompting should be on properties
         // tslint:disable-next-line: no-magic-numbers
         expect(ImperativeConfig.instance.config.properties.profiles.my_profiles.profiles.secured.properties.secret).toEqual(undefined);
+    });
+
+    it("should display warning if unable to securely save credentials", async () => {
+        const handler = new InitHandler();
+        const params = getIHandlerParametersObject();
+        params.arguments.user = false;
+        params.arguments.global = false;
+        params.arguments.prompt = true;
+
+        existsSyncSpy.mockReturnValue(false); // No files exist
+        searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
+        await setupConfigToLoad(); // Setup the config
+
+        setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
+
+        // We aren't testing the config initialization - clear the spies
+        existsSyncSpy.mockClear();
+        searchSpy.mockClear();
+        osHomedirSpy.mockClear();
+        currentWorkingDirectorySpy.mockClear();
+
+        // initWithSchema
+        promptWithTimeoutSpy.mockReturnValue(undefined); // Add fake values for all prompts
+        writeFileSyncSpy.mockImplementation(); // Don't actually write files
+        jest.spyOn(CredentialManagerFactory, "initialized", "get").mockReturnValue(false);
+
+        await handler.process(params as IHandlerParameters);
+
+        const compObj: any = {};
+        // Make changes to satisfy what would be stored on the JSON
+        compObj.$schema = "./fakeapp.schema.json" // Fill in the name of the schema file, and make it first
+        lodash.merge(compObj, ImperativeConfig.instance.config.properties); // Add the properties from the config
+        delete compObj.profiles.my_profiles.profiles.secured.properties.secret; // Delete the secret
+        compObj.secure = ["profiles.my_profiles.profiles.secured.properties.secret"]; // Add the secret field to the secrets
+
+        expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(0);
+        expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
+        expect(params.response.console.log).toHaveBeenCalledTimes(2);
+        expect((params.response.console.log as any).mock.calls[0][0]).toContain("Unable to securely save credentials");
     });
 });

--- a/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
@@ -21,6 +21,7 @@ import * as path from "path";
 import * as lodash from "lodash";
 import * as fs from "fs";
 import * as os from "os";
+import { CredentialManagerFactory } from "../../../../../security";
 
 const getIHandlerParametersObject = (): IHandlerParameters => {
     const x: any = {
@@ -62,6 +63,7 @@ describe("Configuration Initialization command handler", () => {
     beforeEach( async () => {
         jest.resetAllMocks();
         ImperativeConfig.instance.loadedConfig = lodash.cloneDeep(fakeConfig);
+        Object.defineProperty(CredentialManagerFactory, "initialized", { get: () => true });
 
         writeFileSyncSpy = jest.spyOn(fs, "writeFileSync");
         existsSyncSpy = jest.spyOn(fs, "existsSync");

--- a/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
@@ -9,14 +9,14 @@
 *
 */
 
-import { CommandResponse, IHandlerParameters } from "../../../../..";
+import { IHandlerParameters } from "../../../../..";
 import { Config } from "../../../../../config/src/Config";
 import { IConfigOpts } from "../../../../../config";
 import { CliUtils, ImperativeConfig } from "../../../../../utilities";
 import { IImperativeConfig } from "../../../../src/doc/IImperativeConfig";
 import { ICredentialManagerInit } from "../../../../../security/src/doc/ICredentialManagerInit";
 import { CredentialManagerFactory } from "../../../../../security";
-import { expectedConfigObject, expectedSchemaObject } from
+import { expectedConfigObject } from
     "../../../../../../__tests__/__integration__/imperative/__tests__/__integration__/cli/config/__resources__/expectedObjects"
 import SecureHandler from "../../../../src/config/cmd/secure/secure.handler";
 import * as config from "../../../../../../__tests__/__integration__/imperative/src/imperative";
@@ -28,7 +28,25 @@ import * as os from "os";
 
 const getIHandlerParametersObject = (): IHandlerParameters => {
     const x: any = {
-        response: new (CommandResponse as any)(),
+        response: {
+            data: {
+                setMessage: jest.fn((setMsgArgs) => {
+                    // Nothing
+                }),
+                setObj: jest.fn((setObjArgs) => {
+                    // Nothing
+                })
+            },
+            console: {
+                log: jest.fn((logs) => {
+                    // Nothing
+                }),
+                error: jest.fn((errors) => {
+                    // Nothing
+                }),
+                errorHeader: jest.fn(() => undefined)
+            }
+        },
         arguments: {},
         };
     return x as IHandlerParameters;

--- a/packages/imperative/__tests__/config/cmd/set/set.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/set/set.handler.test.ts
@@ -9,14 +9,14 @@
 *
 */
 
-import { CommandResponse, IHandlerParameters } from "../../../../..";
+import { IHandlerParameters } from "../../../../..";
 import { Config } from "../../../../../config/src/Config";
 import { IConfigOpts } from "../../../../../config";
 import { CliUtils, ImperativeConfig } from "../../../../../utilities";
 import { IImperativeConfig } from "../../../../src/doc/IImperativeConfig";
 import { ICredentialManagerInit } from "../../../../../security/src/doc/ICredentialManagerInit";
 import { CredentialManagerFactory } from "../../../../../security";
-import { expectedConfigObject, expectedUserConfigObject, expectedSchemaObject } from
+import { expectedConfigObject, expectedUserConfigObject } from
     "../../../../../../__tests__/__integration__/imperative/__tests__/__integration__/cli/config/__resources__/expectedObjects"
 import SetHandler from "../../../../src/config/cmd/set/set.handler";
 import * as config from "../../../../../../__tests__/__integration__/imperative/src/imperative";
@@ -28,7 +28,25 @@ import * as os from "os";
 
 const getIHandlerParametersObject = (): IHandlerParameters => {
     const x: any = {
-        response: new (CommandResponse as any)(),
+        response: {
+            data: {
+                setMessage: jest.fn((setMsgArgs) => {
+                    // Nothing
+                }),
+                setObj: jest.fn((setObjArgs) => {
+                    // Nothing
+                })
+            },
+            console: {
+                log: jest.fn((logs) => {
+                    // Nothing
+                }),
+                error: jest.fn((errors) => {
+                    // Nothing
+                }),
+                errorHeader: jest.fn(() => undefined)
+            }
+        },
         arguments: {},
         };
     return x as IHandlerParameters;

--- a/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
+++ b/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
@@ -18,6 +18,7 @@ import { CliUtils, ImperativeConfig } from "../../../../utilities";
 import { Config } from "../../../../config";
 import { IConfigSecureFiles } from "../../../../config/src/doc/IConfigSecure";
 import { FakeAuthHandler } from "./__data__/FakeAuthHandler";
+import { CredentialManagerFactory } from "../../../../security";
 
 const MY_APP = "my_app";
 
@@ -33,6 +34,7 @@ describe("BaseAuthHandler config", () => {
     let fakeConfig: Config;
 
     beforeAll(() => {
+        Object.defineProperty(CredentialManagerFactory, "initialized", { get: () => true });
         Object.defineProperty(ImperativeConfig, "instance", {
             get: () => ({ config: fakeConfig })
         });

--- a/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
+++ b/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
@@ -160,6 +160,7 @@ describe("BaseAuthHandler config", () => {
                 expect(fakeConfig.properties.profiles.my_fruit_creds).toBeUndefined();
 
                 const doLoginSpy = jest.spyOn(handler as any, "doLogin");
+                const promptSpy = jest.spyOn(CliUtils, "promptWithTimeout").mockResolvedValueOnce("y");
                 const writeFileSpy = jest.spyOn(fs, "writeFileSync").mockReturnValueOnce(undefined);
                 let caughtError;
 
@@ -171,6 +172,7 @@ describe("BaseAuthHandler config", () => {
 
                 expect(caughtError).toBeUndefined();
                 expect(doLoginSpy).toBeCalledTimes(1);
+                expect(promptSpy).toBeCalledTimes(1);
                 expect(writeFileSpy).toBeCalledTimes(1);
                 expect(fakeVault.save).toBeCalledTimes(1);
 

--- a/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
+++ b/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
@@ -142,7 +142,7 @@ describe("BaseAuthHandler config", () => {
                 }
 
                 expect(caughtError).toBeDefined();
-                expect(caughtError.message).toBe("Unable to securely save credentials");
+                expect(caughtError.message).toBe("Unable to securely save credentials.");
                 expect(caughtError).toBeInstanceOf(ImperativeError);
                 expect(caughtError.additionalDetails).toContain("FAKE_OPT_TOKEN_VALUE");
                 expect(doLoginSpy).toBeCalledTimes(1);

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -123,8 +123,9 @@ export abstract class BaseAuthHandler implements ICommandHandler {
             // process login for old school profiles
             await this.processLoginOld(params, tokenValue);
         } else if (!CredentialManagerFactory.initialized) {
-            throw secureSaveError(`Rerun this command with the "--show-token" flag to print the token to console. Store the token in an ` +
-                `environment variable ${ImperativeConfig.instance.loadedConfig.envVariablePrefix}_OPT_AUTH_TOKEN to use it in future commands.`);
+            throw secureSaveError(`Instead of secure storage, rerun this command with the "--show-token" flag to print the token to console. ` +
+                `Store the token in an environment variable ${ImperativeConfig.instance.loadedConfig.envVariablePrefix}_OPT_AUTH_TOKEN to use it ` +
+                `in future commands.`);
         } else {
             // update the profile given
             // TODO Should config be added to IHandlerParameters?

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -124,7 +124,7 @@ export abstract class BaseAuthHandler implements ICommandHandler {
             await this.processLoginOld(params, tokenValue);
         } else if (!CredentialManagerFactory.initialized) {
             throw secureSaveError(`Instead of secure storage, rerun this command with the "--show-token" flag to print the token to console. ` +
-                `Store the token in an environment variable ${ImperativeConfig.instance.loadedConfig.envVariablePrefix}_OPT_AUTH_TOKEN to use it ` +
+                `Store the token in an environment variable ${ImperativeConfig.instance.loadedConfig.envVariablePrefix}_OPT_TOKEN_VALUE to use it ` +
                 `in future commands.`);
         } else {
             // update the profile given

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -18,6 +18,8 @@ import { ImperativeError } from "../../../../error";
 import { ISaveProfileFromCliArgs } from "../../../../profiles";
 import { CliUtils, ImperativeConfig } from "../../../../utilities";
 import { Config } from "../../../../config";
+import { CredentialManagerFactory } from "../../../../security";
+import { secureSaveError } from "../../../../config/src/ConfigUtils";
 
 /**
  * This class is used by the auth command handlers as the base class for their implementation.
@@ -120,6 +122,9 @@ export abstract class BaseAuthHandler implements ICommandHandler {
         } else if (!ImperativeConfig.instance.config.exists) {
             // process login for old school profiles
             await this.processLoginOld(params, tokenValue);
+        } else if (!CredentialManagerFactory.initialized) {
+            throw secureSaveError(`Rerun this command with the "--show-token" flag to print the token to console. Store the token in an ` +
+                `environment variable ${ImperativeConfig.instance.loadedConfig.envVariablePrefix}_OPT_AUTH_TOKEN to use it in future commands.`);
         } else {
             // update the profile given
             // TODO Should config be added to IHandlerParameters?

--- a/packages/imperative/src/config/cmd/init/init.definition.ts
+++ b/packages/imperative/src/config/cmd/init/init.definition.ts
@@ -24,8 +24,8 @@ export const initDefinition: ICommandDefinition = {
     summary: "init config files",
     description: `Initialize config files. Defaults to initializing "${ImperativeConfig.instance.rootCommandName}.config.json" in the current ` +
         `working directory unless otherwise specified.\n\nUse "--user" to init "${ImperativeConfig.instance.rootCommandName}.config.user.json". ` +
-        `Use "--global" to initialize the configuration files in your home "~/.zowe" directory.\n\nUse "--prompt false" to skip prompting for ` +
-        `values in a CI environment.`,
+        `Use "--global" to initialize the configuration files in your home "~/.zowe" directory.\n\nUse "--no-prompt" to skip prompting for values` +
+        `in a CI environment.`,
     options: [
         {
             name: "global",

--- a/packages/imperative/src/config/cmd/init/init.definition.ts
+++ b/packages/imperative/src/config/cmd/init/init.definition.ts
@@ -22,7 +22,10 @@ export const initDefinition: ICommandDefinition = {
     type: "command",
     handler: join(__dirname, "init.handler"),
     summary: "init config files",
-    description: `Initialize config files. Defaults to initializing "${ImperativeConfig.instance.rootCommandName}.config.json" in the current working directory unless otherwise specified. Use "--user" to init "${ImperativeConfig.instance.rootCommandName}.config.user.json". Use "--global" to initialize the configuration files your home "~/.zowe" directory.`,
+    description: `Initialize config files. Defaults to initializing "${ImperativeConfig.instance.rootCommandName}.config.json" in the current ` +
+        `working directory unless otherwise specified.\n\nUse "--user" to init "${ImperativeConfig.instance.rootCommandName}.config.user.json". ` +
+        `Use "--global" to initialize the configuration files in your home "~/.zowe" directory.\n\nUse "--prompt false" to skip prompting for ` +
+        `values in a CI environment.`,
     options: [
         {
             name: "global",

--- a/packages/imperative/src/config/cmd/init/init.definition.ts
+++ b/packages/imperative/src/config/cmd/init/init.definition.ts
@@ -24,7 +24,7 @@ export const initDefinition: ICommandDefinition = {
     summary: "init config files",
     description: `Initialize config files. Defaults to initializing "${ImperativeConfig.instance.rootCommandName}.config.json" in the current ` +
         `working directory unless otherwise specified.\n\nUse "--user" to init "${ImperativeConfig.instance.rootCommandName}.config.user.json". ` +
-        `Use "--global" to initialize the configuration files in your home "~/.zowe" directory.\n\nUse "--no-prompt" to skip prompting for values` +
+        `Use "--global" to initialize the configuration files in your home "~/.zowe" directory.\n\nUse "--no-prompt" to skip prompting for values ` +
         `in a CI environment.`,
     options: [
         {

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -17,6 +17,7 @@ import { Config, ConfigSchema, IConfig, IConfigProfile } from "../../../../../co
 import { IProfileProperty } from "../../../../../profiles";
 import { ConfigBuilder } from "../../../../../config/src/ConfigBuilder";
 import { IConfigBuilderOpts } from "../../../../../config/src/doc/IConfigBuilderOpts";
+import { CredentialManagerFactory } from "../../../../../security";
 
 /**
  * Init config
@@ -59,6 +60,11 @@ export default class InitHandler implements ICommandHandler {
         // }
 
         await this.initWithSchema(config, params.arguments.user);
+
+        if (!CredentialManagerFactory.initialized && config.api.layers.get().properties.secure.length > 0) {
+            // TODO Consult with UX about the wording and status (warning vs error) of this message
+            params.response.console.log("Warning: secure vault not enabled");
+        }
 
         // Write the active created/updated config layer
         await config.api.layers.write();
@@ -171,7 +177,7 @@ export default class InitHandler implements ICommandHandler {
      */
     private async promptForProp(propName: string, property: IProfileProperty): Promise<any> {
         // skip prompting in CI environment
-        if (this.arguments.ci) {
+        if (this.arguments.ci || !CredentialManagerFactory.initialized) {
             return null;
         }
 

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -11,13 +11,14 @@
 
 import { ICommandArguments, ICommandHandler, IHandlerParameters } from "../../../../../cmd";
 import { ImperativeError } from "../../../../../error";
-import { CliUtils, ImperativeConfig } from "../../../../../utilities";
+import { CliUtils, ImperativeConfig, TextUtils } from "../../../../../utilities";
 import * as https from "https";
 import { Config, ConfigSchema, IConfig, IConfigProfile } from "../../../../../config";
 import { IProfileProperty } from "../../../../../profiles";
 import { ConfigBuilder } from "../../../../../config/src/ConfigBuilder";
 import { IConfigBuilderOpts } from "../../../../../config/src/doc/IConfigBuilderOpts";
 import { CredentialManagerFactory } from "../../../../../security";
+import { secureSaveError } from "../../../../../config/src/ConfigUtils";
 
 /**
  * Init config
@@ -61,9 +62,10 @@ export default class InitHandler implements ICommandHandler {
 
         await this.initWithSchema(config, params.arguments.user);
 
-        if (!CredentialManagerFactory.initialized && config.api.layers.get().properties.secure.length > 0) {
-            // TODO Consult with UX about the wording and status (warning vs error) of this message
-            params.response.console.log("Warning: secure vault not enabled");
+        if (params.arguments.prompt !== false && !CredentialManagerFactory.initialized && config.api.layers.get().properties.secure.length > 0) {
+            const warning = secureSaveError();
+            params.response.console.log(TextUtils.chalk.yellow("Warning:\n") +
+                `${warning.message} Skipped prompting for credentials.\n\n${warning.additionalDetails}\n`);
         }
 
         // Write the active created/updated config layer

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -10,8 +10,7 @@
 */
 
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
-import { IConfigLayer, IConfigOpts } from "../../../../../config";
-import { ImperativeError } from "../../../../../error";
+import { secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { CredentialManagerFactory } from "../../../../../security";
 import { CliUtils, ImperativeConfig } from "../../../../../utilities";
 
@@ -30,7 +29,7 @@ export default class SecureHandler implements ICommandHandler {
 
         // Setup the credential vault API for the config
         if (!CredentialManagerFactory.initialized) {
-            throw new ImperativeError({msg: `secure vault not enabled`});
+            throw secureSaveError();
         }
 
         // Create the config, load the secure values, and activate the desired layer

--- a/packages/imperative/src/config/cmd/set/set.handler.ts
+++ b/packages/imperative/src/config/cmd/set/set.handler.ts
@@ -11,6 +11,7 @@
 
 import * as JSONC from "comment-json";
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
+import { secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { ImperativeError } from "../../../../../error";
 import { CredentialManagerFactory } from "../../../../../security";
 import { CliUtils, ImperativeConfig } from "../../../../../utilities";
@@ -39,7 +40,7 @@ export default class SetHandler implements ICommandHandler {
 
         // Setup the credential vault API for the config
         if (secure && !CredentialManagerFactory.initialized) {
-            throw new ImperativeError({msg: `secure vault not enabled`});
+            throw secureSaveError();
         }
 
         // Get the value to set


### PR DESCRIPTION
* Fix `auth login` to ensure that users are always prompted before storing token when base profile already exists.
* Update `auth login`, `config secure`, and `config set X Y --secure` to show helpful error message when unable to securely save credentials.
* Update `config init` to show helpful warning message when unable to securely save credentials (shown below).

```
$ zdev config init
Warning:
Unable to securely save credentials. Skipped prompting for credentials.

Possible Solutions:
 1. Reinstall Zowe CLI. On Linux systems, also make sure to install the prerequisites listed in Zowe CLI documentation.
 2. Ensure Zowe CLI can access secure credential storage. Zowe CLI needs access to the OS to securely save credentials.

Saved config template to C:\dev\imperative\zowe.config.json
```