### PR TITLE
Update mProgressApi and endBar to prevent output duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Print a subset of the `stdout` and `stderr` buffers when calling `mProgressApi`'s `endBar()` to prevent duplication of output.
+
 ## `4.12.0`
 
 - Enhancement: Added decompression support for REST responses with Content-Encoding `gzip`, `deflate`, or `br`. [#318](https://github.com/zowe/imperative/issues/318)

--- a/packages/cmd/__tests__/response/CommandResponse.test.ts
+++ b/packages/cmd/__tests__/response/CommandResponse.test.ts
@@ -228,7 +228,7 @@ describe("Command Response", () => {
         process.stderr.write = ORIGINAL_STDERR_WRITE;
 
         expect(stdoutMsg).toMatchSnapshot();
-        expect(stderrMsg).toMatchSnapshot();
+        expect(stderrMsg).toMatch(new RegExp(`^Message before progress bar$\n^.*Message during progress bar$\n^Message after progress bar`, 'm'));
         expect(response.buildJsonResponse().stdout.toString()).toEqual(beforeMessage + "\n" + duringMessage + "\n" + afterMessage + "\n");
         expect(response.buildJsonResponse().stderr.toString()).toEqual(beforeMessage + "\n" + duringMessage + "\n" + afterMessage + "\n");
     })

--- a/packages/cmd/__tests__/response/CommandResponse.test.ts
+++ b/packages/cmd/__tests__/response/CommandResponse.test.ts
@@ -195,6 +195,44 @@ describe("Command Response", () => {
             expect((response as any).progressBarInterval).toBeUndefined();
         });
 
+
+    it("should not duplicate output when calling endBar", () => {
+        let stdoutMsg: string = "";
+        let stderrMsg: string = "";
+        const response = new CommandResponse({responseFormat: "default"});
+        process.stdout.write = jest.fn((data) => {
+            stdoutMsg += data;
+        });
+        process.stderr.write = jest.fn((data) => {
+            stderrMsg += data;
+        });
+        const task = {
+            percentComplete: 0,
+            statusMessage: "Test Task",
+            stageName: TaskStage.IN_PROGRESS
+        }
+        const beforeMessage = "Message before progress bar";
+        const duringMessage = "Message during progress bar";
+        const afterMessage = "Message after progress bar";
+
+        response.console.log(beforeMessage);
+        response.console.error(beforeMessage);
+        response.progress.startBar({task});
+        response.console.log(duringMessage);
+        response.console.error(duringMessage);
+        response.progress.endBar();
+        response.console.log(afterMessage);
+        response.console.error(afterMessage);
+
+        process.stdout.write = ORIGINAL_STDOUT_WRITE;
+        process.stderr.write = ORIGINAL_STDERR_WRITE;
+
+        expect(stdoutMsg).toMatchSnapshot();
+        expect(stderrMsg).toMatchSnapshot();
+        expect(response.buildJsonResponse().stdout.toString()).toEqual(beforeMessage + "\n" + duringMessage + "\n" + afterMessage + "\n");
+        expect(response.buildJsonResponse().stderr.toString()).toEqual(beforeMessage + "\n" + duringMessage + "\n" + afterMessage + "\n");
+    })
+
     it("should allow us to create an instance", () => {
         const response = new CommandResponse();
     });

--- a/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
+++ b/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
@@ -999,6 +999,20 @@ Object {
 }
 `;
 
+exports[`Command Response should not duplicate output when calling endBar 1`] = `
+"Message before progress bar
+Message during progress bar
+Message after progress bar
+"
+`;
+
+exports[`Command Response should not duplicate output when calling endBar 2`] = `
+"Message before progress bar
+[1G ██████████| 100%    | Complete[0K[2K[1G[2K[1GMessage during progress bar
+Message after progress bar
+"
+`;
+
 exports[`Command Response should not write an error header to stderr (but still buffer) if silent mode is enabled 1`] = `
 Object {
   "data": Object {},

--- a/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
+++ b/packages/cmd/__tests__/response/__snapshots__/CommandResponse.test.ts.snap
@@ -1006,13 +1006,6 @@ Message after progress bar
 "
 `;
 
-exports[`Command Response should not duplicate output when calling endBar 2`] = `
-"Message before progress bar
-[1G ██████████| 100%    | Complete[0K[2K[1G[2K[1GMessage during progress bar
-Message after progress bar
-"
-`;
-
 exports[`Command Response should not write an error header to stderr (but still buffer) if silent mode is enabled 1`] = `
 Object {
   "data": Object {},


### PR DESCRIPTION
When calling `mProgressApi`'s `endBar()`, the contents of the `stdout` and `stderr` buffers are printed to the console. Before now, calls to `endBar()` would output duplicate data on the console because the buffers are never cleared when their contents are printed to the console. This PR rectifies this behavior by only printing a subset of the buffer that was written after the progress bar started to console.