### PR TITLE
ProfInfoErr class into profInfo-for-next

### DIFF
--- a/packages/config/__tests__/ProfInfoErr.test.ts
+++ b/packages/config/__tests__/ProfInfoErr.test.ts
@@ -1,0 +1,84 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ProfInfoErr } from "../src/ProfInfoErr";
+
+describe("ProfInfoErr tests", () => {
+    it("should throw error with only impErrDetails", async () => {
+        const myMessage = "Only impErrDetails";
+        try {
+            throw new ProfInfoErr({
+                errorCode: ProfInfoErr.CANT_GET_SCHEMA_URL,
+                msg: myMessage,
+            });
+        } catch (error) {
+            expect(error instanceof ProfInfoErr).toEqual(true);
+            expect(error.name).toEqual("ProfInfoErr");
+            expect(error.errorCode).toEqual(ProfInfoErr.CANT_GET_SCHEMA_URL);
+            expect(error.message).toContain(myMessage);
+        }
+    });
+
+    it("should throw error with impErrDetails and profErrProps", async () => {
+        const myMessage = "impErrDetails and profErrProps";
+        const badStuff = ["bad item 1", "bad item 2", "bad item 3"];
+        try {
+            throw new ProfInfoErr(
+                {
+                    errorCode: ProfInfoErr.INVALID_PROF_LOC_TYPE,
+                    msg: myMessage,
+                },
+                {
+                    itemsInError: badStuff
+                }
+            );
+        } catch (error) {
+            expect(error instanceof ProfInfoErr).toEqual(true);
+            expect(error.name).toEqual("ProfInfoErr");
+            expect(error.errorCode).toEqual(ProfInfoErr.INVALID_PROF_LOC_TYPE);
+            expect(error.message).toContain(myMessage);
+            expect(error.itemsInError.length).toEqual(badStuff.length);
+            for (let index = 0;  index < error.itemsInError.length; index++) {
+                expect(error.itemsInError[index]).toEqual(badStuff[index]);
+            }
+        }
+    });
+
+    it("should throw error with impErrDetails, profErrProps, and impErrParms", async () => {
+        const myMessage = "impErrDetails, profErrProps, and impErrParms";
+        const prependErrText = "Stuff before error message";
+        const badStuff = ["bad item 1", "bad item 2", "bad item 3"];
+        try {
+            throw new ProfInfoErr(
+                {
+                    errorCode: ProfInfoErr.INVALID_PROF_LOC_TYPE,
+                    msg: myMessage,
+                },
+                {
+                    itemsInError: badStuff
+                },
+                {
+                    tag:prependErrText
+                }
+            );
+        } catch (error) {
+            expect(error instanceof ProfInfoErr).toEqual(true);
+            expect(error.name).toEqual("ProfInfoErr");
+            expect(error.errorCode).toEqual(ProfInfoErr.INVALID_PROF_LOC_TYPE);
+            expect(error.message).toContain(myMessage);
+            expect(error.itemsInError.length).toEqual(badStuff.length);
+            for (let index = 0;  index < error.itemsInError.length; index++) {
+                expect(error.itemsInError[index]).toEqual(badStuff[index]);
+            }
+            expect(error.message).toEqual(prependErrText + ": " + myMessage);
+        }
+    });
+});

