### PR TITLE
[next] Remove peer dep warning that no longer applies to npm@7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Remove message about NPM peer dep warnings that no longer applies to npm@7.
+- **Breaking:** Imperative no longer requires plug-ins to include CLI package as a peer dependency. It is recommended that CLI plug-ins remove their peer dependency on @zowe/cli for improved compatibility with npm@7. This is a breaking change for plug-ins, as older versions of Imperative will fail to install a plug-in that lacks the CLI peer dependency.
+
 ## `5.0.0-next.202104140156`
 
 - BugFix: Allow SCS to load new securely stored credentials. [#984](https://github.com/zowe/zowe-cli/issues/984)

--- a/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
+++ b/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
@@ -130,7 +130,7 @@ describe("Plugin Management Facility", () => {
         npmPackageName: "PluginHasNoNpmPkgName",
         impConfig: basePluginConfig,
         cliDependency: {
-            peerDepName: "@zowe/core",
+            peerDepName: "@zowe/cli",
             peerDepVer: "-1"
         },
         impDependency: {
@@ -1168,11 +1168,10 @@ describe("Plugin Management Facility", () => {
             expect(pluginCfgProps).toEqual(null);
         });
 
-        it("should record warning when defined CLI package name does not exist in 'peerDependencies'", () => {
+        it("should record warning when Imperative package name does not exist in 'peerDependencies'", () => {
             // alter basePluginCfgProps to reflect the imperative version in the plugin's package.json
             const expectedCfgProps = JSON.parse(JSON.stringify(basePluginCfgProps));
             expectedCfgProps.npmPackageName = pluginName;
-            expectedCfgProps.impDependency.peerDepVer = "1.x";
 
             // mock reading the package.json file of the plugin
             mocks.existsSync.mockReturnValue(true);
@@ -1182,13 +1181,12 @@ describe("Plugin Management Facility", () => {
                 description: "Some description",
                 imperative: expectedCfgProps.impConfig,
                 peerDependencies: {
-                    "@zowe/coreIsNotInPkgJson": "1.x",
-                    "@zowe/imperative": "1.x"
+                    "@zowe/notImperative": "1.x"
                 }
             });
 
             // utility functions mocked to return good values
-            mockGetCliPkgName.mockReturnValue("@zowe/core");
+            mockGetCliPkgName.mockReturnValue("@zowe/cli");
             mockCfgLoad.mockReturnValue(expectedCfgProps.impConfig);
 
             // this is what we are really testing
@@ -1202,14 +1200,13 @@ describe("Plugin Management Facility", () => {
             expect(pluginIssues.getIssueListForPlugin(pluginName).length).toBe(1);
             const recordedIssue = pluginIssues.getIssueListForPlugin(pluginName)[0];
             expect(recordedIssue.issueSev).toBe(IssueSeverity.WARNING);
-            expect(recordedIssue.issueText).toContain("The property '@zowe/core' does not exist within the 'peerDependencies' property");
+            expect(recordedIssue.issueText).toContain("The property '@zowe/imperative' does not exist within the 'peerDependencies' property");
         });
 
         it("should return a plugin config when there are no errors", () => {
             // alter basePluginCfgProps to reflect the imperative version in the plugin's package.json
             const expectedCfgProps = JSON.parse(JSON.stringify(basePluginCfgProps));
             expectedCfgProps.npmPackageName = pluginName;
-            expectedCfgProps.cliDependency.peerDepVer = "1.x";
             expectedCfgProps.impDependency.peerDepVer = "1.x";
 
             // mock reading the package.json file of the plugin
@@ -1220,13 +1217,12 @@ describe("Plugin Management Facility", () => {
                 description: "Some description",
                 imperative: expectedCfgProps.impConfig,
                 peerDependencies: {
-                    "@zowe/core": "1.x",
                     "@zowe/imperative": "1.x"
                 }
             });
 
             // utility functions mocked to return good values
-            mockGetCliPkgName.mockReturnValue("@zowe/core");
+            mockGetCliPkgName.mockReturnValue("@zowe/cli");
             mockCfgLoad.mockReturnValue(expectedCfgProps.impConfig);
 
             // this is what we are really testing

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -840,12 +840,6 @@ export class PluginManagementFacility {
             if (pkgJsonData[peerDepPropNm].hasOwnProperty(pluginCfgProps.cliDependency.peerDepName)) {
                 pluginCfgProps.cliDependency.peerDepVer =
                     pkgJsonData[peerDepPropNm][pluginCfgProps.cliDependency.peerDepName];
-            } else {
-                this.pluginIssues.recordIssue(pluginName, IssueSeverity.WARNING,
-                    "The property '" + pluginCfgProps.cliDependency.peerDepName +
-                    "' does not exist within the '" + peerDepPropNm +
-                    "' property in the file '" + pluginPkgJsonPathNm + "'."
-                );
             }
 
             // get the version of the imperative dependency for this plugin

--- a/packages/imperative/src/plugins/cmd/install/install.handler.ts
+++ b/packages/imperative/src/plugins/cmd/install/install.handler.ts
@@ -96,9 +96,7 @@ export default class InstallHandler implements ICommandHandler {
           "Plug-ins within the Imperative CLI Framework can legitimately gain\n" +
           `control of the ${ImperativeConfig.instance.rootCommandName} CLI application ` +
           "during the execution of every command.\n" +
-          "Install 3rd party plug-ins at your own risk.\n\n" +
-          "Imperative's plugin installation program handles @zowe peer dependencies.\n" +
-          "You can safely ignore NPM warnings about missing @zowe peer dependencies.\n"
+          "Install 3rd party plug-ins at your own risk.\n"
         );
 
         params.response.console.log("Registry = " + installRegistry);


### PR DESCRIPTION
Originally planned to merge this into master branch, but there is a breaking change as described in the changelog.