### PR TITLE
[next] Always create PLUGIN_JSON file if missing

### DIFF
--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -233,7 +233,8 @@ export class PluginManagementFacility {
      */
     public loadAllPluginCfgProps(): void {
         // Initialize the plugin.json file if needed
-        if (!existsSync(this.pmfConst.PLUGIN_JSON) && !this.pmfConst.PLUGIN_USING_CONFIG) {
+        // TODO Skip creation of PMF_ROOT directory once it is deprecated by team config
+        if (!existsSync(this.pmfConst.PLUGIN_JSON)) {
             if (!existsSync(this.pmfConst.PMF_ROOT)) {
                 this.impLogger.debug("Creating PMF_ROOT directory");
                 IO.mkdirp(this.pmfConst.PMF_ROOT);


### PR DESCRIPTION
Fixes an issue in Imperative next branch, where plugins.json file wasn't being created at CLI launch time when team config is being used.

For now, plugins in the team config file are experimental and has not yet been adopted as a new method for managing plugins, so we always want to ensure that plugins.json exists.

This fix is necessary in order for CLI system tests to run successfully with team config.