--- a/packages/config/__tests__/ProfInfoErr.test.ts
+++ b/packages/config/__tests__/ProfInfoErr.test.ts
@@ -17,7 +17,7 @@ describe("ProfInfoErr tests", () => {
         try {
             throw new ProfInfoErr({
                 errorCode: ProfInfoErr.CANT_GET_SCHEMA_URL,
-                msg: myMessage,
+                msg: myMessage
             });
         } catch (error) {
             expect(error instanceof ProfInfoErr).toEqual(true);
@@ -27,14 +27,14 @@ describe("ProfInfoErr tests", () => {
         }
     });
 
-    it("should throw error with impErrDetails and profErrProps", async () => {
-        const myMessage = "impErrDetails and profErrProps";
+    it("should throw error with impErrDetails and profErrParms", async () => {
+        const myMessage = "impErrDetails and profErrParms";
         const badStuff = ["bad item 1", "bad item 2", "bad item 3"];
         try {
             throw new ProfInfoErr(
                 {
                     errorCode: ProfInfoErr.INVALID_PROF_LOC_TYPE,
-                    msg: myMessage,
+                    msg: myMessage
                 },
                 {
                     itemsInError: badStuff
@@ -52,20 +52,18 @@ describe("ProfInfoErr tests", () => {
         }
     });
 
-    it("should throw error with impErrDetails, profErrProps, and impErrParms", async () => {
-        const myMessage = "impErrDetails, profErrProps, and impErrParms";
+    it("should throw error with impErrDetails, profErrParms, and impErrParms", async () => {
+        const myMessage = "impErrDetails, profErrParms, and impErrParms";
         const prependErrText = "Stuff before error message";
         const badStuff = ["bad item 1", "bad item 2", "bad item 3"];
         try {
             throw new ProfInfoErr(
                 {
                     errorCode: ProfInfoErr.INVALID_PROF_LOC_TYPE,
-                    msg: myMessage,
+                    msg: myMessage
                 },
                 {
-                    itemsInError: badStuff
-                },
-                {
+                    itemsInError: badStuff,
                     tag:prependErrText
                 }
             );

--- a/packages/config/__tests__/ProfileInfo.test.ts
+++ b/packages/config/__tests__/ProfileInfo.test.ts
@@ -13,7 +13,7 @@ import * as path from "path";
 import * as jsonfile from "jsonfile";
 import * as lodash from "lodash";
 import { ProfileInfo } from "../src/ProfileInfo";
-import { ImperativeError } from "../..";
+import { ProfInfoErr } from "../src/ProfInfoErr";
 import { Config } from "../src/Config";
 import { ProfLocType } from "../src/doc/IProfLoc";
 import { IProfileSchema, ProfileIO } from "../../profiles";
@@ -63,14 +63,16 @@ describe("ProfileInfo tests", () => {
         describe("readProfilesFromDisk", () => {
 
             it("should throw exception if readProfilesFromDisk not called: TeamConfig", async () => {
-                let impErr: ImperativeError;
+                let caughtErr: ProfInfoErr;
                 const profInfo = createNewProfInfo(teamProjDir);
                 try {
                     profInfo.getDefaultProfile("zosmf");
                 } catch (err) {
-                    impErr = err;
+                    expect(err instanceof ProfInfoErr).toBe(true);
+                    caughtErr = err;
                 }
-                expect(impErr.message).toContain(
+                expect(caughtErr.errorCode).toBe(ProfInfoErr.MUST_READ_FROM_DISK);
+                expect(caughtErr.message).toContain(
                     "You must first call ProfileInfo.readProfilesFromDisk()."
                 );
             });
@@ -330,10 +332,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     (profInfo as any).argTeamConfigLoc("doesNotExist", "fake");
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.PROP_NOT_IN_PROFILE);
                 expect(caughtError.message).toContain("Failed to find property fake in the profile doesNotExist");
             });
 
@@ -369,10 +373,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     profInfo.mergeArgsForProfile(profAttrs);
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.MISSING_REQ_PROP);
                 expect(caughtError.message).toContain("Missing required properties: protocol");
             });
 
@@ -412,10 +418,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     profInfo.mergeArgsForProfile(profAttrs);
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.LOAD_SCHEMA_FAILED);
                 expect(caughtError.message).toContain("Failed to load schema for profile type zosmf");
             });
         });
@@ -455,10 +463,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     (profInfo as any).loadAllSchemas();
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.CANT_GET_SCHEMA_URL);
                 expect(caughtError.message).toContain("Failed to load schema for config file");
                 expect(caughtError.message).toContain("web URLs are not supported by ProfileInfo API");
             });
@@ -474,10 +484,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     (profInfo as any).loadAllSchemas();
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.LOAD_SCHEMA_FAILED);
                 expect(caughtError.message).toContain("Failed to load schema for config file");
                 expect(caughtError.message).toContain("invalid schema file");
             });
@@ -744,10 +756,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     profInfo.mergeArgsForProfile(profAttrs);
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.MISSING_REQ_PROP);
                 expect(caughtError.message).toContain("Missing required properties: protocol");
             });
 
