### PR TITLE
Fix incorrect formatting of code blocks in web help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
+
 - BugFix: Fixed incorrect formatting of code blocks in web help. [#535](https://github.com/zowe/imperative/issues/535)
 
 ## `4.10.2`
+
 - Fix vulnerabilities by updating marked
 
 ## `4.10.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+- BugFix: Fixed incorrect formatting of code blocks in web help. [#535](https://github.com/zowe/imperative/issues/535)
+
 ## `4.10.2`
 - Fix vulnerabilities by updating marked
 

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -324,8 +324,9 @@ export class WebHelpGenerator {
         htmlContent = htmlContent.replace(/(%5C|\\)(?=.+?<\/a>)/g, "");
 
         // Add Copy buttons after command line examples
-        htmlContent = htmlContent.replace(/<code>\$\s*(.*?)<\/code>/g,
-            "<code>$1</code> <button class=\"btn-copy no-print\" data-balloon-pos=\"right\" data-clipboard-text=\"$1\">Copy</button>");
+        htmlContent = htmlContent.replace(/<pre><code>\*\s`\$\s*(.*?)`<\/code><\/pre>/g,
+            `<ul>\n<li><code>$1</code> <button class="btn-copy no-print" data-balloon-pos="right" ` +
+            `data-clipboard-text="$1">Copy</button></li>\n</ul>`);
 
         // Sanitize references to user's home directory
         if (this.sanitizeHomeDir) {

--- a/packages/utilities/__tests__/CliUtils.test.ts
+++ b/packages/utilities/__tests__/CliUtils.test.ts
@@ -137,9 +137,10 @@ describe("CliUtils", () => {
         it("should sleep for 1 second", async() => {
             const startTime = Date.now();
             const oneSec = 1000;
+            const minElapsedTime = 990; // sometimes the OS returns in slightly less than one second
             await CliUtils.sleep(oneSec);
             const timeDiff = Date.now() - startTime;
-            expect(timeDiff).toBeGreaterThanOrEqual(oneSec);
+            expect(timeDiff).toBeGreaterThanOrEqual(minElapsedTime);
         });
     });
 


### PR DESCRIPTION
Fixes #535. The issue seems to have been caused by a breaking change in the `marked` package which was updated to fix vulnerabilities in #515.