### PR TITLE
Fix callerlocation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Bugfix: Replaced `this` with `ImperativeConfig.instance` in `ImperativeConfig.getCallerFile()`. [#5](https://github.com/zowe/imperative/issues/5)
+
 ## `4.12.0`
 
 - Enhancement: Added decompression support for REST responses with Content-Encoding `gzip`, `deflate`, or `br`. [#318](https://github.com/zowe/imperative/issues/318)

--- a/packages/utilities/src/ImperativeConfig.ts
+++ b/packages/utilities/src/ImperativeConfig.ts
@@ -204,7 +204,7 @@ export class ImperativeConfig {
             return require(file);
         } catch (e) {
             e.message = "Could not locate the specified module through requiring directly, nor through " +
-                "searching the directories above " + this.callerLocation +
+                "searching the directories above " + ImperativeConfig.instance.callerLocation +
                 ". 'require()' error message: " + e.message +
                 " \n 'find-up' (directory search) error message:" + findupErr.message;
             throw new ImperativeError({msg: e.message});


### PR DESCRIPTION
I finally bumped into the error described in #5 and was able to test the fix.

Before:
```
[2021/03/27 21:03:73] [FATAL] [Imperative.js:214] { Error: An error was encountered attempting to load the specified configuration module. Cannot read property 'callerLocation' of undefined
```
After:
```
[2021/03/27 21:03:33] [FATAL] [Imperative.js:214] { Error: An error was encountered attempting to load the specified configuration module. Could not locate the specified module through requiring directly, nor through searching the directories above C:\Users\xxxxx\Documents\github\zowe\zowe-cli\lib\main.js. 'require()' error message: Cannot find module 'ssh2' 
```

As I mentioned in the issue, `ImperativeConfig.getCallerFile()` is being passed as a callback, but makes a reference to `this`. By changing `this` to `ImperativeConfig.instance`, it now functions correctly as a callback.

Fixes #5.