### PR TITLE
Added headers[] option to TextUtils.getTable()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## `Recent Changes`
+
+- Enhancement: Added headers[] option to TextUtils.getTable(). [#369](https://github.com/zowe/imperative/issues/369)
+
 ## `4.12.0`
 
 - Enhancement: Added decompression support for REST responses with Content-Encoding `gzip`, `deflate`, or `br`. [#318](https://github.com/zowe/imperative/issues/318)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## `Recent Changes`
+## Recent Changes
 
 - Enhancement: Added headers[] option to TextUtils.getTable(). [#369](https://github.com/zowe/imperative/issues/369)
 

--- a/__tests__/src/packages/utils/TextUtils.test.ts
+++ b/__tests__/src/packages/utils/TextUtils.test.ts
@@ -9,6 +9,12 @@
 *
 */
 
+const tableObjects = [
+    { header1: "value1", 2: "value2", header3: "value3" },
+    { header1: "value1", 2: "value2", header3: "value3" },
+    { header1: "value1", 2: "value2", header3: "value3" },
+]
+
 import { TextUtils } from "../../../../packages/utilities";
 
 describe("TextUtils", () => {
@@ -26,4 +32,18 @@ describe("TextUtils", () => {
         expect(text).toMatchSnapshot();
     });
 
+    it("should grab headers from object properties", () => {
+        TextUtils.chalk.level = 0; // turn off color
+        const color = "yellow"; // any color
+        const table = TextUtils.getTable(tableObjects, color);
+        expect(table).toMatchSnapshot();
+    });
+
+    it("should accept headers from user", () => {
+        TextUtils.chalk.level = 0; // turn off color
+        const color = "yellow"; // any color
+        const headers = ["header1", "2", "header3"];
+        const table = TextUtils.getTable(tableObjects, color, Infinity, true, false, false, headers);
+        expect(table).toMatchSnapshot();
+    });
 });

--- a/__tests__/src/packages/utils/__snapshots__/TextUtils.test.ts.snap
+++ b/__tests__/src/packages/utils/__snapshots__/TextUtils.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextUtils should accept headers from user 1`] = `
+"header1 2      header3
+value1  value2 value3 
+value1  value2 value3 
+value1  value2 value3 "
+`;
+
 exports[`TextUtils should be able to color text red 1`] = `"[31mhighlighting with chalk[39m hello"`;
 
 exports[`TextUtils should be able to color text yellow 1`] = `"[33mhighlighting with chalk[39m hello"`;
+
+exports[`TextUtils should grab headers from object properties 1`] = `
+"2      header1 header3
+value2 value1  value3 
+value2 value1  value3 
+value2 value1  value3 "
+`;

--- a/packages/utilities/src/TextUtils.ts
+++ b/packages/utilities/src/TextUtils.ts
@@ -156,18 +156,12 @@ export class TextUtils {
      */
     public static getTable(objects: any[], primaryHighlightColor: string,
                            maxColumnWidth?: number, includeHeader: boolean = true, includeBorders: boolean = false,
-                           hardWrap: boolean = false, headers: string[] = []): string {
+                           hardWrap: boolean = false, headers?: string[]): string {
         const Table = require("cli-table3");
-        // for every property of every object in the array,
-        // make a header for the table
-        if (headers.length === 0) {
-            for (const obj of objects) {
-                for (const key of Object.keys(obj)) {
-                    if (headers.indexOf(key) === -1) {
-                        headers.push(key);
-                    }
-                }
-            }
+
+        // if the user did not specify which headers to use, build them from the object array
+        if (!headers) {
+            headers = this.buildHeaders(objects);
         }
         if (isNullOrUndefined(maxColumnWidth)) {
             maxColumnWidth = this.getRecommendedWidth() / headers.length;
@@ -209,6 +203,25 @@ export class TextUtils {
             table.push(row);
         }
         return table.toString();
+    }
+
+    /**
+     *  Build table headers from an array of key-value objects
+     * @param {any[]} objects - the key-value objects from which to build headers
+     * @returns {string} the headers array
+     */
+    public static buildHeaders(objects: any[]): string[] {
+        const headers = [];
+        // for every property of every object in the array,
+        // make a header for the table
+        for (const obj of objects) {
+            for (const key of Object.keys(obj)) {
+                if (headers.indexOf(key) === -1) {
+                    headers.push(key);
+                }
+            }
+        }
+        return headers;
     }
 
     /**

--- a/packages/utilities/src/TextUtils.ts
+++ b/packages/utilities/src/TextUtils.ts
@@ -150,19 +150,22 @@ export class TextUtils {
      * @param {boolean}  includeHeader - should the table include a header of the field names of the objects
      * @param includeBorders -  should the table have borders between the cells?
      * @param hardWrap - hard wrap the text within the width of the table cells (defaults to false)
+     * @param headers - specify which headers in which order to display. if omitted, loops through the rows
+     *        and adds object properties as headers in their enumeration order
      * @returns {string} the rendered table
      */
     public static getTable(objects: any[], primaryHighlightColor: string,
                            maxColumnWidth?: number, includeHeader: boolean = true, includeBorders: boolean = false,
-                           hardWrap: boolean = false): string {
+                           hardWrap: boolean = false, headers: string[] = []): string {
         const Table = require("cli-table3");
-        const headers = [];
         // for every property of every object in the array,
         // make a header for the table
-        for (const obj of objects) {
-            for (const key of Object.keys(obj)) {
-                if (headers.indexOf(key) === -1) {
-                    headers.push(key);
+        if (headers.length === 0) {
+            for (const obj of objects) {
+                for (const key of Object.keys(obj)) {
+                    if (headers.indexOf(key) === -1) {
+                        headers.push(key);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added a headers[] parameter to TextUtils.getTable(). This gives the user more control over which headers to display, and in what order. Closes #369.

As a side note, TestUtils.getTable now has 7 parameters, 5 of which are optional. It might be a good idea to move to an ITableOptions object as a parameter. I held off on this for now, as I believe this would be a breaking change, but we might want to consider this for the next major version.

Signed-off-by: mheuzey <michael.heuzey@gmail.com>