### PR TITLE
Don't require "config" to be initialized outside of CLI-only code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed error when Imperative APIs are called and "config" property of ImperativeConfig is not initialized. [#533](https://github.com/zowe/imperative/issues/533)
+
 ## `5.0.0-next.202101281717`
 
 - Enhancement: Added new config API intended to replace the profiles API, and new "config" command group to manage config JSON files. The new API makes it easier for users to create, share, and switch between profile configurations.

--- a/packages/cmd/src/profiles/CommandProfileLoader.ts
+++ b/packages/cmd/src/profiles/CommandProfileLoader.ts
@@ -110,7 +110,7 @@ export class CommandProfileLoader {
         const profileMetaMap: Map<string, IProfileLoaded[]> = new Map<string, IProfileLoaded[]>();
 
         // do not load old school profiles if we are in team-config mode
-        if (ImperativeConfig.instance.config.exists) {
+        if (ImperativeConfig.instance.config?.exists) {
             return new CommandProfiles(profileMap, profileMetaMap);
         }
 

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -35,7 +35,7 @@ export class OverridesLoader {
       packageJson: any
   ): Promise<void> {
     // Initialize the Credential Manager
-    await (ImperativeConfig.instance.config.exists ? this.loadCredentialManager : this.loadCredentialManagerOld)(config, packageJson);
+    await (ImperativeConfig.instance.config?.exists ? this.loadCredentialManager : this.loadCredentialManagerOld)(config, packageJson);
   }
 
   /**

--- a/packages/imperative/src/plugins/utilities/PMFConstants.ts
+++ b/packages/imperative/src/plugins/utilities/PMFConstants.ts
@@ -113,7 +113,7 @@ export class PMFConstants {
         this.IMPERATIVE_PKG_NAME = ImperativeConfig.instance.imperativePackageName;
         this.PMF_ROOT = join(ImperativeConfig.instance.cliHome, "plugins");
         this.PLUGIN_JSON = join(this.PMF_ROOT, "plugins.json");
-        this.PLUGIN_USING_CONFIG = ImperativeConfig.instance.config.exists;
+        this.PLUGIN_USING_CONFIG = ImperativeConfig.instance.config?.exists;
         this.PLUGIN_INSTALL_LOCATION = join(this.PMF_ROOT, "installed");
 
         // Windows format is <prefix>/node_modules

--- a/packages/profiles/src/utils/ProfileIO.ts
+++ b/packages/profiles/src/utils/ProfileIO.ts
@@ -310,7 +310,7 @@ export class ProfileIO {
      * message as part of our crash.
      */
     private static crashInTeamConfigMode() {
-        if (ImperativeConfig.instance.config.exists) {
+        if (ImperativeConfig.instance.config?.exists) {
             try {
                 throw new Error("A Zowe V1 profile operation was attempted with a Zowe V2 configuration in use.");
             } catch (err) {


### PR DESCRIPTION
Fixes "Unable to perform profile I/O operations in Zowe SDKs" (#533)