### PR TITLE
Fix validate command not returning an error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- BugFix: Return with an error code when the `plugins validate` command is run and plugins have errors. Disable this behavior with `--no-fail-on-error` option. Also adds `--fail-on-warning` option to return with an error code when plugins have warnings. [#463](https://github.com/zowe/imperative/issues/463)
+- Enhancement: The `plugins validate` command will return an error code when plugins have errors if the new `--fail-on-error` option is specified. Also adds `--fail-on-warning` option to return with an error code when plugins have warnings. [#463](https://github.com/zowe/imperative/issues/463)
 
 ## `4.13.4`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Return with an error code when the `plugins validate` command is run and plugins have errors. Disable this behavior with `--no-fail-on-error` option. Also adds `--fail-on-warning` option to return with an error code when plugins have warnings. [#463](https://github.com/zowe/imperative/issues/463)
 ## `4.13.4`
 
 - BugFix: Added missing periods at the end of command group descriptions for consistency. [#55](https://github.com/zowe/imperative/issues/55)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Imperative package will be documented in this file.
 ## Recent Changes
 
 - BugFix: Return with an error code when the `plugins validate` command is run and plugins have errors. Disable this behavior with `--no-fail-on-error` option. Also adds `--fail-on-warning` option to return with an error code when plugins have warnings. [#463](https://github.com/zowe/imperative/issues/463)
+
 ## `4.13.4`
 
 - BugFix: Added missing periods at the end of command group descriptions for consistency. [#55](https://github.com/zowe/imperative/issues/55)

--- a/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
@@ -345,7 +345,7 @@ describe("Validate plugin", () => {
                 expect(result.stdout).toContain("The plugin's configuration does not contain an 'imperative.rootCommandDescription' property.");
             });
 
-            it("missing rootCommandDescription property - warning", () => {
+            it("missing rootCommandDescription property - error", () => {
                 const testPlugin = "missing_rootCommandDescription";
                 const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
 
@@ -353,7 +353,7 @@ describe("Validate plugin", () => {
                 let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
                 expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
 
-                cmd = `plugins validate ${testPlugin} --fail-on-error --fail-on-warning`;
+                cmd = `plugins validate ${testPlugin} --fail-on-error`;
                 result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
                 result.stderr = removeNewline(result.stderr);
                 expect(result.stdout).toContain(testPlugin);

--- a/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
@@ -139,6 +139,7 @@ describe("Validate plugin", () => {
                     expect(result.stderr).toMatch(/npm.*WARN/);
                     expect(result.stderr).toContain("requires a peer of @zowe/imperative");
                     expect(result.stderr).toContain("You must install peer dependencies yourself");
+                    expect(result.stderr).not.toContain("Install Failed");
                 } else {
                     expect(result.stderr).toEqual("");
                 }

--- a/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
@@ -107,6 +107,8 @@ describe("Validate plugin", () => {
             result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
             expect(result.stdout).toContain(pluginName);
             expect(result.stdout).toContain("has not been installed");
+            expect(result.stderr).toContain("Problems detected during plugin validation.");
+            expect(result.status).toEqual(1);
         });
 
         describe("when package json contains the following scenarios", () => {
@@ -125,6 +127,8 @@ describe("Validate plugin", () => {
                 expect(result.stdout).toContain("Error");
                 expect(result.stdout).toContain("Your base application already contains a group with the name");
                 expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                expect(result.stderr).toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(1);
             });
 
             it("duplicated command name with installed plugin", () => {
@@ -139,7 +143,6 @@ describe("Validate plugin", () => {
                     expect(result.stderr).toMatch(/npm.*WARN/);
                     expect(result.stderr).toContain("requires a peer of @zowe/imperative");
                     expect(result.stderr).toContain("You must install peer dependencies yourself");
-                    expect(result.stderr).not.toContain("Install Failed");
                 } else {
                     expect(result.stderr).toEqual("");
                 }
@@ -153,6 +156,8 @@ describe("Validate plugin", () => {
                 expect(result.stdout).toContain("Error");
                 expect(result.stdout).toContain("Your base application already contains a group with the name");
                 expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                expect(result.stderr).toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(1);
             });
 
             it("missing pluginHealthCheck property", () => {
@@ -169,6 +174,26 @@ describe("Validate plugin", () => {
                 expect(result.stdout).toContain(testPlugin);
                 expect(result.stdout).toContain("Warning");
                 expect(result.stdout).toContain("The plugin's configuration does not contain an 'imperative.pluginHealthCheck' property.");
+                expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(0);
+            });
+
+            it("missing pluginHealthCheck property - warning", () => {
+                const testPlugin = "missing_pluginHealthCheck";
+                const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                let cmd = `plugins install ${fullPluginPath}`;
+                let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                cmd = `plugins validate ${testPlugin} --fow`;
+                result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                result.stderr = removeNewline(result.stderr);
+                expect(result.stdout).toContain(testPlugin);
+                expect(result.stdout).toContain("Warning");
+                expect(result.stdout).toContain("The plugin's configuration does not contain an 'imperative.pluginHealthCheck' property.");
+                expect(result.stderr).toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(1);
             });
 
             it("missing pluginHealthCheck handler", () => {
@@ -186,6 +211,8 @@ describe("Validate plugin", () => {
                 expect(result.stdout).toContain("Error");
                 expect(result.stdout).toContain(`The program for the 'imperative.pluginHealthCheck' property does not exist:`);
                 expect(result.stdout).toContain("This plugin has configuration errors. No component of the plugin will be available");
+                expect(result.stderr).toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(1);
             });
 
             it("missing peerDependencies properties", () => {
@@ -204,6 +231,28 @@ describe("Validate plugin", () => {
                 expect(result.stdout).toContain("Your '@zowe' dependencies must be contained within a 'peerDependencies' property." +
                     " That property does not exist in the file");
                 expect(result.stdout).toContain("package.json");
+                expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(0);
+            });
+
+            it("missing peerDependencies properties - warning", () => {
+                const testPlugin = "missing_dependencies";
+                const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                let cmd = `plugins install ${fullPluginPath}`;
+                let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                cmd = `plugins validate ${testPlugin} --fow`;
+                result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                result.stderr = removeNewline(result.stderr);
+                expect(result.stdout).toContain(testPlugin);
+                expect(result.stdout).toContain("Warning");
+                expect(result.stdout).toContain("Your '@zowe' dependencies must be contained within a 'peerDependencies' property." +
+                    " That property does not exist in the file");
+                expect(result.stdout).toContain("package.json");
+                expect(result.stderr).toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(1);
             });
 
             it("missing rootCommandDescription property", () => {
@@ -220,6 +269,8 @@ describe("Validate plugin", () => {
                 expect(result.stdout).toContain(testPlugin);
                 expect(result.stdout).toContain("Error");
                 expect(result.stdout).toContain("The plugin's configuration does not contain an 'imperative.rootCommandDescription' property.");
+                expect(result.stderr).toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(1);
             });
 
             describe("definitions property", () => {
@@ -237,6 +288,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain(testPlugin);
                     expect(result.stdout).toContain("Error");
                     expect(result.stdout).toContain("The plugin defines no commands and overrides no framework components");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("is defined with empty array", () => {
@@ -254,6 +307,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain("Error");
                     expect(result.stdout).toContain("The plugin defines no commands and overrides no framework components");
                     expect(result.stdout).toContain("This plugin has configuration errors. No component of the plugin will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("is defined with definition which does not contain name property", () => {
@@ -270,6 +325,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain("Error: Command definition");
                     expect(result.stdout).toContain("no 'name' property");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("is defined with definition which does not contain description property", () => {
@@ -286,6 +343,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain("Error");
                     expect(result.stdout).toContain("has no 'description' property");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("is defined with definition which does not contain type property", () => {
@@ -302,6 +361,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain("Error");
                     expect(result.stdout).toContain("has no 'type' property");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("is defined with definition which does not contain handler property", () => {
@@ -318,6 +379,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain("Error");
                     expect(result.stdout).toContain("has no 'handler' property");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("is defined with definition which contains group type and missing children", () => {
@@ -334,6 +397,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain("Error: Group name");
                     expect(result.stdout).toContain("has no 'children' property");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("is defined with definition which contains invalid handler", () => {
@@ -350,6 +415,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain("Error: The handler for command");
                     expect(result.stdout).toContain("does not exist:");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
             });
 
@@ -368,6 +435,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain(pluginName);
                     expect(result.stdout).toContain(
                         "Error: The plugin's profiles at indexes = '0' and '1' have the same 'type' property = 'DupProfile'.");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
 
                 it("should fail when a plugin contains a profile with the same name as the CLI", () => {
@@ -384,6 +453,8 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain(pluginName);
                     expect(result.stdout).toContain(
                         "Error: The plugin's profile type = 'TestProfile1' already exists within existing profiles.");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
                 });
             });
         });

--- a/packages/imperative/__tests__/plugins/cmd/validate/validate.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/validate/validate.handler.test.ts
@@ -46,6 +46,7 @@ describe("Plugin validate command handler", () => {
     });
   });
 
+  const setExitCodeFunction = jest.fn();
   /**
    * Create object to be passed to process function
    *
@@ -103,7 +104,7 @@ describe("Plugin validate command handler", () => {
       }
     });
 
-    it("should validate with non-existent plugin name and error", async () => {
+    it("should validate with non-existent plugin name and not error", async () => {
       params.arguments.plugin = ["NonExistentPluginName"];
       let error;
       try {
@@ -115,8 +116,21 @@ describe("Plugin validate command handler", () => {
         TextUtils.chalk.red(
         "The specified plugin 'NonExistentPluginName' has not been installed into your CLI application."
       ));
-      expect(error).toBeDefined();
-      expect(error.message).toContain("Problems detected during plugin validation.");
+      expect(error).not.toBeDefined();
+    });
+
+    it("should validate with non-existent plugin name and error", async () => {
+      params.arguments.plugin = ["NonExistentPluginName"];
+      params.arguments.failOnError = true;
+      params.response.data = {setExitCode: setExitCodeFunction, setObj: jest.fn(), setMessage: jest.fn()};
+      await valHandler.process(params as IHandlerParameters);
+      expect(params.response.console.log).toHaveBeenCalledWith(
+        TextUtils.chalk.red(
+        "The specified plugin 'NonExistentPluginName' has not been installed into your CLI application."
+      ));
+      expect(params.response.console.error).toHaveBeenCalledWith("Problems detected during plugin validation. Please check above for more information.");
+      expect(setExitCodeFunction).toHaveBeenCalledTimes(1);
+      expect(setExitCodeFunction).toHaveBeenCalledWith(1);
     });
 
     it("should validate the specific plugin requested by user", async () => {

--- a/packages/imperative/__tests__/plugins/cmd/validate/validate.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/validate/validate.handler.test.ts
@@ -128,7 +128,10 @@ describe("Plugin validate command handler", () => {
         TextUtils.chalk.red(
         "The specified plugin 'NonExistentPluginName' has not been installed into your CLI application."
       ));
-      expect(params.response.console.error).toHaveBeenCalledWith("Problems detected during plugin validation. Please check above for more information.");
+      expect(params.response.console.error).toHaveBeenCalledWith(
+        TextUtils.chalk.red(
+        "Problems detected during plugin validation. Please check above for more information."
+      ));
       expect(setExitCodeFunction).toHaveBeenCalledTimes(1);
       expect(setExitCodeFunction).toHaveBeenCalledWith(1);
     });

--- a/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
@@ -53,19 +53,4 @@ describe("runValidatePlugin", () => {
         expect(resultMsg).toContain(cmdOutputJson.stdout);
         expect(resultMsg).toContain(cmdOutputJson.stderr);
     });
-
-    it("should display both the stdout and stderr of a failed validate command", () => {
-        // mock the output of executing the validatePlugin command
-        cmdOutputJson.stdout = "The validate commands's standard output";
-        cmdOutputJson.stderr = "The validate commands's standard error";
-        mocks.execSync.mockImplementation(() => {
-            const err = new Error("Error!");
-            Object.assign(err, {message: err.message, status: 1, stdout: JSON.stringify(cmdOutputJson)});
-            throw err;
-        });
-        (Imperative as any).mRootCommandName = "dummy";
-        const resultMsg = runValidatePlugin(pluginName);
-        expect(resultMsg).toContain(cmdOutputJson.stdout);
-        expect(resultMsg).toContain(cmdOutputJson.stderr);
-    });
 });

--- a/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
@@ -53,4 +53,19 @@ describe("runValidatePlugin", () => {
         expect(resultMsg).toContain(cmdOutputJson.stdout);
         expect(resultMsg).toContain(cmdOutputJson.stderr);
     });
+
+    it("should display both the stdout and stderr of a failed validate command", () => {
+        // mock the output of executing the validatePlugin command
+        cmdOutputJson.stdout = "The validate commands's standard output";
+        cmdOutputJson.stderr = "The validate commands's standard error";
+        mocks.execSync.mockImplementation(() => {
+            const err = new Error("Error!");
+            Object.assign(err, {message: err.message, status: 1, stdout: JSON.stringify(cmdOutputJson)});
+            throw err;
+        });
+        (Imperative as any).mRootCommandName = "dummy";
+        const resultMsg = runValidatePlugin(pluginName);
+        expect(resultMsg).toContain(cmdOutputJson.stdout);
+        expect(resultMsg).toContain(cmdOutputJson.stderr);
+    });
 });

--- a/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
+++ b/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
@@ -42,7 +42,7 @@ export const validateDefinition: ICommandDefinition = {
       type: "boolean",
       description: "Enables throwing an error and setting an error code if plugin validation detects an error",
       required: false,
-      defaultValue: true
+      defaultValue: false
     },
     {
       name: "fail-on-warning",

--- a/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
+++ b/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
@@ -50,6 +50,7 @@ export const validateDefinition: ICommandDefinition = {
       type: "boolean",
       description: "Treat validation warnings as errors. Requires fail-on-error.",
       required: false,
+      defaultValue: false,
       implies: ["fail-on-error"]
     }
   ],

--- a/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
+++ b/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
@@ -37,11 +37,20 @@ export const validateDefinition: ICommandDefinition = {
   ],
   options: [
     {
-        name: "fail-on-warning",
-        aliases: ["fow"],
-        type: "boolean",
-        description: "Treat validation warnings as errors.",
-        required: false,
+      name: "fail-on-error",
+      aliases: ["foe"],
+      type: "boolean",
+      description: "Enables throwing an error and setting an error code if plugin validation detects an error",
+      required: false,
+      defaultValue: true
+    },
+    {
+      name: "fail-on-warning",
+      aliases: ["fow"],
+      type: "boolean",
+      description: "Treat validation warnings as errors. Requires fail-on-error.",
+      required: false,
+      implies: ["fail-on-error"]
     }
   ],
   examples: [

--- a/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
+++ b/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
@@ -64,7 +64,7 @@ export const validateDefinition: ICommandDefinition = {
     },
     {
       description: "Validate a plug-in named my-plugin, and treat warnings as errors",
-      options    : "my-plugin --fow"
+      options    : "my-plugin --fail-on-warning"
     }
   ]
 };

--- a/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
+++ b/packages/imperative/src/plugins/cmd/validate/validate.definition.ts
@@ -35,6 +35,15 @@ export const validateDefinition: ICommandDefinition = {
       required: false
     }
   ],
+  options: [
+    {
+        name: "fail-on-warning",
+        aliases: ["fow"],
+        type: "boolean",
+        description: "Treat validation warnings as errors.",
+        required: false,
+    }
+  ],
   examples: [
     {
       description: `Validate a plug-in named my-plugin`,
@@ -44,5 +53,9 @@ export const validateDefinition: ICommandDefinition = {
       description: "Validate all installed plug-ins",
       options    : ""
     },
+    {
+      description: "Validate a plug-in named my-plugin, and treat warnings as errors",
+      options    : "my-plugin --fow"
+    }
   ]
 };

--- a/packages/imperative/src/plugins/cmd/validate/validate.handler.ts
+++ b/packages/imperative/src/plugins/cmd/validate/validate.handler.ts
@@ -81,9 +81,10 @@ export default class ValidateHandler implements ICommandHandler {
       }
     }
 
-    if (err === true) {
+    if (err === true && params.arguments.failOnError) {
       params.response.console.log("\n");
-      throw new ImperativeError({msg: "Problems detected during plugin validation. Please check above for more information."});
+      params.response.console.error("Problems detected during plugin validation. Please check above for more information.");
+      params.response.data.setExitCode(1);
     }
   }
 

--- a/packages/imperative/src/plugins/cmd/validate/validate.handler.ts
+++ b/packages/imperative/src/plugins/cmd/validate/validate.handler.ts
@@ -83,7 +83,7 @@ export default class ValidateHandler implements ICommandHandler {
 
     if (err === true && params.arguments.failOnError) {
       params.response.console.log("\n");
-      params.response.console.error("Problems detected during plugin validation. Please check above for more information.");
+      params.response.console.error(TextUtils.chalk.red("Problems detected during plugin validation. Please check above for more information."));
       params.response.data.setExitCode(1);
     }
   }

--- a/packages/imperative/src/plugins/utilities/runValidatePlugin.ts
+++ b/packages/imperative/src/plugins/utilities/runValidatePlugin.ts
@@ -39,14 +39,9 @@ export function runValidatePlugin(pluginName: string): string {
 
     const impLogger = Logger.getImperativeLogger();
     impLogger.debug(`Running plugin validation command = ${cmdToRun} plugins validate "${pluginName}" --response-format-json`);
-    let valOutputJsonTxt: string;
-    try {
-        valOutputJsonTxt = execSync(`${cmdToRun} plugins validate "${pluginName}" --response-format-json`, {
-            cwd: PMFConstants.instance.PMF_ROOT
-        }).toString();
-    } catch (err) {
-        valOutputJsonTxt = err.stdout.toString();
-    }
+    const valOutputJsonTxt = execSync(`${cmdToRun} plugins validate "${pluginName}" --response-format-json --no-fail-on-error`, {
+        cwd: PMFConstants.instance.PMF_ROOT
+    }).toString();
 
     // Debug trace information
     impLogger.trace(`Command Output: ${valOutputJsonTxt}`);

--- a/packages/imperative/src/plugins/utilities/runValidatePlugin.ts
+++ b/packages/imperative/src/plugins/utilities/runValidatePlugin.ts
@@ -39,9 +39,14 @@ export function runValidatePlugin(pluginName: string): string {
 
     const impLogger = Logger.getImperativeLogger();
     impLogger.debug(`Running plugin validation command = ${cmdToRun} plugins validate "${pluginName}" --response-format-json`);
-    const valOutputJsonTxt = execSync(`${cmdToRun} plugins validate "${pluginName}" --response-format-json`, {
-        cwd: PMFConstants.instance.PMF_ROOT
-    }).toString();
+    let valOutputJsonTxt: string;
+    try {
+        valOutputJsonTxt = execSync(`${cmdToRun} plugins validate "${pluginName}" --response-format-json`, {
+            cwd: PMFConstants.instance.PMF_ROOT
+        }).toString();
+    } catch (err) {
+        valOutputJsonTxt = err.stdout.toString();
+    }
 
     // Debug trace information
     impLogger.trace(`Command Output: ${valOutputJsonTxt}`);


### PR DESCRIPTION
Allows the `validate plugins` command to return an error code and display an error if validation finds problems. Planned to enable this functionality by default in V2, but useful for upcoming scripting in V1 (i.e. extended web-help generation).

Note: Update Zowe CLI to add `--no-fail-on-error` in the post-install script validatePlugins.js once the fail-on-error option is true by default in V2.