### PR TITLE
Change Override Credential Manager Service Name to Use DafaultCredentialManager Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Allow SCS to load new securely stored credentials. [#984](https://github.com/zowe/zowe-cli/issues/984)
+
 ## `5.0.0-next.202104071400`
 
 - Enhancement: Add the ProfileInfo API to provide the following functionality:

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -371,9 +371,13 @@ export class CommandProcessor {
             process.chdir(params.arguments.dcd as string)
 
             // reinit config for daemon client directory
-            ImperativeConfig.instance.config = await Config.load(ImperativeConfig.instance.rootCommandName, ImperativeConfig.instance.config.opts);
+            const newOpts = ImperativeConfig.instance.config?.opts || {};
+
+            if (newOpts.vault == null) newOpts.vault = ImperativeConfig.instance.config?.mVault;
+            ImperativeConfig.instance.config = await Config.load(ImperativeConfig.instance.rootCommandName, newOpts);
             this.mConfig = ImperativeConfig.instance.config;
         }
+
         const prepareResponse = this.constructResponseObject(params);
         prepareResponse.succeeded();
 

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -80,6 +80,8 @@ export class OverridesLoader {
   ): Promise<void> {
     const overrides: IImperativeOverrides = config.overrides;
 
+    const ZOWE_CLI_PACKAGE_NAME = `@zowe/cli`;
+
     // The manager display name used to populate the "managed by" fields in profiles
     const displayName: string = (
         overrides.CredentialManager != null
@@ -107,7 +109,8 @@ export class OverridesLoader {
         // The display name will be the plugin name that introduced the override OR it will default to the CLI name
         displayName,
 
-        service: DefaultCredentialManager.SVC_NAME,
+        // zowe cli will always add `Zowe` to it's list of service names
+        service: config?.name === ZOWE_CLI_PACKAGE_NAME ? DefaultCredentialManager.SVC_NAME : config?.name,
 
         // If the default is to be used, we won't implant the invalid credential manager
         invalidOnFailure: !(Manager == null)

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -97,7 +97,7 @@ export class OverridesLoader {
         config.productDisplayName || config.name;
 
     // Initialize the credential manager if an override was supplied and/or keytar was supplied in package.json
-    if (overrides.CredentialManager != null || packageJson.dependencies?.keytar != null) {
+    if (overrides.CredentialManager != null || packageJson.dependencies?.keytar != null || packageJson.optionalDependencies?.keytar != null) {
       let Manager = overrides.CredentialManager;
       if (typeof overrides.CredentialManager === "string" && !isAbsolute(overrides.CredentialManager)) {
         Manager = resolve(process.mainModule.filename, "../", overrides.CredentialManager);

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -10,7 +10,7 @@
 */
 
 import { IImperativeOverrides } from "./doc/IImperativeOverrides";
-import { CredentialManagerFactory } from "../../security";
+import { CredentialManagerFactory, DefaultCredentialManager } from "../../security";
 import { IImperativeConfig } from "./doc/IImperativeConfig";
 import { isAbsolute, resolve } from "path";
 import { AppSettings } from "../../settings";
@@ -106,8 +106,9 @@ export class OverridesLoader {
         Manager,
         // The display name will be the plugin name that introduced the override OR it will default to the CLI name
         displayName,
-        // The service is always the CLI name (Keytar and other plugins can use this to uniquely identify the service)
-        service: config.name,
+
+        service: DefaultCredentialManager.SVC_NAME,
+
         // If the default is to be used, we won't implant the invalid credential manager
         invalidOnFailure: !(Manager == null)
       });


### PR DESCRIPTION
Fix https://github.com/zowe/zowe-cli/issues/984

This adds `Zowe` to the list of service names to read from for SCS plugin (and any others that likely do not exist).  It allows the old SCS plugin to read credentials securely stored via DefaultCredentialManager.  

I think this is technically a breaking change since `@zowe/cli` will no longer be added to [`allServices`](https://github.com/zowe/zowe-cli-scs-plugin/blob/master/src/credentials/KeytarCredentialManager.ts#L50). 

Signed-off-by: Dan Kelosky <dkelosky@gmail.com>