### PR TITLE
Update 'marked' to address security vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## `4.10.1`
+
+- Fix vulnerabilities by updating marked
+
 ## `4.10.0`
 
 - Enhancement: Added an `arrayAllowDuplicate` option to the `ICommandOptionDefinition` interface. By default, the option value is set to `true` and duplicate values are allowed in an array. Specify `false` if you want Imperative to throw an error for duplicate array values. [#437](https://github.com/zowe/imperative/issues/437)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9433,9 +9433,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
-      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
+      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA=="
     },
     "matchdep": {
       "version": "2.0.0",
@@ -13186,6 +13186,12 @@
           "version": "9.18.3",
           "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
           "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
+          "dev": true
+        },
+        "marked": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
           "dev": true
         },
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "levenshtein": "1.0.5",
     "lodash-deep": "2.0.0",
     "log4js": "6.3.0",
-    "marked": "0.8.0",
+    "marked": "1.2.7",
     "moment": "2.20.1",
     "mustache": "2.3.0",
     "opener": "1.5.2",


### PR DESCRIPTION
There is a Denial of Service vulnerability in "marked" versions prior to 1.1.1,
the fix is available in 1.1.1 or later, see this commit which included the fix https://github.com/markedjs/marked/commit/bd4f8c464befad2b304d51e33e89e567326e62e0

This is the screenshot of "whitesource" which identified the issue:
![image](https://user-images.githubusercontent.com/17565183/104270655-f3cc0980-54d3-11eb-90fd-f2b530da1aee.png)

In my package-lock.json, I also see:
```
"@zowe/imperative": {
			"version": "4.10.0",
			"resolved": "https://registry.npmjs.org/@zowe/imperative/-/imperative-4.10.0.tgz",
			"integrity": "sha512-P1/yKhg/pnQ/0anid2EYsFh2HES5fCL1VsJ5f43xU/IjPbvRW6dZAHdSQjrs20guWdJzTMFc8IULUzkxfWrCWg==",
			"requires": {
				"@types/lodash-deep": "2.0.0",
				"@types/yargs": "13.0.4",
				"@zowe/perf-timing": "1.0.7",
				"chalk": "2.4.2",
				"cli-table3": "0.5.1",
				"dataobject-parser": "1.2.1",
				"deepmerge": "3.0.0",
				"find-up": "2.1.0",
				"fs-extra": "8.1.0",
				"glob": "7.1.6",
				"js-yaml": "3.13.1",
				"jsonfile": "4.0.0",
				"jsonschema": "1.1.1",
				"levenshtein": "1.0.5",
				"lodash-deep": "2.0.0",
				"log4js": "6.3.0",
				"marked": "0.8.0",
				"moment": "2.20.1",
```