### PR TITLE
Revert Line Change from #589

### DIFF
--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -97,7 +97,7 @@ export class OverridesLoader {
         config.productDisplayName || config.name;
 
     // Initialize the credential manager if an override was supplied and/or keytar was supplied in package.json
-    if (overrides.CredentialManager != null || packageJson.dependencies?.keytar != null || packageJson.optionalDependencies?.keytar != null) {
+    if (overrides.CredentialManager != null || packageJson.dependencies?.keytar != null) {
       let Manager = overrides.CredentialManager;
       if (typeof overrides.CredentialManager === "string" && !isAbsolute(overrides.CredentialManager)) {
         Manager = resolve(process.mainModule.filename, "../", overrides.CredentialManager);


### PR DESCRIPTION
#589 introduced and issue where plain text profiles can no longer be read. I tested this manually, but it seemed to continue to work from residual items in my credential manger.