### PR TITLE
[next] Don't prompt for token value in "config secure"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- Enhancement: Login to authentication service to obtain token value instead of prompting for it in `config secure` command.
+- Enhancement: Log in to authentication service to obtain token value instead of prompting for it in `config secure` command.
 
 ## `5.0.0-next.202108181618`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Login to authentication service to obtain token value instead of prompting for it in `config secure` command.
+
 ## `5.0.0-next.202108181618`
 
 - Breaking: Make `fail-on-error` option true by default on `zowe plugins validate` command.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18330,9 +18330,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -33919,9 +33919,9 @@
       "dev": true
     },
     "tar": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.8.tgz",
-      "integrity": "sha512-sb9b0cp855NbkMJcskdSYA7b11Q8JsX4qe4pyUAfHp+Y6jBjJeek2ZVlwEfWayshEIwlIzXx0Fain3QG9JPm2A==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/packages/cmd/src/doc/profiles/definition/ICommandProfileAuthConfig.ts
+++ b/packages/cmd/src/doc/profiles/definition/ICommandProfileAuthConfig.ts
@@ -9,7 +9,6 @@
 *
 */
 
-import { TOKEN_TYPE_CHOICES } from "../../../../../rest/src/session/SessConstants";
 import { IPartialCommandDefinition } from "../../IPartialCommandDefinition";
 
 export interface ICommandProfileAuthConfig {
@@ -23,11 +22,6 @@ export interface ICommandProfileAuthConfig {
      * The handler should inherit from Imperative BaseAuthHandler.
      */
     handler: string;
-
-    /**
-     * Type of token used by the authentication service
-     */
-    tokenType?: TOKEN_TYPE_CHOICES;
 
     /**
      * Command properties for `auth login <serviceName>`

--- a/packages/cmd/src/doc/profiles/definition/ICommandProfileAuthConfig.ts
+++ b/packages/cmd/src/doc/profiles/definition/ICommandProfileAuthConfig.ts
@@ -9,6 +9,7 @@
 *
 */
 
+import { TOKEN_TYPE_CHOICES } from "../../../../../rest/src/session/SessConstants";
 import { IPartialCommandDefinition } from "../../IPartialCommandDefinition";
 
 export interface ICommandProfileAuthConfig {
@@ -22,6 +23,11 @@ export interface ICommandProfileAuthConfig {
      * The handler should inherit from Imperative BaseAuthHandler.
      */
     handler: string;
+
+    /**
+     * Type of token used by the authentication service
+     */
+    tokenType?: TOKEN_TYPE_CHOICES;
 
     /**
      * Command properties for `auth login <serviceName>`

--- a/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
@@ -755,8 +755,8 @@ describe("Configuration Secure command handler", () => {
                 caughtError = error;
             }
 
-            // expect(caughtError).toBeDefined();
-            // expect(caughtError.message).toContain("Failed to fetch jwtToken");
+            expect(caughtError).toBeDefined();
+            expect(caughtError.message).toContain("Failed to fetch jwtToken");
             expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(2);  // User and password
             expect(mockAuthLogin).toHaveBeenCalledTimes(1);
             expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(0);

--- a/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
@@ -11,7 +11,7 @@
 
 import { IHandlerParameters } from "../../../../..";
 import { Config } from "../../../../../config/src/Config";
-import { IConfigOpts } from "../../../../../config";
+import { IConfig, IConfigOpts } from "../../../../../config";
 import { ImperativeConfig } from "../../../../../utilities";
 import { IImperativeConfig } from "../../../../src/doc/IImperativeConfig";
 import { ICredentialManagerInit } from "../../../../../security/src/doc/ICredentialManagerInit";
@@ -25,6 +25,7 @@ import * as path from "path";
 import * as lodash from "lodash";
 import * as fs from "fs";
 import * as os from "os";
+import { SessConstants } from "../../../../../rest";
 
 const getIHandlerParametersObject = (): IHandlerParameters => {
     const x: any = {
@@ -462,5 +463,304 @@ describe("Configuration Secure command handler", () => {
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(0);
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(0);
         expect(ImperativeConfig.instance.config.api.secure.secureFields().length).toEqual(0);
+    });
+
+    describe("special prompting for auth token", () => {
+        const expectedConfigObjectWithToken: IConfig = {
+            $schema: "./fakeapp.schema.json",
+            profiles: {
+                base: {
+                    type: "base",
+                    properties: {
+                        host: "example.com",
+                        port: 443,
+                        tokenType: SessConstants.TOKEN_TYPE_JWT
+                    },
+                    secure: [
+                        "tokenValue"
+                    ]
+                },
+            },
+            defaults: {
+                base: "base"
+            }
+        };
+
+        const authHandlerPath = __dirname + "/../../../../src/auth/handlers/BaseAuthHandler";
+        const handler = new SecureHandler();
+        const params = getIHandlerParametersObject();
+        let mockAuthLogin;
+        let mockGetPromptParams;
+        let promptWithTimeoutSpy;
+
+        beforeAll(() => {
+            mockAuthLogin = jest.fn().mockResolvedValue("fakeLoginData");
+            mockGetPromptParams = jest.fn().mockReturnValue([{ defaultTokenType: SessConstants.TOKEN_TYPE_JWT }, mockAuthLogin]);
+
+            jest.doMock(authHandlerPath, () => {
+                const { BaseAuthHandler } = jest.requireActual(authHandlerPath);
+                return {
+                    default: jest.fn(() => {
+                        const handler = Object.create(BaseAuthHandler.prototype);
+                        return Object.assign(handler, {
+                            getPromptParams: mockGetPromptParams
+                        });
+                    })
+                };
+            });
+        });
+
+        beforeEach(async () => {
+            params.arguments.userConfig = false;
+            params.arguments.globalConfig = false;
+
+            // Start doing fs mocks
+            // And the prompting of the secure handler
+            keytarGetPasswordSpy.mockReturnValue(fakeSecureData);
+            keytarSetPasswordSpy.mockImplementation();
+            keytarDeletePasswordSpy.mockImplementation();
+            readFileSyncSpy = jest.spyOn(fs, "readFileSync");
+            writeFileSyncSpy = jest.spyOn(fs, "writeFileSync");
+            existsSyncSpy = jest.spyOn(fs, "existsSync");
+
+            mockAuthLogin.mockClear();
+            promptWithTimeoutSpy = jest.fn(() => "fakePromptingData");
+            (params.response.console as any).prompt = promptWithTimeoutSpy;
+        });
+
+        it("should invoke auth handler to obtain token and store it securely", async () => {
+            const eco = lodash.cloneDeep(expectedConfigObjectWithToken);
+
+            readFileSyncSpy.mockReturnValueOnce(JSON.stringify(eco));
+            existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false); // Only the project config exists
+            writeFileSyncSpy.mockImplementation();
+            searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
+
+            await setupConfigToLoad(); // Setup the config
+
+            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValueOnce({
+                profiles: [{
+                    type: "base",
+                    authConfig: [{ handler: authHandlerPath } as any]
+                } as any]
+            });
+
+            await handler.process(params);
+
+            const fakeSecureDataExpectedJson = lodash.cloneDeep(fakeSecureDataJson);
+            delete fakeSecureDataExpectedJson[fakeProjPath];
+            fakeSecureDataExpectedJson[fakeProjPath] = {
+                "profiles.base.properties.tokenValue": "fakeLoginData"
+            };
+            const fakeSecureDataExpected = Buffer.from(JSON.stringify(fakeSecureDataExpectedJson)).toString("base64");
+
+            const compObj: any = {};
+            // Make changes to satisfy what would be stored on the JSON
+            compObj.$schema = "./fakeapp.schema.json"; // Fill in the name of the schema file, and make it first
+            lodash.merge(compObj, ImperativeConfig.instance.config.properties); // Add the properties from the config
+            delete compObj.profiles.base.properties.tokenValue;  // Delete the secret
+            compObj.profiles.base.secure = ["tokenValue"];  // Add the secret field to the secrets
+
+            expect(keytarDeletePasswordSpy).toHaveBeenCalledTimes(process.platform === "win32" ? 4 : 3);
+            expect(keytarGetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(2);  // User and password
+            expect(mockAuthLogin).toHaveBeenCalledTimes(1);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledWith("Zowe", "secure_config_props", fakeSecureDataExpected);
+            expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+            expect(writeFileSyncSpy).toHaveBeenNthCalledWith(1, fakeProjPath, JSON.stringify(compObj, null, 4)); // Config
+        });
+
+        it("should not invoke auth handler if profile type is undefined", async () => {
+            const eco = lodash.cloneDeep(expectedConfigObjectWithToken);
+            delete eco.profiles.base.type;
+
+            readFileSyncSpy.mockReturnValueOnce(JSON.stringify(eco));
+            existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false); // Only the project config exists
+            writeFileSyncSpy.mockImplementation();
+            searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
+
+            await setupConfigToLoad(); // Setup the config
+            await handler.process(params);
+
+            const fakeSecureDataExpectedJson = lodash.cloneDeep(fakeSecureDataJson);
+            delete fakeSecureDataExpectedJson[fakeProjPath];
+            fakeSecureDataExpectedJson[fakeProjPath] = {
+                "profiles.base.properties.tokenValue": "fakePromptingData"
+            };
+            const fakeSecureDataExpected = Buffer.from(JSON.stringify(fakeSecureDataExpectedJson)).toString("base64");
+
+            const compObj: any = {};
+            // Make changes to satisfy what would be stored on the JSON
+            compObj.$schema = "./fakeapp.schema.json"; // Fill in the name of the schema file, and make it first
+            lodash.merge(compObj, ImperativeConfig.instance.config.properties); // Add the properties from the config
+            delete compObj.profiles.base.properties.tokenValue;  // Delete the secret
+            compObj.profiles.base.secure = ["tokenValue"];  // Add the secret field to the secrets
+
+            expect(keytarDeletePasswordSpy).toHaveBeenCalledTimes(process.platform === "win32" ? 4 : 3);
+            expect(keytarGetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
+            expect(mockAuthLogin).toHaveBeenCalledTimes(0);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledWith("Zowe", "secure_config_props", fakeSecureDataExpected);
+            expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+            expect(writeFileSyncSpy).toHaveBeenNthCalledWith(1, fakeProjPath, JSON.stringify(compObj, null, 4)); // Config
+        });
+
+        it("should not invoke auth handler if profile token type is undefined", async () => {
+            const eco = lodash.cloneDeep(expectedConfigObjectWithToken);
+            delete eco.profiles.base.properties.tokenType;
+
+            readFileSyncSpy.mockReturnValueOnce(JSON.stringify(eco));
+            existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false); // Only the project config exists
+            writeFileSyncSpy.mockImplementation();
+            searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
+
+            await setupConfigToLoad(); // Setup the config
+            await handler.process(params);
+
+            const fakeSecureDataExpectedJson = lodash.cloneDeep(fakeSecureDataJson);
+            delete fakeSecureDataExpectedJson[fakeProjPath];
+            fakeSecureDataExpectedJson[fakeProjPath] = {
+                "profiles.base.properties.tokenValue": "fakePromptingData"
+            };
+            const fakeSecureDataExpected = Buffer.from(JSON.stringify(fakeSecureDataExpectedJson)).toString("base64");
+
+            const compObj: any = {};
+            // Make changes to satisfy what would be stored on the JSON
+            compObj.$schema = "./fakeapp.schema.json"; // Fill in the name of the schema file, and make it first
+            lodash.merge(compObj, ImperativeConfig.instance.config.properties); // Add the properties from the config
+            delete compObj.profiles.base.properties.tokenValue;  // Delete the secret
+            compObj.profiles.base.secure = ["tokenValue"];  // Add the secret field to the secrets
+
+            expect(keytarDeletePasswordSpy).toHaveBeenCalledTimes(process.platform === "win32" ? 4 : 3);
+            expect(keytarGetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
+            expect(mockAuthLogin).toHaveBeenCalledTimes(0);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledWith("Zowe", "secure_config_props", fakeSecureDataExpected);
+            expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+            expect(writeFileSyncSpy).toHaveBeenNthCalledWith(1, fakeProjPath, JSON.stringify(compObj, null, 4)); // Config
+        });
+
+        it("should not invoke auth handler if no matching auth config is found", async () => {
+            const eco = lodash.cloneDeep(expectedConfigObjectWithToken);
+
+            readFileSyncSpy.mockReturnValueOnce(JSON.stringify(eco));
+            existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false); // Only the project config exists
+            writeFileSyncSpy.mockImplementation();
+            searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
+
+            await setupConfigToLoad(); // Setup the config
+
+            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValueOnce({
+                profiles: [{
+                    type: "not-base",
+                    authConfig: [{ handler: authHandlerPath } as any]
+                } as any]
+            });
+
+            await handler.process(params);
+
+            const fakeSecureDataExpectedJson = lodash.cloneDeep(fakeSecureDataJson);
+            delete fakeSecureDataExpectedJson[fakeProjPath];
+            fakeSecureDataExpectedJson[fakeProjPath] = {
+                "profiles.base.properties.tokenValue": "fakePromptingData"
+            };
+            const fakeSecureDataExpected = Buffer.from(JSON.stringify(fakeSecureDataExpectedJson)).toString("base64");
+
+            const compObj: any = {};
+            // Make changes to satisfy what would be stored on the JSON
+            compObj.$schema = "./fakeapp.schema.json"; // Fill in the name of the schema file, and make it first
+            lodash.merge(compObj, ImperativeConfig.instance.config.properties); // Add the properties from the config
+            delete compObj.profiles.base.properties.tokenValue;  // Delete the secret
+            compObj.profiles.base.secure = ["tokenValue"];  // Add the secret field to the secrets
+
+            expect(keytarDeletePasswordSpy).toHaveBeenCalledTimes(process.platform === "win32" ? 4 : 3);
+            expect(keytarGetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
+            expect(mockAuthLogin).toHaveBeenCalledTimes(0);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledWith("Zowe", "secure_config_props", fakeSecureDataExpected);
+            expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+            expect(writeFileSyncSpy).toHaveBeenNthCalledWith(1, fakeProjPath, JSON.stringify(compObj, null, 4)); // Config
+        });
+
+        it("should not invoke auth handler if auth handler is for different token type", async () => {
+            const eco = lodash.cloneDeep(expectedConfigObjectWithToken);
+
+            readFileSyncSpy.mockReturnValueOnce(JSON.stringify(eco));
+            existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false); // Only the project config exists
+            writeFileSyncSpy.mockImplementation();
+            searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
+
+            await setupConfigToLoad(); // Setup the config
+
+            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValueOnce({
+                profiles: [{
+                    type: "base",
+                    authConfig: [{ handler: authHandlerPath } as any]
+                } as any]
+            });
+            mockGetPromptParams.mockReturnValueOnce([{ defaultTokenType: SessConstants.TOKEN_TYPE_LTPA }, mockAuthLogin]);
+
+            await handler.process(params);
+
+            const fakeSecureDataExpectedJson = lodash.cloneDeep(fakeSecureDataJson);
+            delete fakeSecureDataExpectedJson[fakeProjPath];
+            fakeSecureDataExpectedJson[fakeProjPath] = {
+                "profiles.base.properties.tokenValue": "fakePromptingData"
+            };
+            const fakeSecureDataExpected = Buffer.from(JSON.stringify(fakeSecureDataExpectedJson)).toString("base64");
+
+            const compObj: any = {};
+            // Make changes to satisfy what would be stored on the JSON
+            compObj.$schema = "./fakeapp.schema.json"; // Fill in the name of the schema file, and make it first
+            lodash.merge(compObj, ImperativeConfig.instance.config.properties); // Add the properties from the config
+            delete compObj.profiles.base.properties.tokenValue;  // Delete the secret
+            compObj.profiles.base.secure = ["tokenValue"];  // Add the secret field to the secrets
+
+            expect(keytarDeletePasswordSpy).toHaveBeenCalledTimes(process.platform === "win32" ? 4 : 3);
+            expect(keytarGetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(1);
+            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
+            expect(mockAuthLogin).toHaveBeenCalledTimes(0);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledWith("Zowe", "secure_config_props", fakeSecureDataExpected);
+            expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
+            expect(writeFileSyncSpy).toHaveBeenNthCalledWith(1, fakeProjPath, JSON.stringify(compObj, null, 4)); // Config
+        });
+
+        it("should fail to invoke auth handler if it throws an error", async () => {
+            const eco = lodash.cloneDeep(expectedConfigObjectWithToken);
+
+            readFileSyncSpy.mockReturnValueOnce(JSON.stringify(eco));
+            existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false); // Only the project config exists
+            writeFileSyncSpy.mockImplementation();
+            searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
+
+            await setupConfigToLoad(); // Setup the config
+
+            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValueOnce({
+                profiles: [{
+                    type: "base",
+                    authConfig: [{ handler: authHandlerPath } as any]
+                } as any]
+            });
+            mockAuthLogin.mockRejectedValueOnce(new Error("bad handler"));
+            let caughtError;
+
+            try {
+                await handler.process(params);
+            } catch (error) {
+                caughtError = error;
+            }
+
+            // expect(caughtError).toBeDefined();
+            // expect(caughtError.message).toContain("Failed to fetch jwtToken");
+            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(2);  // User and password
+            expect(mockAuthLogin).toHaveBeenCalledTimes(1);
+            expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(0);
+            expect(writeFileSyncSpy).toHaveBeenCalledTimes(0);
+        });
     });
 });

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -38,7 +38,7 @@ export abstract class BaseAuthHandler implements ICommandHandler {
     /**
      * The description of your service to be used in CLI prompt messages
      */
-    protected abstract mServiceDescription?: string;
+    protected mServiceDescription?: string;
 
     /**
      * The session being created from the command line arguments / profile

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -11,7 +11,7 @@
 
 import { ICommandHandler, IHandlerParameters, ICommandArguments, IHandlerResponseApi } from "../../../../cmd";
 import { Constants } from "../../../../constants";
-import { ISession, ConnectionPropsForSessCfg, Session, SessConstants, AbstractSession } from "../../../../rest";
+import { ISession, ConnectionPropsForSessCfg, Session, SessConstants, AbstractSession, IOptionsForAddConnProps } from "../../../../rest";
 import { Imperative } from "../../Imperative";
 import { ImperativeExpect } from "../../../../expect";
 import { ImperativeError } from "../../../../error";
@@ -34,6 +34,11 @@ export abstract class BaseAuthHandler implements ICommandHandler {
      * The default token type to use if not specified as a command line option
      */
     protected abstract mDefaultTokenType: SessConstants.TOKEN_TYPE_CHOICES;
+
+    /**
+     * The description of your service to be used in CLI prompt messages
+     */
+    protected abstract mServiceDescription?: string;
 
     /**
      * The session being created from the command line arguments / profile
@@ -62,6 +67,20 @@ export abstract class BaseAuthHandler implements ICommandHandler {
                     msg: `The group name "${commandParameters.positionals[1]}" was passed to the BaseAuthHandler, but it is not valid.`
                 });
         }
+    }
+
+    /**
+     * This is called by the "config secure" handler when it needs to prompt
+     * for connection info to obtain an auth token.
+     * @returns A tuple containing:
+     *  - Options for adding connection properties
+     *  - The login handler
+     */
+    public getPromptParams(): [IOptionsForAddConnProps, (session: AbstractSession) => Promise<string>] {
+        return [{
+            defaultTokenType: this.mDefaultTokenType,
+            serviceDescription: this.mServiceDescription
+        }, this.doLogin];
     }
 
     /**

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -23,6 +23,9 @@ import { ImperativeConfig } from "../../../../../utilities";
 import { BaseAuthHandler } from "../../../auth/handlers/BaseAuthHandler";
 
 export default class SecureHandler implements ICommandHandler {
+    /**
+     * The parameters object passed to the command handler.
+     */
     private params: IHandlerParameters;
 
     /**
@@ -51,9 +54,9 @@ export default class SecureHandler implements ICommandHandler {
         }
 
         // Prompt for values designated as secure
-        let authTokenProp: string;  // TODO Handle multiple auth tokens in one config file?
+        let authTokenProp: string;
         for (const propName of secureProps) {
-            if (authTokenProp == null && propName.endsWith(".tokenValue")) {  // TODO Handle kebab case?
+            if (authTokenProp == null && propName.endsWith(".tokenValue")) {
                 authTokenProp = propName;
                 continue;
             }
@@ -80,12 +83,20 @@ export default class SecureHandler implements ICommandHandler {
         await config.save(false);
     }
 
+    /**
+     * Checks if authentication service is associated with an auth token
+     * property. If an auth service is found, we log in to it obtain the token
+     * instead of prompting for the value.
+     * @param config Team config class from which the property was loaded
+     * @param propPath JSON property path of the auth token
+     * @returns Token value, or undefined if none was obtained
+     */
     private async handlePromptForAuthToken(config: Config, propPath: string): Promise<string | undefined> {
         const profilePath = propPath.slice(0, propPath.indexOf(".properties"));
         const profileType = lodash.get(config.properties, `${profilePath}.type`);
         const profile = config.api.profiles.get(profilePath.replace(/profiles\./g, ""));
         if (profileType == null || profile.tokenType == null) {
-            return;
+            return;  // Can't find auth service if profile type or token type are unknown
         }
 
         const authConfigs: ICommandProfileAuthConfig[] = [];
@@ -98,26 +109,27 @@ export default class SecureHandler implements ICommandHandler {
         for (const authConfig of authConfigs) {
             const authHandler: ICommandHandlerRequire = require(authConfig.handler);
             const authHandlerClass = new authHandler.default();
+
             if (authHandlerClass instanceof BaseAuthHandler) {
                 const [promptParams, loginHandler] = authHandlerClass.getPromptParams();
 
-                if (profile.tokenType === promptParams.defaultTokenType) {
-                    if (promptParams.serviceDescription != null) {
-                        this.params.response.console.log(`Logging in to ${promptParams.serviceDescription}`);
-                    }
+                if (profile.tokenType !== promptParams.defaultTokenType) {
+                    continue;  // Don't use auth service that has mismatched token type
+                } else if (promptParams.serviceDescription != null) {
+                    this.params.response.console.log(`Logging in to ${promptParams.serviceDescription}`);
+                }
 
-                    const sessCfg: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt({}, profile as ICommandArguments,
-                        { parms: this.params, doPrompting: true, requestToken: true, ...promptParams });
-                    Logger.getAppLogger().info(`Fetching ${profile.tokenType} for ${propPath}`);
+                const sessCfg: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt({}, profile as ICommandArguments,
+                    { parms: this.params, doPrompting: true, requestToken: true, ...promptParams });
+                Logger.getAppLogger().info(`Fetching ${profile.tokenType} for ${propPath}`);
 
-                    try {
-                        return await loginHandler(new Session(sessCfg));
-                    } catch (error) {
-                        throw new ImperativeError({
-                            msg: `Failed to fetch ${profile.tokenType} for ${propPath}`,
-                            causeErrors: error
-                        });
-                    }
+                try {
+                    return await loginHandler(new Session(sessCfg));
+                } catch (error) {
+                    throw new ImperativeError({
+                        msg: `Failed to fetch ${profile.tokenType} for ${propPath}`,
+                        causeErrors: error
+                    });
                 }
             }
         }

--- a/packages/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -173,7 +173,7 @@ export class ConnectionPropsForSessCfg {
             if (ConnectionPropsForSessCfg.propHasValue(sessCfgToUse.port) === false) {
                 let answer: any;
                 while (answer === undefined) {
-                    answer = await this.clientPrompt(`Enter the port number for ${serviceDescription}: `, {
+                    answer = await this.clientPrompt(`Enter the port number of ${serviceDescription}: `, {
                         parms: connOptsToUse.parms
                     });
                     if (answer === null) {
@@ -198,7 +198,7 @@ export class ConnectionPropsForSessCfg {
             if (ConnectionPropsForSessCfg.propHasValue(sessCfgToUse.user) === false) {
                 let answer = "";
                 while (answer === "") {
-                    answer = await this.clientPrompt("Enter user name: ", {
+                    answer = await this.clientPrompt(`Enter the user name for ${serviceDescription}: `, {
                         parms: connOptsToUse.parms
                     });
                     if (answer === null) {
@@ -212,7 +212,7 @@ export class ConnectionPropsForSessCfg {
                 let answer = "";
                 while (answer === "") {
 
-                    answer = await this.clientPrompt("Enter password : ", {
+                    answer = await this.clientPrompt(`Enter the password for ${serviceDescription}: `, {
                         hideText: true,
                         parms: connOptsToUse.parms
                     });


### PR DESCRIPTION
Instead of prompting users directly for token value, log in to an authentication service like API ML to obtain the token.

This implements the first part of https://github.com/zowe/zowe-cli/issues/923:
> 1. Standardize on `zowe config secure`
>     > prompt for a username/password combo to get the token