### PR TITLE
Fix "Illegal invocation" error for prompts in daemon mode

### DIFF
--- a/packages/rest/__tests__/session/ConnectionPropsForSessCfg.test.ts
+++ b/packages/rest/__tests__/session/ConnectionPropsForSessCfg.test.ts
@@ -214,6 +214,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         CliUtils.promptWithTimeout = jest.fn(() => {
             return Promise.resolve(userFromPrompt);
         });
+        const mockClientPrompt = jest.spyOn(ConnectionPropsForSessCfg as any, "clientPrompt");
 
         const initialSessCfg = {
             hostname: "SomeHost",
@@ -250,6 +251,7 @@ describe("ConnectionPropsForSessCfg tests", () => {
         CliUtils.promptWithTimeout = promptWithTimeoutReal;
 
         expect(commandHandlerPrompt).toBeCalled(); // we are only testing that we call an already tested prompt method if in CLI mode
+        expect((mockClientPrompt.mock.calls[0][1] as any).parms).toBe(parms);  // toBe is important here, parms object must be same as original
     });
 
     it("get user name from prompt", async() => {

--- a/packages/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -9,7 +9,6 @@
 *
 */
 
-import * as lodash from "lodash";
 import { CliUtils } from "../../../utilities";
 import { ICommandArguments, IHandlerParameters } from "../../../cmd";
 import { ImperativeError } from "../../../error";
@@ -101,10 +100,10 @@ export class ConnectionPropsForSessCfg {
         const impLogger = Logger.getImperativeLogger();
 
         /* Create copies of our initialSessCfg and connOpts so that
-         * we can modifify them without changing the caller's copy.
+         * we can modify them without changing the caller's copy.
          */
-        const sessCfgToUse  = lodash.cloneDeep(initialSessCfg);
-        const connOptsToUse = lodash.cloneDeep(connOpts);
+        const sessCfgToUse = { ...initialSessCfg };
+        const connOptsToUse = { ...connOpts };
         const serviceDescription = connOptsToUse.serviceDescription || "your service";
 
         // resolve all values between sessCfg and cmdArgs using option choices


### PR DESCRIPTION
Fix #639, a bug introduced in https://github.com/zowe/imperative/pull/610

Using `lodash.deepCopy` to perform a recursive deep copy on the `IHandlePromptOptions` interface attempts to deep copy the `parms: IHandlerParameters` property if present.

`IHandlerParameters` contains classes that aren't JSON serializable, resulting in strange errors when `params.response.console.prompt` is called on the deep-copied object.

The ES6 spread operator (`...`) deep copies objects with simple types like boolean/number/string, while preserving references to the original `IHandlerParameters` interface.