### PR TITLE
Don't show secure values from config in plain text

### DIFF
--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.login.fruit.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.login.fruit.integration.test.ts
@@ -12,14 +12,18 @@
 import { runCliScript } from "../../../../../../src/TestUtil";
 import { ITestEnvironment } from "../../../../../../__src__/environment/doc/response/ITestEnvironment";
 import { SetupTestEnvironment } from "../../../../../../__src__/environment/SetupTestEnvironment";
-import { join } from "path";
 import * as fs from "fs";
-import * as os from "os";
 import * as keytar from "keytar";
 
 // Test Environment populated in the beforeAll();
 let TEST_ENVIRONMENT: ITestEnvironment;
 describe("imperative-test-cli auth login", () => {
+    async function loadSecureProp(profileName: string): Promise<string> {
+        const securedValue = await keytar.getPassword("imperative-test-cli", "secure_config_props");
+        const securedValueJson = JSON.parse(Buffer.from(securedValue, "base64").toString());
+        return Object.values(securedValueJson)[0][`profiles.${profileName}.properties.authToken`];
+    }
+
     // Create the unique test environment
     beforeAll(async () => {
         TEST_ENVIRONMENT = await SetupTestEnvironment.createTestEnv({
@@ -41,7 +45,7 @@ describe("imperative-test-cli auth login", () => {
             await keytar.deletePassword("imperative-test-cli", "secure_config_props");
         });
 
-        it("should load values from base profile and store token in it 1", () => {
+        it("should load values from base profile and store token in it 1", async () => {
             const response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_local.sh",
                 TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
             expect(response.stderr.toString()).toBe("");
@@ -50,10 +54,11 @@ describe("imperative-test-cli auth login", () => {
             // the output of the command should include token value
             expect(response.stdout.toString()).toContain("user:     fakeUser");
             expect(response.stdout.toString()).toContain("password: fakePass");
-            expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+            expect(response.stdout.toString()).toContain("authToken: (secure value)");
+            expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
         });
 
-        it("should load values from base profile and store token in it 2", () => {
+        it("should load values from base profile and store token in it 2", async () => {
             const response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_global.sh",
                 TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
             expect(response.stderr.toString()).toBe("");
@@ -62,10 +67,11 @@ describe("imperative-test-cli auth login", () => {
             // the output of the command should include token value
             expect(response.stdout.toString()).toContain("user:     fakeUser");
             expect(response.stdout.toString()).toContain("password: fakePass");
-            expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+            expect(response.stdout.toString()).toContain("authToken: (secure value)");
+            expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
         });
 
-        it("should load values from base profile and store token in it 3", () => {
+        it("should load values from base profile and store token in it 3", async () => {
             const response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_local_user.sh",
                 TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
             expect(response.stderr.toString()).toBe("");
@@ -74,10 +80,11 @@ describe("imperative-test-cli auth login", () => {
             // the output of the command should include token value
             expect(response.stdout.toString()).toContain("user:     fakeUser");
             expect(response.stdout.toString()).toContain("password: fakePass");
-            expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+            expect(response.stdout.toString()).toContain("authToken: (secure value)");
+            expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
         });
 
-        it("should load values from base profile and store token in it 4", () => {
+        it("should load values from base profile and store token in it 4", async () => {
             const response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_global_user.sh",
                 TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
             expect(response.stderr.toString()).toBe("");
@@ -86,7 +93,8 @@ describe("imperative-test-cli auth login", () => {
             // the output of the command should include token value
             expect(response.stdout.toString()).toContain("user:     fakeUser");
             expect(response.stdout.toString()).toContain("password: fakePass");
-            expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+            expect(response.stdout.toString()).toContain("authToken: (secure value)");
+            expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
         });
 
         it("should load values from base profile and show token only", () => {
@@ -130,7 +138,7 @@ describe("imperative-test-cli auth login", () => {
             expect(response.stdout.toString()).not.toContain("authToken:");
         });
 
-        it("should create a profile, if requested 1", () => {
+        it("should create a profile, if requested 1", async () => {
             let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_create_config.sh",
                 TEST_ENVIRONMENT.workingDir + "/testDir", ["y", "fakeUser", "fakePass"]);
             expect(response.stderr.toString()).toBe("");
@@ -144,12 +152,13 @@ describe("imperative-test-cli auth login", () => {
             expect(response.status).toBe(0);
             expect(response.stdout.toString()).toContain("host:      fakeHost");
             expect(response.stdout.toString()).toContain("port:      3000");
-            expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+            expect(response.stdout.toString()).toContain("authToken: (secure value)");
+            expect(await loadSecureProp("my_base")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
             expect(response.stdout.toString()).not.toContain("user:");
             expect(response.stdout.toString()).not.toContain("password:");
         });
 
-        it("should create a profile, if requested 2", () => {
+        it("should create a profile, if requested 2", async () => {
             let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_create_config.sh",
                 TEST_ENVIRONMENT.workingDir + "/testDir", ["yes", "fakeUser", "fakePass"]);
             expect(response.stderr.toString()).toBe("");
@@ -163,7 +172,8 @@ describe("imperative-test-cli auth login", () => {
             expect(response.status).toBe(0);
             expect(response.stdout.toString()).toContain("host:      fakeHost");
             expect(response.stdout.toString()).toContain("port:      3000");
-            expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+            expect(response.stdout.toString()).toContain("authToken: (secure value)");
+            expect(await loadSecureProp("my_base")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
             expect(response.stdout.toString()).not.toContain("user:");
             expect(response.stdout.toString()).not.toContain("password:");
         });

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.logout.fruit.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.logout.fruit.integration.test.ts
@@ -19,6 +19,12 @@ import * as keytar from "keytar";
 // Test Environment populated in the beforeAll();
 let TEST_ENVIRONMENT: ITestEnvironment;
 describe("cmd-cli auth logout", () => {
+    async function loadSecureProp(profileName: string): Promise<string> {
+        const securedValue = await keytar.getPassword("imperative-test-cli", "secure_config_props");
+        const securedValueJson = JSON.parse(Buffer.from(securedValue, "base64").toString());
+        return Object.values(securedValueJson)[0][`profiles.${profileName}.properties.authToken`];
+    }
+
     // Create the unique test environment
     beforeAll(async () => {
         TEST_ENVIRONMENT = await SetupTestEnvironment.createTestEnv({
@@ -37,14 +43,14 @@ describe("cmd-cli auth logout", () => {
         await keytar.deletePassword("imperative-test-cli", "secure_config_props");
     });
 
-    it("should have auth logout command that loads values from base profile and removes the token 1", () => {
+    it("should have auth logout command that loads values from base profile and removes the token 1", async () => {
         let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_local.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
 
         // the output of the command should include token value
-        expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+        expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
 
         response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_logout_config.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir");
@@ -56,14 +62,14 @@ describe("cmd-cli auth logout", () => {
         expect(response.stdout.toString()).not.toContain("tokenValue:");
     });
 
-    it("should have auth logout command that loads values from base profile and removes the token 2", () => {
+    it("should have auth logout command that loads values from base profile and removes the token 2", async () => {
         let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_global.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
 
         // the output of the command should include token value
-        expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+        expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
 
         response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_logout_config.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir");
@@ -75,14 +81,14 @@ describe("cmd-cli auth logout", () => {
         expect(response.stdout.toString()).not.toContain("tokenValue:");
     });
 
-    it("should have auth logout command that loads values from base profile and removes the token 3", () => {
+    it("should have auth logout command that loads values from base profile and removes the token 3", async () => {
         let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_local_user.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
 
         // the output of the command should include token value
-        expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+        expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
 
         response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_logout_config.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir");
@@ -94,14 +100,14 @@ describe("cmd-cli auth logout", () => {
         expect(response.stdout.toString()).not.toContain("tokenValue:");
     });
 
-    it("should have auth logout command that loads values from base profile and removes the token 4", () => {
+    it("should have auth logout command that loads values from base profile and removes the token 4", async () => {
         let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_global_user.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
 
         // the output of the command should include token value
-        expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+        expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
 
         response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_logout_config.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir");
@@ -113,14 +119,14 @@ describe("cmd-cli auth logout", () => {
         expect(response.stdout.toString()).not.toContain("tokenValue:");
     });
 
-    it("should have auth logout command that invalidates another token", () => {
+    it("should have auth logout command that invalidates another token", async () => {
         let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_local.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
 
         // the output of the command should include token value
-        expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+        expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
 
         response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_logout_specify_token_config.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir", ["jwtToken=fakeToken:fakeToken@fakeToken"]);
@@ -128,6 +134,6 @@ describe("cmd-cli auth logout", () => {
         expect(response.status).toBe(0);
 
         // the output of the command should include token value
-        expect(response.stdout.toString()).toContain("authToken: jwtToken=fakeUser:fakePass@fakeToken");
+        expect(await loadSecureProp("my_base_fruit")).toBe("jwtToken=fakeUser:fakePass@fakeToken");
     });
 });

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/__resources__/expectedObjects.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/__resources__/expectedObjects.ts
@@ -250,7 +250,8 @@ export const expectedConfigObject: IConfig = {
                 secured: {
                     type: "secured",
                     properties: {
-                        info: ""
+                        info: "",
+                        secret: "(secure value)"
                     }
                 }
             },

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/__resources__/expectedObjects.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/__resources__/expectedObjects.ts
@@ -250,8 +250,7 @@ export const expectedConfigObject: IConfig = {
                 secured: {
                     type: "secured",
                     properties: {
-                        info: "",
-                        secret: "(secure value)"
+                        info: ""
                     }
                 }
             },

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/init/cli.imperative-test-cli.config.init.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/init/cli.imperative-test-cli.config.init.integration.test.ts
@@ -102,6 +102,7 @@ describe("imperative-test-cli config init", () => {
             TEST_ENVIRONMENT.workingDir, [""]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.schema.json");
+        expect(response.output.toString()).not.toContain("Unable to securely save credentials");
         expect(response.output.toString()).toContain(`Saved config template to`);
         expect(response.output.toString()).toContain(expectedConfigLocation);
         expect(fs.existsSync(expectedConfigLocation)).toEqual(true);
@@ -114,6 +115,7 @@ describe("imperative-test-cli config init", () => {
             TEST_ENVIRONMENT.workingDir, ["--user"]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.user.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.schema.json");
+        expect(response.output.toString()).not.toContain("Unable to securely save credentials");
         expect(response.output.toString()).toContain(`Saved config template to`);
         expect(response.output.toString()).toContain(expectedConfigLocation);
         expect(fs.existsSync(expectedConfigLocation)).toEqual(true);
@@ -126,6 +128,7 @@ describe("imperative-test-cli config init", () => {
             TEST_ENVIRONMENT.workingDir, ["--global"]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.schema.json");
+        expect(response.output.toString()).not.toContain("Unable to securely save credentials");
         expect(response.output.toString()).toContain(`Saved config template to`);
         expect(response.output.toString()).toContain(expectedConfigLocation);
         expect(fs.existsSync(expectedConfigLocation)).toEqual(true);
@@ -138,6 +141,7 @@ describe("imperative-test-cli config init", () => {
             TEST_ENVIRONMENT.workingDir, ["--global --user"]);
         const expectedConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.user.json");
         const expectedSchemaLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.schema.json");
+        expect(response.output.toString()).not.toContain("Unable to securely save credentials");
         expect(response.output.toString()).toContain(`Saved config template to`);
         expect(response.output.toString()).toContain(expectedConfigLocation);
         expect(fs.existsSync(expectedConfigLocation)).toEqual(true);

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/__snapshots__/cli.imperative-test-cli.config.list.integration.test.ts.snap
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/__snapshots__/cli.imperative-test-cli.config.list.integration.test.ts.snap
@@ -36,7 +36,8 @@ exports[`imperative-test-cli config list should list the profiles configuration 
     secured: 
       type:       secured
       properties: 
-        info: 
+        info:   
+        secret: (secure value)
 my_base: 
   type:       base
   properties: 

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/__snapshots__/cli.imperative-test-cli.config.list.integration.test.ts.snap
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/__snapshots__/cli.imperative-test-cli.config.list.integration.test.ts.snap
@@ -8,7 +8,8 @@ exports[`imperative-test-cli config list should list the configuration 1`] = `
       secured: 
         type:       secured
         properties: 
-          info: 
+          info:   
+          secret: (secure value)
   my_base: 
     type:       base
     properties: 

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/cli.imperative-test-cli.config.list.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/cli.imperative-test-cli.config.list.integration.test.ts
@@ -13,7 +13,6 @@ import { ITestEnvironment } from "../../../../../../../__src__/environment/doc/r
 import { SetupTestEnvironment } from "../../../../../../../__src__/environment/SetupTestEnvironment";
 import { runCliScript } from "../../../../../../../src/TestUtil";
 import { expectedConfigObject } from "../__resources__/expectedObjects";
-import * as fs from "fs";
 import * as path from "path";
 import * as lodash from "lodash";
 
@@ -139,6 +138,7 @@ describe("imperative-test-cli config list", () => {
             secure: []
         };
         const expectedProjectConfig = lodash.cloneDeep(expectedConfigObject);
+        expectedProjectConfig.profiles.my_profiles.profiles.secured.properties.secret = "(secure value)";
         const expectedResponse = {
             data: {}
         };

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/cli.imperative-test-cli.config.list.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/list/cli.imperative-test-cli.config.list.integration.test.ts
@@ -80,6 +80,7 @@ describe("imperative-test-cli config list", () => {
                                 type: "secured",
                                 properties: {
                                     info: "",
+                                    secret: "(secure value)"
                                 }
                             }
                         },

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/secure/cli.imperative-test-cli.config.secure.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/secure/cli.imperative-test-cli.config.secure.integration.test.ts
@@ -31,7 +31,7 @@ describe("imperative-test-cli config secure", () => {
 
     const expectedJson = lodash.cloneDeep(expectedConfigObject);
     delete expectedJson.$schema;
-    // expectedJson.profiles.my_profiles.profiles.secured.properties.secret = "anotherFakeValue";
+    expectedJson.profiles.my_profiles.profiles.secured.properties.secret = "(secure value)";
     expectedJson.secure = [];
 
     const expectedUserJson = expectedUserConfigObject;

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/secure/cli.imperative-test-cli.config.secure.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/secure/cli.imperative-test-cli.config.secure.integration.test.ts
@@ -31,7 +31,7 @@ describe("imperative-test-cli config secure", () => {
 
     const expectedJson = lodash.cloneDeep(expectedConfigObject);
     delete expectedJson.$schema;
-    expectedJson.profiles.my_profiles.profiles.secured.properties.secret = "anotherFakeValue";
+    // expectedJson.profiles.my_profiles.profiles.secured.properties.secret = "anotherFakeValue";
     expectedJson.secure = [];
 
     const expectedUserJson = expectedUserConfigObject;

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/set/cli.imperative-test-cli.config.set.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/set/cli.imperative-test-cli.config.set.integration.test.ts
@@ -31,8 +31,8 @@ describe("imperative-test-cli config set", () => {
 
     const expectedJson = lodash.cloneDeep(expectedConfigObject);
     delete expectedJson.$schema;
-    expectedJson.profiles.my_profiles.profiles.secured.properties.info = "some_fake_information";
-    expectedJson.profiles.my_profiles.profiles.secured.properties.secret = "fakeValue";
+    expectedJson.profiles.my_profiles.profiles.secured.properties.info = "(secure value)";
+    expectedJson.profiles.my_profiles.profiles.secured.properties.secret = "(secure value)";
     expectedJson.secure = [];
 
     const expectedUserJson = lodash.cloneDeep(expectedJson);
@@ -49,8 +49,6 @@ describe("imperative-test-cli config set", () => {
         expectedGlobalProjectConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "imperative-test-cli.config.json");
         expectedUserConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.user.json");
         expectedProjectConfigLocation = path.join(TEST_ENVIRONMENT.workingDir, "test", "imperative-test-cli.config.json");
-        expectedJson.profiles.my_profiles.profiles.secured.properties.info = "some_fake_information";
-        expectedUserJson.profiles.my_profiles.profiles.secured.properties.info = "some_fake_information";
         await keytar.setPassword("imperative-test-cli", "secure_config_props", Buffer.from("{}").toString("base64"));
     });
     afterEach(() => {
@@ -198,7 +196,6 @@ describe("imperative-test-cli config set", () => {
             const fileContents = JSON.parse(fs.readFileSync(expectedGlobalUserConfigLocation).toString());
             const config = runCliScript(__dirname + "/../list/__scripts__/list_config.sh", TEST_ENVIRONMENT.workingDir, ["--rfj"]).stdout.toString();
             const configJson = JSON.parse(config);
-            expectedUserJson.profiles.my_profiles.profiles.secured.properties.info = {data: "fake"};
             const securedValue = await keytar.getPassword(service, "secure_config_props");
             const securedValueJson = JSON.parse(Buffer.from(securedValue, "base64").toString());
             const expectedSecuredValueJson = {};

--- a/packages/config/__tests__/Config.test.ts
+++ b/packages/config/__tests__/Config.test.ts
@@ -203,9 +203,21 @@ describe("Config tests", () => {
 
     it("should provide a deep copy of layers", () => {
         const config = new (Config as any)();
-        config._layers = {};
-        config.layers.properties = {};
+        config._layers = [];
+        config.layers.push({});
         expect(Object.keys(config._layers).length).toBe(0);
+    });
+
+    it("should make secure values in maskedProperties", async () => {
+        jest.spyOn(Config, "search").mockReturnValue(__dirname + "/__resources__/project.config.json");
+        jest.spyOn(fs, "existsSync")
+            .mockReturnValueOnce(false)     // Project user layer
+            .mockReturnValueOnce(true)      // Project layer
+            .mockReturnValueOnce(false)     // User layer
+            .mockReturnValueOnce(false);    // Global layer
+        const config = await Config.load(MY_APP);
+        expect(config.properties.profiles.fruit.properties.secret).toBeUndefined();
+        expect(config.maskedProperties.profiles.fruit.properties.secret).toBe(Config.SECURE_VALUE);
     });
 
     describe("set", () => {

--- a/packages/imperative/__tests__/Imperative.test.ts
+++ b/packages/imperative/__tests__/Imperative.test.ts
@@ -166,7 +166,7 @@ describe("Imperative", () => {
             (Imperative as any).defineCommands = jest.fn(() => undefined);
 
             mocks.ConfigurationLoader.load.mockReturnValue(defaultConfig);
-            mocks.OverridesLoader.load.mockReturnValue(new Promise((resolve) => resolve()));
+            mocks.OverridesLoader.load.mockResolvedValue(undefined);
             mocks.Config.load.mockResolvedValue({});
         });
 
@@ -175,6 +175,7 @@ describe("Imperative", () => {
             const result = await Imperative.init();
 
             expect(result).toBeUndefined();
+            expect(mocks.Config.load).toHaveBeenCalledTimes(1);
             expect(mocks.OverridesLoader.load).toHaveBeenCalledTimes(1);
             expect(mocks.OverridesLoader.load).toHaveBeenCalledWith(defaultConfig, {version: 10000, name: "sample"});
         });
@@ -222,42 +223,6 @@ describe("Imperative", () => {
                 await Imperative.init();
 
                 expect(ConfigManagementFacility.instance.init).toHaveBeenCalledTimes(1);
-            });
-
-            describe("load", () => {
-                beforeEach(() => {
-                    Object.defineProperty(mocks.CredentialManagerFactory, "initialized", { get: () => true });
-                });
-
-                it("should load config JSON layers", async () => {
-                    mocks.Config.load.mockResolvedValue({
-                        secureLoad: jest.fn()
-                    });
-
-                    await Imperative.init();
-
-                    expect(mocks.Config.load).toHaveBeenCalledTimes(1);
-                    expect(mocks.ImperativeConfig.instance.config.secureLoad).toHaveBeenCalledTimes(1);
-                });
-
-                it("should not fail if secure load fails", async () => {
-                    mocks.Config.load.mockResolvedValue({
-                        secureLoad: jest.fn(() => {
-                            throw new Error("secure load failed");
-                        })
-                    });
-                    let caughtError;
-
-                    try {
-                        await Imperative.init();
-                    } catch (error) {
-                        caughtError = error;
-                    }
-
-                    expect(mocks.Config.load).toHaveBeenCalledTimes(1);
-                    expect(mocks.ImperativeConfig.instance.config.secureLoad).toHaveBeenCalledTimes(1);
-                    expect(caughtError).toBeUndefined();
-                });
             });
         });
 

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -82,31 +82,6 @@ describe("OverridesLoader", () => {
       });
     });
 
-    it("should load the default when not passed any configuration and keytar is present in optional dependencies.", async () => {
-      const config: IImperativeConfig = {
-        name: "ABCD",
-        overrides: {},
-        productDisplayName: "a fake CLI"
-      };
-
-      // Fake out package.json for the overrides loader
-      const packageJson = {
-        optionalDependencies: {
-          keytar: "1.0"
-        }
-      };
-
-      await OverridesLoader.load(config, packageJson);
-
-      expect(CredentialManagerFactory.initialize).toHaveBeenCalledTimes(1);
-      expect(CredentialManagerFactory.initialize).toHaveBeenCalledWith({
-        Manager: undefined,
-        displayName: config.productDisplayName,
-        invalidOnFailure: false,
-        service: config.name
-      });
-    });
-
     describe("should load a credential manager specified by the user", () => {
       it("was passed a class", async () => {
         const config: IImperativeConfig = {

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -82,6 +82,31 @@ describe("OverridesLoader", () => {
       });
     });
 
+    it("should load the default when not passed any configuration and keytar is present in optional dependencies.", async () => {
+      const config: IImperativeConfig = {
+        name: "ABCD",
+        overrides: {},
+        productDisplayName: "a fake CLI"
+      };
+
+      // Fake out package.json for the overrides loader
+      const packageJson = {
+        optionalDependencies: {
+          keytar: "1.0"
+        }
+      };
+
+      await OverridesLoader.load(config, packageJson);
+
+      expect(CredentialManagerFactory.initialize).toHaveBeenCalledTimes(1);
+      expect(CredentialManagerFactory.initialize).toHaveBeenCalledWith({
+        Manager: undefined,
+        displayName: config.productDisplayName,
+        invalidOnFailure: false,
+        service: config.name
+      });
+    });
+
     describe("should load a credential manager specified by the user", () => {
       it("was passed a class", async () => {
         const config: IImperativeConfig = {

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -274,7 +274,7 @@ describe("OverridesLoader", () => {
         expect(caughtError).toBeUndefined();
         expect(CredentialManagerFactory.initialize).toHaveBeenCalledTimes(1);
         expect(ImperativeConfig.instance.config.secureLoad).toHaveBeenCalledTimes(1);
-    });
+      });
     });
   });
 });

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -178,8 +178,11 @@ describe("OverridesLoader", () => {
 
     describe("when config JSON exists", () => {
       beforeEach(() => {
-        jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValueOnce({
-          config: { exists: () => false }
+        jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValue({
+          config: {
+            exists: () => true,
+            secureLoad: jest.fn()
+          }
         } as any);
       });
 
@@ -245,6 +248,33 @@ describe("OverridesLoader", () => {
           service: null
         });
       });
+
+      it("should not fail if secure load fails", async () => {
+        const config: IImperativeConfig = {
+          name: "ABCD",
+          overrides: {}
+        };
+
+        // Fake out package.json for the overrides loader
+        const packageJson = {
+          dependencies: {
+            keytar: "1.0"
+          }
+        };
+
+        Object.defineProperty(CredentialManagerFactory, "initialized", { get: () => true });
+        let caughtError;
+
+        try {
+          await OverridesLoader.load(config, packageJson);
+        } catch (error) {
+          caughtError = error;
+        }
+
+        expect(caughtError).toBeUndefined();
+        expect(CredentialManagerFactory.initialize).toHaveBeenCalledTimes(1);
+        expect(ImperativeConfig.instance.config.secureLoad).toHaveBeenCalledTimes(1);
+    });
     });
   });
 });

--- a/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
@@ -104,6 +104,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
+        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -126,6 +127,7 @@ describe("Configuration Initialization command handler", () => {
         delete compObj.profiles.my_profiles.profiles.secured.properties.secret; // Delete the secret
         compObj.secure = ["profiles.my_profiles.profiles.secured.properties.secret"]; // Add the secret field to the secrets
 
+        expect(ensureCredMgrSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledWith(expectedSchemaObjectNoBase);
 
@@ -153,6 +155,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
+        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -175,6 +178,7 @@ describe("Configuration Initialization command handler", () => {
         delete compObj.profiles.my_profiles.profiles.secured.properties.secret; // Delete the secret
         delete compObj.profiles.my_profiles.profiles.secured.properties.info; // Delete info as well
 
+        expect(ensureCredMgrSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledWith(expectedSchemaObjectNoBase);
 
@@ -197,6 +201,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
+        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -219,6 +224,7 @@ describe("Configuration Initialization command handler", () => {
         delete compObj.profiles.my_profiles.profiles.secured.properties.secret; // Delete the secret
         compObj.secure = ["profiles.my_profiles.profiles.secured.properties.secret"]; // Add the secret field to the secrets
 
+        expect(ensureCredMgrSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledWith(expectedSchemaObjectNoBase);
 
@@ -246,6 +252,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
+        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -268,6 +275,7 @@ describe("Configuration Initialization command handler", () => {
         delete compObj.profiles.my_profiles.profiles.secured.properties.secret; // Delete the secret
         delete compObj.profiles.my_profiles.profiles.secured.properties.info; // Delete info as well
 
+        expect(ensureCredMgrSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledTimes(1);
         expect(setSchemaSpy).toHaveBeenCalledWith(expectedSchemaObjectNoBase);
 

--- a/packages/imperative/__tests__/config/cmd/list/list.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/list/list.handler.test.ts
@@ -54,8 +54,8 @@ const configLayers: IConfigLayer[] = [
             profiles: {
                 email: {
                     properties: {
-                        host: "smtp.gmail.com",
-                        port: 587,
+                        host: "fakeHost",
+                        port: 25,
                         user: "admin",
                         password: "123456"
                     }

--- a/packages/imperative/__tests__/config/cmd/list/list.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/list/list.handler.test.ts
@@ -1,0 +1,174 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+jest.mock("../../../../../utilities/src/ImperativeConfig");
+
+import { IConfig, IConfigLayer } from "../../../../../config";
+import { ImperativeConfig } from "../../../../../utilities";
+import ListHandler from "../../../../src/config/cmd/list/list.handler";
+
+let dataObj: any;
+let formatObj: any;
+let errorText: string;
+let logText: string;
+
+// "Mocked" version of the handler parameters for a config list command
+const handlerParms: any = {
+    response: {
+        data: {
+            setObj: jest.fn((jsonObj) => {
+                dataObj = jsonObj;
+            })
+        },
+        format: {
+            output: jest.fn((formatArgs) => {
+                formatObj = formatArgs.output;
+            })
+        },
+        console: {
+            log: jest.fn((msgText) => {
+                logText = msgText;
+            }),
+            error: jest.fn((msgText) => {
+                errorText = msgText;
+            })
+        }
+    }
+};
+
+const configLayers: IConfigLayer[] = [
+    {
+        exists: true,
+        path: "fakePath",
+        user: false,
+        global: false,
+        properties: {
+            profiles: {
+                email: {
+                    properties: {
+                        host: "smtp.gmail.com",
+                        port: 587,
+                        user: "admin",
+                        password: "123456"
+                    }
+                }
+            },
+            defaults: {},
+            plugins: [],
+            secure: [
+                "profiles.email.properties.user",
+                "profiles.email.properties.password"
+            ]
+        }
+    }
+];
+
+const configMaskedProps: IConfig = configLayers[0].properties;
+configMaskedProps.profiles.email.properties.user = "(secure value)";
+configMaskedProps.profiles.email.properties.password = "(secure value)";
+
+describe("Configuration List command handler", () => {
+    const configMock = jest.fn();
+
+    beforeAll(() => {
+        Object.defineProperty(ImperativeConfig.instance, "config", {
+            get: configMock
+        });
+    });
+
+    beforeEach(() => {
+        dataObj = null;
+        formatObj = null;
+        errorText = null;
+        logText = null;
+    })
+
+    it("should output empty object when there is no config", async () => {
+        configMock.mockReturnValueOnce({
+            exists: false
+        });
+        handlerParms.arguments = {};
+
+        await (new ListHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj).toEqual({});
+        expect(formatObj).toEqual(dataObj);
+    });
+
+    it("should output entire config", async () => {
+        configMock.mockReturnValueOnce({
+            exists: true,
+            maskedProperties: configMaskedProps
+        });
+        handlerParms.arguments = {};
+
+        await (new ListHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj).toEqual(configLayers[0].properties);
+        expect(dataObj.profiles.email.properties.user).toBe("(secure value)");
+        expect(dataObj.profiles.email.properties.password).toBe("(secure value)");
+        expect(formatObj).toEqual(dataObj);
+    });
+
+    it("should output config property", async () => {
+        configMock.mockReturnValueOnce({
+            exists: true,
+            maskedProperties: configMaskedProps
+        });
+        handlerParms.arguments = { property: "secure" };
+
+        await (new ListHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj).toEqual(configLayers[0].properties.secure);
+        expect(formatObj).toEqual(dataObj);
+    });
+
+    it("should output entire config listed by location", async () => {
+        configMock.mockReturnValueOnce({
+            exists: true,
+            layers: configLayers
+        });
+        handlerParms.arguments = { locations: true };
+
+        await (new ListHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj.fakePath).toEqual(configLayers[0].properties);
+        expect(dataObj.fakePath.profiles.email.properties.user).toBe("(secure value)");
+        expect(dataObj.fakePath.profiles.email.properties.password).toBe("(secure value)");
+        expect(formatObj).toEqual(dataObj);
+    });
+
+    it("should output config property listed by location", async () => {
+        configMock.mockReturnValueOnce({
+            exists: true,
+            layers: configLayers
+        });
+        handlerParms.arguments = { locations: true, property: "secure" };
+
+        await (new ListHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj.fakePath).toEqual(configLayers[0].properties.secure);
+        expect(formatObj).toEqual(dataObj);
+    });
+
+    it("should output entire config at root level", async () => {
+        configMock.mockReturnValueOnce({
+            exists: true,
+            maskedProperties: configMaskedProps
+        });
+        handlerParms.arguments = { root: true };
+
+        await (new ListHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj).toEqual(Object.keys(configLayers[0].properties));
+        expect(formatObj).toEqual(dataObj);
+    });
+});

--- a/packages/imperative/__tests__/config/cmd/profiles/profiles.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/profiles/profiles.handler.test.ts
@@ -71,7 +71,7 @@ const configProps: IConfig = {
     secure: []
 };
 
-describe("Configuration List command handler", () => {
+describe("Configuration Profiles command handler", () => {
     const configMock = jest.fn();
 
     beforeAll(() => {

--- a/packages/imperative/__tests__/config/cmd/profiles/profiles.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/profiles/profiles.handler.test.ts
@@ -51,15 +51,15 @@ const configProps: IConfig = {
                 incoming: {
                     type: "imap",
                     properties: {
-                        host: "imap.gmail.com",
-                        port: 993
+                        host: "fakeHost",
+                        port: 143
                     }
                 },
                 outgoing: {
                     type: "smtp",
                     properties: {
-                        host: "smtp.gmail.com",
-                        port: 587
+                        host: "fakeHost",
+                        port: 25
                     }
                 }
             },

--- a/packages/imperative/__tests__/config/cmd/profiles/profiles.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/profiles/profiles.handler.test.ts
@@ -1,0 +1,101 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+jest.mock("../../../../../utilities/src/ImperativeConfig");
+
+import { IConfig } from "../../../../../config";
+import { ImperativeConfig } from "../../../../../utilities";
+import ProfilesHandler from "../../../../src/config/cmd/profiles/profiles.handler";
+
+let dataObj: any;
+let formatObj: any;
+let errorText: string;
+let logText: string;
+
+// "Mocked" version of the handler parameters for a config list command
+const handlerParms: any = {
+    response: {
+        data: {
+            setObj: jest.fn((jsonObj) => {
+                dataObj = jsonObj;
+            })
+        },
+        format: {
+            output: jest.fn((formatArgs) => {
+                formatObj = formatArgs.output;
+            })
+        },
+        console: {
+            log: jest.fn((msgText) => {
+                logText = msgText;
+            }),
+            error: jest.fn((msgText) => {
+                errorText = msgText;
+            })
+        }
+    }
+};
+
+const configProps: IConfig = {
+    profiles: {
+        email: {
+            profiles: {
+                incoming: {
+                    type: "imap",
+                    properties: {
+                        host: "imap.gmail.com",
+                        port: 993
+                    }
+                },
+                outgoing: {
+                    type: "smtp",
+                    properties: {
+                        host: "smtp.gmail.com",
+                        port: 587
+                    }
+                }
+            },
+            properties: {}
+        }
+    },
+    defaults: {},
+    plugins: [],
+    secure: []
+};
+
+describe("Configuration List command handler", () => {
+    const configMock = jest.fn();
+
+    beforeAll(() => {
+        Object.defineProperty(ImperativeConfig.instance, "config", {
+            get: configMock
+        });
+    });
+
+    beforeEach(() => {
+        dataObj = null;
+        formatObj = null;
+        errorText = null;
+        logText = null;
+    })
+
+    it("should output list of nested profiles", async () => {
+        configMock.mockReturnValueOnce({
+            exists: true,
+            properties: configProps
+        });
+
+        await (new ProfilesHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj).toEqual(["email", "email.incoming", "email.outgoing"]);
+        expect(formatObj).toEqual(dataObj);
+    });
+});

--- a/packages/imperative/__tests__/config/cmd/schema/schema.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/schema/schema.handler.test.ts
@@ -1,0 +1,119 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+jest.mock("../../../../../utilities/src/ImperativeConfig");
+
+import { ImperativeConfig } from "../../../../../utilities";
+import { IProfileTypeConfiguration } from "../../../../../profiles";
+import SchemaHandler from "../../../../src/config/cmd/schema/schema.handler";
+
+let dataObj: any;
+let errorText: string;
+let logText: string;
+
+// "Mocked" version of the handler parameters for a config schema command
+const handlerParms: any = {
+    response: {
+        data: {
+            setObj: jest.fn((jsonObj) => {
+                dataObj = jsonObj;
+            })
+        },
+        console: {
+            log: jest.fn((msgText) => {
+                logText = msgText;
+            }),
+            error: jest.fn((msgText) => {
+                errorText = msgText;
+            })
+        }
+    }
+};
+
+const testProfileConfiguration: IProfileTypeConfiguration[] = [
+    {
+        type: "zosmf",
+        schema: {
+            title: "zosmf",
+            description: "A fake zosmf profile",
+            type: "zosmf",
+            required: [],
+            properties: {
+                host: {
+                    type: "string",
+                    secure: true
+                }
+            }
+        }
+    },
+    {
+        type: "base",
+        schema: {
+            title: "base",
+            description: "A fake base profile",
+            type: "base",
+            required: [],
+            properties: {
+                port: {
+                    type: "number",
+                    secure: false
+                }
+            }
+        }
+    }
+];
+
+const expectedSchemaObj: any = {
+    "$schema": "https://json-schema.org/draft/2019-09/schema#",
+    "$version": 1,
+    "type": "object",
+    "description": "config",
+    "properties": {
+        "profiles": {},
+        "defaults": {},
+        "secure": {}
+    }
+};
+
+describe("Configuration Schema command handler", () => {
+    const loadedConfigMock = jest.fn();
+
+    beforeAll(() => {
+        Object.defineProperty(ImperativeConfig.instance, "loadedConfig", {
+            get: loadedConfigMock
+        });
+    });
+
+    beforeEach(() => {
+        dataObj = null;
+        errorText = null;
+        logText = null;
+    })
+
+    it("should print schema JSON", async () => {
+        loadedConfigMock.mockReturnValueOnce({
+            profiles: testProfileConfiguration
+        });
+
+        await (new SchemaHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj).toMatchObject(expectedSchemaObj);
+        expect(JSON.parse(logText)).toMatchObject(dataObj);
+    });
+
+    it("should fail when Imperative config not loaded", async () => {
+        loadedConfigMock.mockReturnValueOnce(undefined);
+
+        await (new SchemaHandler()).process(handlerParms);
+        expect(errorText).toBe("Failed to load profile schemas");
+        expect(logText).toBeNull();
+    });
+});

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -60,8 +60,7 @@ import { IYargsContext } from "./doc/IYargsContext";
 import { ICommandProfileAuthConfig } from "../../cmd/src/doc/profiles/definition/ICommandProfileAuthConfig";
 import { ImperativeExpect } from "../../expect";
 import { CompleteAuthGroupBuilder } from "./auth/builders/CompleteAuthGroupBuilder";
-import { Config, IConfigVault } from "../../config";
-import { CredentialManagerFactory } from "../../security";
+import { Config } from "../../config";
 
 // Bootstrap the performance tools
 if (PerfTiming.isEnabled) {
@@ -223,27 +222,6 @@ export class Imperative {
                  */
                 await OverridesLoader.load(ImperativeConfig.instance.loadedConfig,
                     ImperativeConfig.instance.callerPackageJson);
-
-                /**
-                 * After the plugins and secure credentials are loaded, rebuild the configuration with the
-                 * secure values
-                 */
-                if (CredentialManagerFactory.initialized) {
-                    const vault: IConfigVault = {
-                        load: ((key: string): Promise<string> => {
-                            return CredentialManagerFactory.manager.load(key, true);
-                        }),
-                        save: ((key: string, value: any): Promise<void> => {
-                            return CredentialManagerFactory.manager.save(key, value);
-                        })
-                    };
-                    try {
-                        await ImperativeConfig.instance.config.secureLoad(vault);
-                    } catch (err) {
-                        // Secure vault is optional since we can prompt for values instead
-                        Logger.getImperativeLogger().warn(`Secure vault not enabled. Reason: ${err.message}`);
-                    }
-                }
 
                 /**
                  * Build API object

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -52,7 +52,7 @@ export class OverridesLoader {
       return this.loadCredentialManagerOld(config, packageJson);
     }
 
-    if (packageJson.dependencies?.keytar == null && packageJson.optionalDependencies?.keytar == null) {
+    if (!this.hasKeytarDep(packageJson)) {
       return;
     }
 
@@ -96,7 +96,7 @@ export class OverridesLoader {
         config.productDisplayName || config.name;
 
     // Initialize the credential manager if an override was supplied and/or keytar was supplied in package.json
-    if (overrides.CredentialManager != null || (packageJson.dependencies != null && packageJson.dependencies.keytar != null)) {
+    if (overrides.CredentialManager != null || this.hasKeytarDep(packageJson)) {
       let Manager = overrides.CredentialManager;
       if (typeof overrides.CredentialManager === "string" && !isAbsolute(overrides.CredentialManager)) {
         Manager = resolve(process.mainModule.filename, "../", overrides.CredentialManager);
@@ -113,5 +113,9 @@ export class OverridesLoader {
         invalidOnFailure: !(Manager == null)
       });
     }
+  }
+
+  private static hasKeytarDep(packageJson: any): boolean {
+    return packageJson.dependencies?.keytar != null || packageJson.optionalDependencies?.keytar != null;
   }
 }

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -11,14 +11,13 @@
 
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
 import { ImperativeConfig, TextUtils } from "../../../../../utilities";
-import { Config, ConfigSchema, IConfig, IConfigVault } from "../../../../../config";
+import { Config, ConfigSchema, IConfig } from "../../../../../config";
 import { IProfileProperty } from "../../../../../profiles";
 import { ConfigBuilder } from "../../../../../config/src/ConfigBuilder";
 import { IConfigBuilderOpts } from "../../../../../config/src/doc/IConfigBuilderOpts";
 import { CredentialManagerFactory } from "../../../../../security";
 import { secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { OverridesLoader } from "../../../OverridesLoader";
-import { Logger } from "../../../../../logger";
 
 /**
  * Init config

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -77,36 +77,9 @@ export default class InitHandler implements ICommandHandler {
      * now before performing config operations in the init handler.
      */
     private async ensureCredentialManagerLoaded() {
-        if (CredentialManagerFactory.initialized) {
-            return;
-        }
-
-        /**
-         * Now we should apply any overrides to default Imperative functionality. This is where CLI
-         * developers are able to really start customizing Imperative and how it operates internally.
-         */
-        await OverridesLoader.loadCredentialManager(ImperativeConfig.instance.loadedConfig,
-            ImperativeConfig.instance.callerPackageJson);
-
-        /**
-         * After the plugins and secure credentials are loaded, rebuild the configuration with the
-         * secure values
-         */
-        if (CredentialManagerFactory.initialized) {
-            const vault: IConfigVault = {
-                load: ((key: string): Promise<string> => {
-                    return CredentialManagerFactory.manager.load(key, true);
-                }),
-                save: ((key: string, value: any): Promise<void> => {
-                    return CredentialManagerFactory.manager.save(key, value);
-                })
-            };
-            try {
-                await ImperativeConfig.instance.config.secureLoad(vault);
-            } catch (err) {
-                // Secure vault is optional since we can prompt for values instead
-                Logger.getImperativeLogger().warn(`Secure vault not enabled. Reason: ${err.message}`);
-            }
+        if (!CredentialManagerFactory.initialized) {
+            await OverridesLoader.loadCredentialManager(ImperativeConfig.instance.loadedConfig,
+                ImperativeConfig.instance.callerPackageJson);
         }
     }
 

--- a/packages/imperative/src/config/cmd/list/list.handler.ts
+++ b/packages/imperative/src/config/cmd/list/list.handler.ts
@@ -45,7 +45,7 @@ export default abstract class ListHandler implements ICommandHandler {
             } else {
                 obj = config.maskedProperties;
                 if (property != null)
-                    obj = (config.properties as any)[property];
+                    obj = (config.maskedProperties as any)[property];
             }
         }
 

--- a/packages/imperative/src/config/cmd/list/list.handler.ts
+++ b/packages/imperative/src/config/cmd/list/list.handler.ts
@@ -14,7 +14,7 @@ import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
 import { Config } from "../../../../../config";
 import { ImperativeConfig } from "../../../../../utilities";
 
-export default abstract class ListHandler implements ICommandHandler {
+export default class ListHandler implements ICommandHandler {
     /**
      * Process the command and input.
      *

--- a/packages/imperative/src/config/cmd/list/list.handler.ts
+++ b/packages/imperative/src/config/cmd/list/list.handler.ts
@@ -9,7 +9,9 @@
 *
 */
 
+import * as lodash from "lodash";
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
+import { Config } from "../../../../../config";
 import { ImperativeConfig } from "../../../../../utilities";
 
 export default abstract class ListHandler implements ICommandHandler {
@@ -33,10 +35,15 @@ export default abstract class ListHandler implements ICommandHandler {
                         obj[layer.path] = layer.properties;
                         if (property != null)
                             obj[layer.path] = (layer.properties as any)[property];
+                        if (obj[layer.path] != null) {
+                            for (const secureProp of layer.properties.secure) {
+                                lodash.set(obj[layer.path], secureProp, Config.SECURE_VALUE);
+                            }
+                        }
                     }
                 }
             } else {
-                obj = config.properties;
+                obj = config.maskedProperties;
                 if (property != null)
                     obj = (config.properties as any)[property];
             }

--- a/packages/imperative/src/config/cmd/profiles/profiles.handler.ts
+++ b/packages/imperative/src/config/cmd/profiles/profiles.handler.ts
@@ -29,6 +29,7 @@ export default class ProfilesHandler implements ICommandHandler {
         const config = ImperativeConfig.instance.config;
         const paths: string[] = [];
         this.build(config.properties.profiles, "", paths);
+        params.response.data.setObj(paths);
         params.response.format.output({
             format: "list",
             output: paths

--- a/packages/imperative/src/config/cmd/schema/schema.handler.ts
+++ b/packages/imperative/src/config/cmd/schema/schema.handler.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
+import { ICommandHandler, ICommandProfileTypeConfiguration, IHandlerParameters } from "../../../../../cmd";
 import { Config, ConfigSchema } from "../../../../../config";
 import { ImperativeConfig } from "../../../../../utilities";
 
@@ -25,7 +25,15 @@ export default class SchemaHandler implements ICommandHandler {
      * @throws {ImperativeError}
      */
     public async process(params: IHandlerParameters): Promise<void> {
-        const schema = ConfigSchema.buildSchema(ImperativeConfig.instance.loadedConfig.profiles);
+        let profileConfigs: ICommandProfileTypeConfiguration[];
+        try {
+            profileConfigs = ImperativeConfig.instance.loadedConfig.profiles;
+        } catch (err) {
+            params.response.console.error("Failed to load profile schemas");
+            return;
+        }
+        const schema = ConfigSchema.buildSchema(profileConfigs);
+        params.response.data.setObj(schema);
         params.response.console.log(JSON.stringify(schema, null, Config.INDENT));
     }
 }


### PR DESCRIPTION
Fixes #505. The output of "config list" command now replaces any secure values with the text `(secure value)`.

Also fixes an issue where optional Keytar dependency isn't loaded, when new config JSON file doesn't exist.

Added unit tests that were missing for "config list", "config profiles", and "config schema" command handlers.