### PR TITLE
Prof info restore env

### DIFF
--- a/packages/config/__tests__/ProfileInfo.test.ts
+++ b/packages/config/__tests__/ProfileInfo.test.ts
@@ -26,9 +26,9 @@ describe("ProfileInfo tests", () => {
 
     const tsoProfName = "tsoProfName";
     const tsoJsonLoc = "LPAR1." + tsoProfName;
-    const testDir = __dirname + "/__resources__";
-    const teamProjDir = testDir + "/" + testAppNm + "_team_config_proj";
-    const homeDirPath = testDir + "/" + testAppNm + "_home";
+    const testDir = path.join(__dirname,  "__resources__");
+    const teamProjDir = path.join(testDir, testAppNm + "_team_config_proj");
+    const homeDirPath = path.join(testDir, testAppNm + "_home");
     let origDir: string;
 
     beforeAll(() => {
@@ -132,8 +132,8 @@ describe("ProfileInfo tests", () => {
                 expect(profAttrs.profLoc.locType).not.toBeNull();
 
                 const retrievedOsLoc = path.normalize(profAttrs.profLoc.osLoc);
-                const expectedOsLoc = path.normalize(homeDirPath + "/profiles/" +
-                    desiredProfType + "/" + profAttrs.profName + ".yaml"
+                const expectedOsLoc = path.join(homeDirPath, "profiles",
+                    desiredProfType, profAttrs.profName + ".yaml"
                 );
                 expect(retrievedOsLoc).toBe(expectedOsLoc);
 

--- a/packages/config/__tests__/ProfileInfo.test.ts
+++ b/packages/config/__tests__/ProfileInfo.test.ts
@@ -98,9 +98,7 @@ describe("ProfileInfo tests", () => {
                 expect(profAttrs.profLoc.locType).not.toBeNull();
 
                 const retrievedOsLoc = path.normalize(profAttrs.profLoc.osLoc);
-                const expectedOsLoc = path.normalize(teamProjDir + "/" +
-                    testAppNm + ".config.json"
-                );
+                const expectedOsLoc = path.join(teamProjDir, testAppNm + ".config.json");
                 expect(retrievedOsLoc).toBe(expectedOsLoc);
 
                 expect(profAttrs.profLoc.jsonLoc).toBe(tsoJsonLoc);

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -216,7 +216,7 @@ export class ProfileInfo {
                 defaultProfile.profName = loadedProfile.name;
                 defaultProfile.profLoc = {
                     locType: ProfLocType.OLD_PROFILE,
-                    osLoc: nodeJsPath.resolve(profRootDir + "/" + profileType + "/" +
+                    osLoc: nodeJsPath.join(profRootDir, profileType,
                         loadedProfile.name + AbstractProfileManager.PROFILE_EXTENSION)
                 }
             } catch (err) {

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -17,6 +17,7 @@ import { IProfAttrs } from "./doc/IProfAttrs";
 import { IProfArgAttrs } from "./doc/IProfArgAttrs";
 import { IProfLoc, ProfLocType } from "./doc/IProfLoc";
 import { IProfMergedArg } from "./doc/IProfMergedArg";
+import { IProfOpts } from "./doc/IProfOpts";
 
 // for team config functions
 import { Config } from "./config";
@@ -105,6 +106,7 @@ export class ProfileInfo {
     private mUsingTeamConfig: boolean = false;
     private mAppName: string = null;
     private mImpLogger: Logger = null;
+    private mOverrideWithEnv: boolean = false;
 
     // _______________________________________________________________________
     /**
@@ -114,8 +116,15 @@ export class ProfileInfo {
      *        The name of the application (like "zowe" in zowe.config.json)
      *        whose configuration you want to access.
      */
-    public constructor(appName: string) {
+    public constructor(appName: string, profInfoOpts?: IProfOpts) {
         this.mAppName = appName;
+
+        // use any supplied environment override setting
+        if (profInfoOpts?.overrideWithEnv) {
+            this.mOverrideWithEnv = profInfoOpts.overrideWithEnv;
+        }
+
+        // do enough Imperative stuff to let imperative utilities work
         this.initImpUtils();
     }
 
@@ -250,6 +259,8 @@ export class ProfileInfo {
      * - For a team configuration, both the base profile values and the
      *   service profile values will be overridden with values from a
      *   zowe.config.user.json file (if it exists).
+     * - An environment variable for that argument (if environment overrides
+     *   are enabled).
      *
      * @param profile
      *        The profile whose arguments are to be merged.
@@ -257,7 +268,8 @@ export class ProfileInfo {
      * @returns An object that contains an array of known profile argument
      *          values and an array of required profile arguments which
      *          have no value assigned. Either of the two arrays could be
-     *          of zero length, depending on the user's configuration
+     *          of zero length, depending on the user's configuration and
+     *          environment.
      *
      *          We will return null if the profile does not exist
      *          in the current Zowe configuration.
@@ -268,6 +280,9 @@ export class ProfileInfo {
         // todo: Actually implement something
         const implementSomething: any = null;
         mergedArgs = implementSomething;
+
+        // overwrite with any values found in environment
+        this.overrideWithEnv(mergedArgs);
 
         return mergedArgs;
     }
@@ -292,6 +307,9 @@ export class ProfileInfo {
         // todo: Actually implement something
         const implementSomething: any = null;
         mergedArgs = implementSomething;
+
+        // overwrite with any values found in environment
+        this.overrideWithEnv(mergedArgs);
 
         return mergedArgs;
     }
@@ -333,7 +351,7 @@ export class ProfileInfo {
      * Ensures that ProfileInfo.readProfilesFromDisk() is called before
      * an operation that requires that information.
      */
-    private ensureReadFromDisk()  {
+    private ensureReadFromDisk() {
         if (this.mLoadedConfig == null) {
             throw new ImperativeError({
                 msg: "You must first call ProfileInfo.readProfilesFromDisk()."
@@ -373,5 +391,27 @@ export class ProfileInfo {
         );
         Logger.initLogger(loggingConfig);
         this.mImpLogger = Logger.getImperativeLogger();
+    }
+
+    // _______________________________________________________________________
+    /**
+     * Override values in a merged argument object with values found in
+     * environment variables. The choice to override enviroment variables is
+     * controlled by an option on the ProfileInfo constructor.
+     *
+     * @param mergedArgs
+     *      On input, this must be an object containing merged arguments
+     *      obtained from configuration settings. This function will override
+     *      values in mergedArgs.knownArgs with values found in environment
+     *      variables. It will also move arguments from mergedArgs.missingArgs
+     *      into mergedArgs.knownArgs if a value is found in an environment
+     *      variable for any missingArgs.
+     */
+    private overrideWithEnv(mergedArgs: IProfMergedArg) {
+        if (this.mOverrideWithEnv === false) {
+            return;
+        }
+
+        // todo: get values from environment variables
     }
 }

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -115,6 +115,9 @@ export class ProfileInfo {
      * @param appName
      *        The name of the application (like "zowe" in zowe.config.json)
      *        whose configuration you want to access.
+     *
+     * @param profInfoOpts
+     *        Options that will control the behavior of ProfileInfo.
      */
     public constructor(appName: string, profInfoOpts?: IProfOpts) {
         this.mAppName = appName;

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -20,7 +20,7 @@ import { IProfMergedArg } from "./doc/IProfMergedArg";
 import { IProfOpts } from "./doc/IProfOpts";
 
 // for team config functions
-import { Config } from "./config";
+import { Config } from "./Config";
 import { IConfigOpts } from "./doc/IConfigOpts";
 import { IConfigLayer } from "./doc/IConfigLayer";
 

--- a/packages/config/src/doc/IProfAttrs.ts
+++ b/packages/config/src/doc/IProfAttrs.ts
@@ -26,8 +26,9 @@ export interface IProfAttrs {
 
     /**
      * Location of this profile.
-     * profNmLoc.ProfLocType can never be ProfLocType.DEFAULT,
-     * because this is the location of a profile, not an argument value.
+     * profNmLoc.ProfLocType can never be ProfLocType.ENV or
+     * ProfLocType.DEFAULT, because this is the location of a profile,
+     * not an argument value.
      */
     profLoc: IProfLoc;
 }

--- a/packages/config/src/doc/IProfLoc.ts
+++ b/packages/config/src/doc/IProfLoc.ts
@@ -11,13 +11,14 @@
 
 /**
  * This enum represents the type of location for a property.
- * Note that properties with location type of DEFAULT
+ * Note that properties with location types of ENV and DEFAULT
  * cannot be stored back to disk. Thus the consumer app must
  * make its own decision about where to store the property.
  */
 export enum ProfLocType {
     OLD_PROFILE = 0,    // an old-school profile
     TEAM_CONFIG,        // a team configuration
+    ENV,                // an environment variable
     DEFAULT             // the default value from a profile definition
 };
 
@@ -28,11 +29,13 @@ export interface IProfLoc {
      */
     locType:    ProfLocType.OLD_PROFILE |
                 ProfLocType.TEAM_CONFIG |
+                ProfLocType.ENV |
                 ProfLocType.DEFAULT;
 
     /**
      * For OLD_PROFILE and TEAM_CONFIG, this is the path to
      * the file on disk which contains the argument.
+     * For ENV, this is the name of the environment variable.
      * This is not used for DEFAULT.
      */
     osLoc?: string;
@@ -41,9 +44,9 @@ export interface IProfLoc {
      * For SOURCE_TEAM_CONFIG, this is the dotted path into
      * the JSON configuration object for the profile.
      * This property is not used (undefined) for SOURCE_OLD_PROFILE,
-     * because the old-shool profiles use a simple name/value pair like:
+     * because the old-school profiles use a simple name/value pair like:
      *      ArgumentName: value
-     * This property is also not used for DEFAULT.
+     * This property is also not used for ENV or DEFAULT.
      */
     jsonLoc?: string;
 };

--- a/packages/config/src/doc/IProfOpts.ts
+++ b/packages/config/src/doc/IProfOpts.ts
@@ -1,0 +1,23 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * Options that will affect the behavior of the ProfileInfo class.
+ * They are supplied on the ProfileInfo constructor.
+ */
+export interface IProfOpts {
+    /**
+     * Indicates if environment variables should override values
+     * stored in Zowe configuration profiles on disk.
+     * The default is false.
+     */
+    overrideWithEnv?: boolean;
+}


### PR DESCRIPTION
Restores the skeleton to implement overriding values with environment variables.

This is a small change with low impact. I will merge this into profInfo-for-next at close of business Fri Mar 12, unless objections are raised.