@@ -782,10 +796,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     profInfo.mergeArgsForProfile(profAttrs);
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.LOAD_SCHEMA_FAILED);
                 expect(caughtError.message).toContain("Failed to load schema for profile type zosmf");
             });
         });
@@ -825,10 +841,12 @@ describe("ProfileInfo tests", () => {
                 try {
                     (profInfo as any).loadAllSchemas();
                 } catch (error) {
+                    expect(error instanceof ProfInfoErr).toBe(true);
                     caughtError = error;
                 }
 
                 expect(caughtError).toBeDefined();
+                expect(caughtError.errorCode).toBe(ProfInfoErr.LOAD_SCHEMA_FAILED);
                 expect(caughtError.message).toContain("Failed to load schema for profile type");
                 expect(caughtError.message).toContain("invalid meta file");
             });
@@ -848,10 +866,12 @@ describe("ProfileInfo tests", () => {
                     profLoc: { locType: ProfLocType.DEFAULT }
                 });
             } catch (error) {
+                expect(error instanceof ProfInfoErr).toBe(true);
                 caughtError = error;
             }
 
             expect(caughtError).toBeDefined();
+            expect(caughtError.errorCode).toBe(ProfInfoErr.INVALID_PROF_LOC_TYPE);
             expect(caughtError.message).toContain("Invalid profile location type: DEFAULT");
         });
     });

--- a/packages/config/__tests__/ProfileInfo.test.ts
+++ b/packages/config/__tests__/ProfileInfo.test.ts
@@ -15,6 +15,7 @@ import * as lodash from "lodash";
 import { ProfileInfo } from "../src/ProfileInfo";
 import { ProfInfoErr } from "../src/ProfInfoErr";
 import { Config } from "../src/Config";
+import { IConfigOpts } from "../src/doc/IConfigOpts";
 import { ProfLocType } from "../src/doc/IProfLoc";
 import { IProfileSchema, ProfileIO } from "../../profiles";
 
@@ -85,7 +86,20 @@ describe("ProfileInfo tests", () => {
                 const teamConfig: Config = profInfo.getTeamConfig();
                 expect(teamConfig).not.toBeNull();
                 expect(teamConfig.exists).toBe(true);
+            });
 
+            it("should successfully read a team config from a starting directory", async () => {
+                // ensure that we are not in the team project directory
+                process.chdir(origDir);
+                const profInfo = new ProfileInfo(testAppNm);
+
+                const teamCfgOpts:IConfigOpts = { projectDir: teamProjDir };
+                await profInfo.readProfilesFromDisk(teamCfgOpts);
+
+                expect(profInfo.usingTeamConfig).toBe(true);
+                const teamConfig: Config = profInfo.getTeamConfig();
+                expect(teamConfig).not.toBeNull();
+                expect(teamConfig.exists).toBe(true);
             });
         });
 

--- a/packages/config/src/ProfInfoErr.ts
+++ b/packages/config/src/ProfInfoErr.ts
@@ -79,7 +79,11 @@ export class ProfInfoErr extends ImperativeError {
     ) {
         super(impErrDetails, profErrParms);
         this.name = "ProfInfoErr";
-        this.mItemsInError = profErrParms?.itemsInError;
+
+        // make a shallow copy of the itemsInError array
+        if (profErrParms) {
+            this.mItemsInError = [...profErrParms.itemsInError];
+        }
     }
 
     /**

--- a/packages/config/src/ProfInfoErr.ts
+++ b/packages/config/src/ProfInfoErr.ts
@@ -10,7 +10,9 @@
 */
 
 // for imperative operations
-import { ImperativeError } from "../../error";
+import { IProfInfoErr } from "./doc/IProfInfoErr";
+import { ImperativeError, IImperativeError } from "../../error";
+import { IImperativeErrorParms } from "../../error/src/doc/IImperativeErrorParms";
 
 /**
  * This class is the error exception mechanism for the ProfileInfo API.
@@ -63,20 +65,31 @@ export class ProfInfoErr extends ImperativeError {
     // _______________________________________________________________________
 
     /**
-     * This property is used when an error is returned that is related
-     * to a number of configuration items. For example, if a problem is
-     * identified that affects a subset of profiles, those affected
-     * profiles can be identified in mItemsInError. Our consuming can
-     * easily identify each affected profile by traversing mItemsInError.
+     * Construct the ProfInfoErr error object. It adds properties in
+     * IProfInfoErr to the existing properties of ImperativeError.
+     *
+     * @param impErrDetails
+     *        ImperativeError details and text (stack, messages, etc.)
+     *
+     * @param impErrParms
+     *        ImperativeError control parameters to indicate logging of node-report and more
      */
