### PR TITLE
Update changelog in pipeline before deploy stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,16 +152,18 @@ node('zowe-jenkins-agent-dind') {
         header: "## Recent Changes"
     )
 
-    // Deploys the application if on a protected branch. Give the version input
-    // 30 minutes before an auto timeout approve.
-    pipeline.deploy(
-        versionArguments: [timeout: [time: 30, unit: 'MINUTES']]
+    // Perform the versioning email mechanism
+    pipeline.version(
+        timeout: [time: 30, unit: 'MINUTES'],
+        updateChangelogArgs: [
+            file: "CHANGELOG.md",
+            header: "## Recent Changes"
+        ]
     )
 
-    pipeline.updateChangelog(
-        file: "CHANGELOG.md",
-        header: "## Recent Changes"
-    )
+    // Deploys the application if on a protected branch. Give the version input
+    // 30 minutes before an auto timeout approve.
+    pipeline.deploy()
 
     def logLocation = "__tests__/__results__"
     // Once called, no stages can be added and all added stages will be executed. On completion


### PR DESCRIPTION
Version number in changelog should be updated before we deploy a new package 😸 This fix was made in the CLI repo a while ago, but we forgot to port it to Imperative 😿 