### PR TITLE
Fix character escaping behavior in web help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed regression where characters are not correctly escaped in web help causing extra slashes ("\") to appear. [#644](https://github.com/zowe/imperative/issues/644)
+
 ## `4.13.4`
 
 - BugFix: Added missing periods at the end of command group descriptions for consistency. [#55](https://github.com/zowe/imperative/issues/55)

--- a/packages/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/cmd/src/help/DefaultHelpGenerator.ts
@@ -368,7 +368,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
                 const positionalString = "{{codeBegin}}" +
                     positional.name + "{{codeEnd}}\t\t " +
                     this.dimGrey("{{italic}}(" + this.explainType(positional.type) + "){{italic}}");
-                let fullDescription = this.mProduceMarkdown ? this.escapeMarkdown(positional.description) : positional.description;
+                let fullDescription = positional.description;
                 if (positional.regex) {
                     fullDescription += (DefaultHelpGenerator.HELP_INDENT +
                         DefaultHelpGenerator.HELP_INDENT + "Must match regular expression: {{codeBegin}}"
@@ -522,10 +522,11 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
 
     /**
      * Utility function to escape Markdown special characters.
+     * Note: This should only be called once to avoid double escaping.
      * @param {string} text - The text to escape
      * @return {string} - The escaped string
      */
     private escapeMarkdown(text: string): string {
-        return text.replace(/([\*\#\-\`\_\[\]\+\.\!])/g, "\\$1");
+        return text.replace(/([\*\#\-\`\_\[\]\+\.\!\\])/g, "\\$1");
     }
 }

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -194,7 +194,7 @@ export class WebHelpGenerator {
      * @param markdownContent String containing Markdown content
      * @returns String containing HTML content
      */
-     private renderMarkdown(markdownContent: string): string {
+    private renderMarkdown(markdownContent: string): string {
         if (this.markdownIt == null) {
             this.markdownIt = require("markdown-it")({ html: true, linkify: true });
         }

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -105,12 +105,8 @@ export class WebHelpGenerator {
         // This allows printing dot characters on the same line to show progress
         cmdResponse.console.log(Buffer.from("Generating web help"));
 
-        // Load additional dependencies
-        this.markdownIt = require("markdown-it")({ html: true, linkify: true });
-        const fsExtra = require("fs-extra");
-        const sanitizeHtml = require("sanitize-html");
-
         // Ensure web-help/docs folder exists and is empty
+        const fsExtra = require("fs-extra");
         fsExtra.emptyDirSync(this.mDocsDir);
         const webHelpDir: string = path.join(this.mDocsDir, "..");
 
@@ -159,12 +155,11 @@ export class WebHelpGenerator {
 
         let rootHelpContent: string = this.genDocsHeader(rootCommandName);
         rootHelpContent += `<h2><a href="${rootCommandName}.html" name="${rootCommandName}">${rootCommandName}</a>${this.genPrintButton()}</h2>\n`;
-        rootHelpContent += this.markdownIt.render(sanitizeHtml(this.mConfig.loadedConfig.rootCommandDescription)) + "\n";
+        rootHelpContent += this.renderMarkdown(this.mConfig.loadedConfig.rootCommandDescription) + "\n";
         const helpGen = new DefaultHelpGenerator({ produceMarkdown: true, rootCommandName } as any,
             { commandDefinition: uniqueDefinitions, fullCommandTree: uniqueDefinitions });
-        rootHelpContent += this.markdownIt.render(sanitizeHtml(
-            this.buildChildrenSummaryTables(helpGen, rootCommandName) + "\n\n" +
-            helpGen.buildGlobalOptionsSection().replace(/Global options/, "Global Options")));
+        rootHelpContent += this.renderMarkdown(this.buildChildrenSummaryTables(helpGen, rootCommandName) + "\n\n" +
+            helpGen.buildGlobalOptionsSection().replace(/Global options/, "Global Options"));
         this.singlePageHtml = rootHelpContent.replace(/<h4>Groups.+?<\/ul>/s, "");
         rootHelpContent += this.genDocsFooter();
         fs.writeFileSync(rootHelpHtmlPath, rootHelpContent);
@@ -191,6 +186,21 @@ export class WebHelpGenerator {
 
         this.writeTreeData();
         cmdResponse.console.log("done!");
+    }
+
+    /**
+     * Converts Markdown string to HTML string. Any HTML contained in the
+     * input Markdown string will be sanitized.
+     * @param markdownContent String containing Markdown content
+     * @returns String containing HTML content
+     */
+     private renderMarkdown(markdownContent: string): string {
+        if (this.markdownIt == null) {
+            this.markdownIt = require("markdown-it")({ html: true, linkify: true });
+        }
+
+        const sanitizeHtml = require("sanitize-html");
+        return this.markdownIt.render(sanitizeHtml(markdownContent));
     }
 
     /**
@@ -305,7 +315,6 @@ export class WebHelpGenerator {
      * @param {ITreeNode} parentNode
      */
     private genCommandHelpPage(definition: ICommandDefinition, fullCommandName: string, docsDir: string, parentNode: IWebHelpTreeNode) {
-        const sanitizeHtml = require("sanitize-html");
         const rootCommandName: string = this.treeNodes[0].text;
         const helpGen = new DefaultHelpGenerator({ produceMarkdown: true, rootCommandName } as any,
             { commandDefinition: definition, fullCommandTree: this.mFullCommandTree });
@@ -323,14 +332,11 @@ export class WebHelpGenerator {
         markdownContent = markdownContent.replace(/^(\s+Default value:.+$)(\s+Allowed values:.+$)/gm, "$1\n$2");
 
         let htmlContent = "<h2>" + this.genBreadcrumb(rootCommandName, fullCommandName) + this.genPrintButton() + "</h2>\n";
-        htmlContent += this.markdownIt.render(sanitizeHtml(markdownContent));
-
-        // Remove backslash escapes from URLs
-        htmlContent = htmlContent.replace(/(%5C|\\)(?=.+?<\/a>)/g, "");
+        htmlContent += this.renderMarkdown(markdownContent);
 
         // Add Copy buttons after command line examples
         htmlContent = htmlContent.replace(/<code>\$\s*(.*?)<\/code>/g,
-        `<code>$1</code> <button class="btn-copy no-print" data-balloon-pos="right" data-clipboard-text="$1">Copy</button>`);
+            `<code>$1</code> <button class="btn-copy no-print" data-balloon-pos="right" data-clipboard-text="$1">Copy</button>`);
 
         // Sanitize references to user's home directory
         if (this.sanitizeHomeDir) {


### PR DESCRIPTION
* Fix `escapeMarkdown` being called twice for positional descriptions, causing characters to be double escaped
  * This was a regression introduced in #621
  * Thanks to @awharn for helping to diagnose 🙂 
* Fix backslash character not being escaped, causing it to disappear at some places in web help
* Remove hack to "Remove backslash escapes from URLs" that used to be necessary to work around "marked" bug