-    private mItemsInError: string[] = [];
-
-    public get itemsInError(): string[] {
-        return this.mItemsInError;
+    constructor(
+        impErrDetails: IImperativeError,
+        profErrProps?: IProfInfoErr,
+        impErrParms?: IImperativeErrorParms
+    ) {
+        super(impErrDetails, impErrParms);
+        this.name = "ProfInfoErr";
+        this.mProfErrProps = profErrProps;
     }
 
-    public set itemsInError(itemArray: string[]) {
-        // make a shallow copy of the supplied array
-        this.mItemsInError = [...itemArray];
+    /**
+     * Additional error properties, specific to ProfInfoErr.
+     */
+    private mProfErrProps: IProfInfoErr = {};
+
+    public get itemsInError(): string[] {
+        return this.mProfErrProps.itemsInError;
     }
 }

--- a/packages/config/src/ProfInfoErr.ts
+++ b/packages/config/src/ProfInfoErr.ts
@@ -1,0 +1,82 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+// for imperative operations
+import { ImperativeError } from "../../error";
+
+/**
+ * This class is the error exception mechanism for the ProfileInfo API.
+ * It is derived from ImperativeError. We use a separate class so that
+ * our consumer can check the type of error, and then rely on errorCode
+ * values that are unique to ProfInfoErr. ProfInfoErr will always
+ * populate the errorCode property. Our consumer can use the errorCode to
+ * determine if it should process partial results.
+ */
+export class ProfInfoErr extends ImperativeError {
+
+    // _______________________________________________________________________
+    // The following are the complete set of errorCodes for ProfInfoErr.
+
+    /**
+     * Unable to retrieve the schema from a URL reference.
+     * Currently, the ProfiInfo API does not attempt to retrieve a schema
+     * through a URL. A URL does work to provide intellisense in VSCode
+     * when editing a config file.
+     */
+    public static readonly CANT_GET_SCHEMA_URL: string = "CantGetSchemaUrl";
+
+    /**
+     * The specified type of profile location is invalid for the requested operation.
+     */
+    public static readonly INVALID_PROF_LOC_TYPE: string = "InvalidProfLocType";
+
+    /**
+     * Failed to load the schema for a specified type of profile.
+     */
+    public static readonly LOAD_SCHEMA_FAILED: string = "LoadSchemaFailed";
+
+    /**
+     * A required profile property was not assigned a value.
+     */
+    public static readonly MISSING_REQ_PROP: string = "MissingProp";
+
+    /**
+     * The ProfileInfo.readProfilesFromDisk function was not called before
+     * a function which requires that prerequisite.
+     */
+    public static readonly MUST_READ_FROM_DISK: string = "MustReadFromDisk";
+
+    /**
+     * A specified property that is expected to exist in a specified profile
+     * does not exist in that profile.
+     */
+    public static readonly PROP_NOT_IN_PROFILE: string = "PropNotInProfile";
+
+    // _______________________________________________________________________
+
+    /**
+     * This property is used when an error is returned that is related
+     * to a number of configuration items. For example, if a problem is
+     * identified that affects a subset of profiles, those affected
+     * profiles can be identified in mItemsInError. Our consuming can
+     * easily identify each affected profile by traversing mItemsInError.
+     */
+    private mItemsInError: string[] = [];
+
+    public get itemsInError(): string[] {
+        return this.mItemsInError;
+    }
+
+    public set itemsInError(itemArray: string[]) {
+        // make a shallow copy of the supplied array
+        this.mItemsInError = [...itemArray];
+    }
+}

--- a/packages/config/src/ProfInfoErr.ts
+++ b/packages/config/src/ProfInfoErr.ts
@@ -10,9 +10,8 @@
 */
 
 // for imperative operations
-import { IProfInfoErr } from "./doc/IProfInfoErr";
+import { IProfInfoErrParms } from "./doc/IProfInfoErrParms";
 import { ImperativeError, IImperativeError } from "../../error";
-import { IImperativeErrorParms } from "../../error/src/doc/IImperativeErrorParms";
 
 /**
  * This class is the error exception mechanism for the ProfileInfo API.
@@ -66,30 +65,29 @@ export class ProfInfoErr extends ImperativeError {
 
     /**
      * Construct the ProfInfoErr error object. It adds properties in
-     * IProfInfoErr to the existing properties of ImperativeError.
+     * IProfInfoErrParms to the existing properties of ImperativeError.
      *
      * @param impErrDetails
      *        ImperativeError details and text (stack, messages, etc.)
      *
-     * @param impErrParms
-     *        ImperativeError control parameters to indicate logging of node-report and more
+     * @param profErrParms
+     *        ProfInfoErr parms and ImperativeError control parameters.
      */
     constructor(
         impErrDetails: IImperativeError,
-        profErrProps?: IProfInfoErr,
-        impErrParms?: IImperativeErrorParms
+        profErrParms?: IProfInfoErrParms
     ) {
-        super(impErrDetails, impErrParms);
+        super(impErrDetails, profErrParms);
         this.name = "ProfInfoErr";
-        this.mProfErrProps = profErrProps;
+        this.mItemsInError = profErrParms?.itemsInError;
     }
 
     /**
      * Additional error properties, specific to ProfInfoErr.
      */
-    private mProfErrProps: IProfInfoErr = {};
+    private mItemsInError: string[] = [];
 
     public get itemsInError(): string[] {
-        return this.mProfErrProps.itemsInError;
+        return this.mItemsInError;
     }
 }

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -37,7 +37,6 @@ import { IProfileLoaded, IProfileSchema, ProfileIO } from "../../profiles";
 import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
 import { LoggingConfigurer } from "../../imperative/src/LoggingConfigurer";
 import { CliUtils, ImperativeConfig } from "../../utilities";
-import { ImperativeError } from "../../error";
 import { ImperativeExpect } from "../../expect";
 import { Logger } from "../../logger";
 

--- a/packages/config/src/doc/IProfInfoErr.ts
+++ b/packages/config/src/doc/IProfInfoErr.ts
@@ -1,0 +1,26 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+/**
+ * Options that will affect the behavior of the ProfileInfo class.
+ * They are supplied on the ProfileInfo constructor.
+ */
+export interface IProfInfoErr {
+
+    /**
+     * This property is used when an error is returned that is related
+     * to a number of configuration items. For example, if a problem is
+     * identified that affects a subset of profiles, those affected
+     * profiles can be identified in the itemsInError array. An app can
+     * easily identify each affected profile by traversing itemsInError.
+     */
+    itemsInError?: string[];
+}

--- a/packages/config/src/doc/IProfInfoErrParms.ts
+++ b/packages/config/src/doc/IProfInfoErrParms.ts
@@ -9,11 +9,13 @@
 *
 */
 
+import { IImperativeErrorParms } from "../../../error/src/doc/IImperativeErrorParms";
+
 /**
  * Options that will affect the behavior of the ProfileInfo class.
  * They are supplied on the ProfileInfo constructor.
  */
-export interface IProfInfoErr {
+export interface IProfInfoErrParms extends IImperativeErrorParms {
 
     /**
      * This property is used when an error is returned that is related


### PR DESCRIPTION
This PR adds the ProfInfoErr class.

The way that I envision ProfInfoErr being used is:
- All errors from the ProfileInfo class will throw a ProfInfoErr.
- We will always set the errorCode property for any error thrown in ProfileInfo.
- Consumers will test for "instanceof ProfInfoErr", and then test our errorCode.

The following two items work, but we could change them based on your review opinions.
1. The errorCode property is a string. I defined a constant for each known error, and chose to use a mnemonic phase as the value.

           MISSING_REQ_PROP: string = "MissingProp"

    We could choose smaller strings, maybe numbers? "1", "2", "3", etc. I know that our mainframe division likes IBM-style error codes (like IEB1234), but I hate them. I do not think that they are necessary in this context, and I like the mnemonic.

2. I added a property named itemsInError, which is an array of strings. It is not currently used anywhere. I added it to address the need that Andrew identified for listing multiple bad items with one thrown error. If that property does not work for the identified problem, it can be changed.