### PR TITLE
[next] Change default log level to WARN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Breaking: Changed default log level from DEBUG to WARN for Imperative logger and app logger to reduce the volume of logs written to disk. [#634](https://github.com/zowe/imperative/issues/634)
+
 ## `5.0.0-next.202109281439`
 
 - Enhancement: Added `config import` command that imports team config files from a local path or web URL. [#1083](https://github.com/zowe/zowe-cli/issues/1083)

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/__snapshots__/cli.imperative-test-cli.test.logging.integration.test.ts.snap
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/__snapshots__/cli.imperative-test-cli.test.logging.integration.test.ts.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`imperative-test-cli test logging command default levels app logger should default to DEBUG 1`] = `
+exports[`imperative-test-cli test logging command default levels app logger should default to WARN 1`] = `
 "Test Log Command!
 "
 `;
 
-exports[`imperative-test-cli test logging command default levels imperative logger should default to DEBUG 1`] = `
+exports[`imperative-test-cli test logging command default levels imperative logger should default to WARN 1`] = `
 "Test Log Command!
 "
 `;
 
-exports[`imperative-test-cli test logging command error & invalid value handling app logger should default to DEBUG if a blank is specified 1`] = `
+exports[`imperative-test-cli test logging command error & invalid value handling app logger should default to WARN if a blank is specified 1`] = `
 "Test Log Command!
 "
 `;
 
-exports[`imperative-test-cli test logging command error & invalid value handling app logger should default to DEBUG if an invalid level is specified also warn user with the error 1`] = `
+exports[`imperative-test-cli test logging command error & invalid value handling app logger should default to WARN if an invalid level is specified and also warn user with the error 1`] = `
 "Test Log Command!
 "
 `;
 
-exports[`imperative-test-cli test logging command error & invalid value handling imperative logger should default to DEBUG if a blank is specified 1`] = `
+exports[`imperative-test-cli test logging command error & invalid value handling imperative logger should default to WARN if a blank is specified 1`] = `
 "Test Log Command!
 "
 `;
 
-exports[`imperative-test-cli test logging command error & invalid value handling imperative logger should default to DEBUG if an invalid level is specified and also warn user with the error 1`] = `
+exports[`imperative-test-cli test logging command error & invalid value handling imperative logger should default to WARN if an invalid level is specified and also warn user with the error 1`] = `
 "Test Log Command!
 "
 `;

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.logging.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/test/cli.imperative-test-cli.test.logging.integration.test.ts
@@ -39,7 +39,7 @@ describe("imperative-test-cli test logging command", () => {
                 });
             });
 
-            it("should default to DEBUG", () => {
+            it("should default to WARN", () => {
                 // Log working directory to make it easier to identify the directory for this test
                 TestLogger.info(`Working directory: ${TEST_ENVIRONMENT.workingDir}`);
 
@@ -58,8 +58,8 @@ describe("imperative-test-cli test logging command", () => {
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
-                expect(logContents).toContain("[DEBUG]");
-                expect(logContents).toContain("[INFO]");
+                expect(logContents).not.toContain("[DEBUG]");
+                expect(logContents).not.toContain("[INFO]");
                 expect(logContents).toContain("[WARN]");
                 expect(logContents).toContain("[ERROR]");
                 expect(logContents).toContain("[FATAL]");
@@ -77,7 +77,7 @@ describe("imperative-test-cli test logging command", () => {
                 });
             });
 
-            it("should default to DEBUG", () => {
+            it("should default to WARN", () => {
                 // Log working directory to make it easier to identify the directory for this test
                 TestLogger.info(`Working directory: ${TEST_ENVIRONMENT.workingDir}`);
 
@@ -96,8 +96,8 @@ describe("imperative-test-cli test logging command", () => {
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
-                expect(logContents).toContain("[DEBUG]");
-                expect(logContents).toContain("[INFO]");
+                expect(logContents).not.toContain("[DEBUG]");
+                expect(logContents).not.toContain("[INFO]");
                 expect(logContents).toContain("[WARN]");
                 expect(logContents).toContain("[ERROR]");
                 expect(logContents).toContain("[FATAL]");
@@ -120,7 +120,7 @@ describe("imperative-test-cli test logging command", () => {
                 });
             });
 
-            it("should default to DEBUG if a blank is specified", () => {
+            it("should default to WARN if a blank is specified", () => {
                 // Log working directory to make it easier to identify the directory for this test
                 TestLogger.info(`Working directory: ${TEST_ENVIRONMENT.workingDir}`);
 
@@ -139,14 +139,14 @@ describe("imperative-test-cli test logging command", () => {
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
-                expect(logContents).toContain("[DEBUG]");
-                expect(logContents).toContain("[INFO]");
+                expect(logContents).not.toContain("[DEBUG]");
+                expect(logContents).not.toContain("[INFO]");
                 expect(logContents).toContain("[WARN]");
                 expect(logContents).toContain("[ERROR]");
                 expect(logContents).toContain("[FATAL]");
             });
 
-            it("should default to DEBUG if an invalid level is specified and also warn user with the error", () => {
+            it("should default to WARN if an invalid level is specified and also warn user with the error", () => {
                 // Log working directory to make it easier to identify the directory for this test
                 TestLogger.info(`Working directory: ${TEST_ENVIRONMENT.workingDir}`);
 
@@ -156,7 +156,7 @@ describe("imperative-test-cli test logging command", () => {
                 const errorMsg = response.stderr.toString();
                 expect(errorMsg).toContain("AWESOME");
                 expect(errorMsg).toContain("IMPERATIVE_TEST_CLI_IMPERATIVE_LOG_LEVEL");
-                expect(errorMsg).toContain(LoggerConfigBuilder.DEFAULT_LOG_LEVEL);
+                expect(errorMsg).toContain(LoggerConfigBuilder.getDefaultLogLevel());
                 expect(response.status).toBe(0);
                 expect(response.stdout.toString()).toMatchSnapshot();
 
@@ -168,8 +168,8 @@ describe("imperative-test-cli test logging command", () => {
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
-                expect(logContents).toContain("[DEBUG]");
-                expect(logContents).toContain("[INFO]");
+                expect(logContents).not.toContain("[DEBUG]");
+                expect(logContents).not.toContain("[INFO]");
                 expect(logContents).toContain("[WARN]");
                 expect(logContents).toContain("[ERROR]");
                 expect(logContents).toContain("[FATAL]");
@@ -187,7 +187,7 @@ describe("imperative-test-cli test logging command", () => {
                 });
             });
 
-            it("should default to DEBUG if a blank is specified", () => {
+            it("should default to WARN if a blank is specified", () => {
                 // Log working directory to make it easier to identify the directory for this test
                 TestLogger.info(`Working directory: ${TEST_ENVIRONMENT.workingDir}`);
 
@@ -206,14 +206,14 @@ describe("imperative-test-cli test logging command", () => {
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
-                expect(logContents).toContain("[DEBUG]");
-                expect(logContents).toContain("[INFO]");
+                expect(logContents).not.toContain("[DEBUG]");
+                expect(logContents).not.toContain("[INFO]");
                 expect(logContents).toContain("[WARN]");
                 expect(logContents).toContain("[ERROR]");
                 expect(logContents).toContain("[FATAL]");
             });
 
-            it("should default to DEBUG if an invalid level is specified also warn user with the error", () => {
+            it("should default to WARN if an invalid level is specified and also warn user with the error", () => {
                 // Log working directory to make it easier to identify the directory for this test
                 TestLogger.info(`Working directory: ${TEST_ENVIRONMENT.workingDir}`);
 
@@ -223,7 +223,7 @@ describe("imperative-test-cli test logging command", () => {
                 const errorMsg = response.stderr.toString();
                 expect(errorMsg).toContain("AWESOME");
                 expect(errorMsg).toContain("IMPERATIVE_TEST_CLI_APP_LOG_LEVEL");
-                expect(errorMsg).toContain(LoggerConfigBuilder.DEFAULT_LOG_LEVEL);
+                expect(errorMsg).toContain(LoggerConfigBuilder.getDefaultLogLevel());
                 expect(response.status).toBe(0);
                 expect(response.stdout.toString()).toMatchSnapshot();
 
@@ -235,8 +235,8 @@ describe("imperative-test-cli test logging command", () => {
 
                 // Check for each tag
                 expect(logContents).not.toContain("[TRACE]");
-                expect(logContents).toContain("[DEBUG]");
-                expect(logContents).toContain("[INFO]");
+                expect(logContents).not.toContain("[DEBUG]");
+                expect(logContents).not.toContain("[INFO]");
                 expect(logContents).toContain("[WARN]");
                 expect(logContents).toContain("[ERROR]");
                 expect(logContents).toContain("[FATAL]");

--- a/__tests__/src/packages/imperative/plugins/suites/UsingPlugins.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/UsingPlugins.ts
@@ -248,8 +248,8 @@ describe("Using a Plugin", () => {
         const impLogLocation = join(config.defaultHome, "imperative", "logs", "imperative.log");
         const impLogContent = readFileSync(impLogLocation).toString();
         expect(result.stdout).toContain(resolve(impLogLocation));
-        expect(impLogContent).toContain(`Log message from test plugin: DEBUG: ${randomTest}`);
-        expect(impLogContent).toContain(`Log message from test plugin: INFO: ${randomTest}`);
+        expect(impLogContent).not.toContain(`Log message from test plugin: DEBUG: ${randomTest}`);
+        expect(impLogContent).not.toContain(`Log message from test plugin: INFO: ${randomTest}`);
         expect(impLogContent).toContain(`Log message from test plugin: WARN: ${randomTest}`);
         expect(impLogContent).toContain(`Log message from test plugin: ERROR: ${randomTest}`);
 
@@ -257,8 +257,8 @@ describe("Using a Plugin", () => {
         const appLogLocation = join(config.defaultHome, config.name, "logs", config.name + ".log");
         const appLogContent = readFileSync(appLogLocation).toString();
         expect(result.stdout).toContain(resolve(appLogLocation));
-        expect(appLogContent).toContain(`Log message from test plugin: DEBUG: ${randomTest}`);
-        expect(appLogContent).toContain(`Log message from test plugin: INFO: ${randomTest}`);
+        expect(appLogContent).not.toContain(`Log message from test plugin: DEBUG: ${randomTest}`);
+        expect(appLogContent).not.toContain(`Log message from test plugin: INFO: ${randomTest}`);
         expect(appLogContent).toContain(`Log message from test plugin: WARN: ${randomTest}`);
         expect(appLogContent).toContain(`Log message from test plugin: ERROR: ${randomTest}`);
     });

--- a/packages/cmd/__tests__/help/WebHelpManager.test.ts
+++ b/packages/cmd/__tests__/help/WebHelpManager.test.ts
@@ -43,7 +43,7 @@ describe("WebHelpManager", () => {
         const cmdReponse = new CommandResponse({ silent: false });
         let opener: any;
         let instPluginsFileNm: string;
-        let oldProcessEnv;
+        let oldProcessEnv: any;
 
         beforeAll( async () => {
             jest.mock("opener");

--- a/packages/cmd/src/help/WebHelpManager.ts
+++ b/packages/cmd/src/help/WebHelpManager.ts
@@ -214,7 +214,8 @@ export class WebHelpManager implements IWebHelpManager {
         const currentMetadata: IWebHelpPackageMetadata[] = this.calcPackageMetadata(myConfig.callerPackageJson,
             require(path.join(myConfig.cliHome, "plugins", "plugins.json")));
 
-        const metadataChanged: boolean = !this.eqPackageMetadata(cachedMetadata, currentMetadata);
+        const metadataChanged: boolean = process.env.NODE_ENV === "development" ||
+            !this.eqPackageMetadata(cachedMetadata, currentMetadata);
         return metadataChanged ? currentMetadata : null;
     }
 

--- a/packages/imperative/__tests__/__snapshots__/LoggingConfigurer.test.ts.snap
+++ b/packages/imperative/__tests__/__snapshots__/LoggingConfigurer.test.ts.snap
@@ -40,19 +40,19 @@ Object {
         "appenders": Array [
           "app",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "default": Object {
         "appenders": Array [
           "default",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "imperative": Object {
         "appenders": Array [
           "imperative",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
     },
   },
@@ -107,7 +107,7 @@ Object {
         "appenders": Array [
           "default",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "imperative": Object {
         "appenders": Array [
@@ -186,13 +186,13 @@ Object {
         "appenders": Array [
           "default",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "extraOne": Object {
         "appenders": Array [
           "extraOne",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "extraTwo": Object {
         "appenders": Array [
@@ -251,13 +251,13 @@ Object {
         "appenders": Array [
           "app",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "default": Object {
         "appenders": Array [
           "default",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "imperative": Object {
         "appenders": Array [
@@ -310,19 +310,19 @@ Object {
         "appenders": Array [
           "app",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "default": Object {
         "appenders": Array [
           "default",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "imperative": Object {
         "appenders": Array [
           "imperative",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
     },
   },
@@ -369,19 +369,19 @@ Object {
         "appenders": Array [
           "app",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "default": Object {
         "appenders": Array [
           "default",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "imperative": Object {
         "appenders": Array [
           "imperative",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
     },
   },
@@ -428,19 +428,19 @@ Object {
         "appenders": Array [
           "app",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "default": Object {
         "appenders": Array [
           "default",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "imperative": Object {
         "appenders": Array [
           "imperative",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
     },
   },

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -489,7 +489,7 @@ export class Imperative {
             } else {
                 message = "Imperative log level '" + envSettings.imperativeLogLevel.value +
                     "' from environmental variable setting '" + envSettings.imperativeLogLevel.key + "' is not recognised.  " +
-                    "Logger level is set to '" + LoggerConfigBuilder.DEFAULT_LOG_LEVEL + "'.  " +
+                    "Logger level is set to '" + LoggerConfigBuilder.getDefaultLogLevel() + "'.  " +
                     "Valid levels are " + Logger.DEFAULT_VALID_LOG_LEVELS.toString();
                 new Console().warn(message);
                 this.log.warn(message);
@@ -507,7 +507,7 @@ export class Imperative {
             } else {
                 message = "Application log level '" + envSettings.appLogLevel.value +
                     "' from environmental variable setting '" + envSettings.appLogLevel.key + "' is not recognised.  " +
-                    "Logger level is set to '" + LoggerConfigBuilder.DEFAULT_LOG_LEVEL + "'.  " +
+                    "Logger level is set to '" + LoggerConfigBuilder.getDefaultLogLevel() + "'.  " +
                     "Valid levels are " + Logger.DEFAULT_VALID_LOG_LEVELS.toString();
                 new Console().warn(message);
                 this.log.warn(message);

--- a/packages/logger/__tests__/LoggerConfigBuilder.test.ts
+++ b/packages/logger/__tests__/LoggerConfigBuilder.test.ts
@@ -75,7 +75,7 @@ describe("LoggerConfigBuilder tests", () => {
     });
 
     describe("getDefaultLogLevel", () => {
-        let oldProcessEnv;
+        let oldProcessEnv: any;
 
         beforeEach(() => {
             oldProcessEnv = { ...process.env };

--- a/packages/logger/__tests__/LoggerConfigBuilder.test.ts
+++ b/packages/logger/__tests__/LoggerConfigBuilder.test.ts
@@ -47,7 +47,7 @@ describe("LoggerConfigBuilder tests", () => {
         expect(config).toMatchSnapshot();
     });
 
-    it("Should multiple appenders to basic log4js configuration", () => {
+    it("Should add multiple appenders to basic log4js configuration", () => {
         let config = LoggerConfigBuilder.getDefaultIConfigLogging();
         const file1Key = "sampleFile1";
         const file2Key = "sampleFile2";
@@ -74,4 +74,26 @@ describe("LoggerConfigBuilder tests", () => {
         expect(builtPath).toBe(result);
     });
 
+    describe("getDefaultLogLevel", () => {
+        let oldProcessEnv;
+
+        beforeEach(() => {
+            oldProcessEnv = { ...process.env };
+        });
+
+        afterEach(() => {
+            process.env = oldProcessEnv;
+        });
+
+        it("should default to log level DEBUG in development mode", () => {
+            process.env.NODE_ENV = "development";
+            const logLevel = LoggerConfigBuilder.getDefaultLogLevel();
+            expect(logLevel).toBe("DEBUG");
+        });
+
+        it("should default to log level WARN in production mode", () => {
+            const logLevel = LoggerConfigBuilder.getDefaultLogLevel();
+            expect(logLevel).toBe("WARN");
+        });
+    });
 });

--- a/packages/logger/__tests__/__snapshots__/LoggerConfigBuilder.test.ts.snap
+++ b/packages/logger/__tests__/__snapshots__/LoggerConfigBuilder.test.ts.snap
@@ -76,16 +76,7 @@ Object {
 }
 `;
 
-exports[`LoggerConfigBuilder tests Should get a basic log4js configuration from getDefaultIConfigLogging 1`] = `
-Object {
-  "log4jsConfig": Object {
-    "appenders": Object {},
-    "categories": Object {},
-  },
-}
-`;
-
-exports[`LoggerConfigBuilder tests Should multiple appenders to basic log4js configuration 1`] = `
+exports[`LoggerConfigBuilder tests Should add multiple appenders to basic log4js configuration 1`] = `
 Object {
   "log4jsConfig": Object {
     "appenders": Object {
@@ -150,6 +141,15 @@ Object {
         "level": "WARN",
       },
     },
+  },
+}
+`;
+
+exports[`LoggerConfigBuilder tests Should get a basic log4js configuration from getDefaultIConfigLogging 1`] = `
+Object {
+  "log4jsConfig": Object {
+    "appenders": Object {},
+    "categories": Object {},
   },
 }
 `;

--- a/packages/logger/__tests__/__snapshots__/LoggerConfigBuilder.test.ts.snap
+++ b/packages/logger/__tests__/__snapshots__/LoggerConfigBuilder.test.ts.snap
@@ -27,13 +27,13 @@ Object {
         "appenders": Array [
           "sampleConsole",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "sampleFile": Object {
         "appenders": Array [
           "sampleFile",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
     },
   },
@@ -69,7 +69,7 @@ Object {
         "appenders": Array [
           "sampleFile",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
     },
   },
@@ -129,25 +129,25 @@ Object {
         "appenders": Array [
           "sampleConsole1",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "sampleConsole2": Object {
         "appenders": Array [
           "sampleConsole2",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "sampleFile1": Object {
         "appenders": Array [
           "sampleFile1",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
       "sampleFile2": Object {
         "appenders": Array [
           "sampleFile2",
         ],
-        "level": "DEBUG",
+        "level": "WARN",
       },
     },
   },

--- a/packages/logger/src/LoggerConfigBuilder.ts
+++ b/packages/logger/src/LoggerConfigBuilder.ts
@@ -17,8 +17,6 @@ import * as os from "os";
 export class LoggerConfigBuilder {
 
     public static readonly DEFAULT_LANG = "en";
-
-    public static readonly DEFAULT_LOG_LEVEL = "DEBUG";
     public static readonly DEFAULT_LOG_TYPE_CONSOLE = "console";
     public static readonly DEFAULT_LOG_TYPE_PAT = "pattern";
     public static readonly DEFAULT_LOG_LAYOUT = "[%d{yyyy/MM/dd} %d{hh:mm:ss.SSS}] [%p] %m";
@@ -73,7 +71,7 @@ export class LoggerConfigBuilder {
         };
         config.log4jsConfig.categories[categoryName] = {
             appenders: [key],
-            level: logLevel ? logLevel : LoggerConfigBuilder.DEFAULT_LOG_LEVEL,
+            level: logLevel ? logLevel : LoggerConfigBuilder.getDefaultLogLevel(),
         };
         return config;
     }
@@ -97,7 +95,7 @@ export class LoggerConfigBuilder {
         };
         config.log4jsConfig.categories[categoryName] = {
             appenders: [key],
-            level: logLevel ? logLevel : LoggerConfigBuilder.DEFAULT_LOG_LEVEL,
+            level: logLevel ? logLevel : LoggerConfigBuilder.getDefaultLogLevel(),
         };
         return config;
     }
@@ -109,5 +107,13 @@ export class LoggerConfigBuilder {
     public static getDefaultFileName(name: string) {
         return LoggerConfigBuilder.DEFAULT_LOG_DIR + name + IO.FILE_DELIM +
         LoggerConfigBuilder.DEFAULT_LOG_FILE_DIR + name + LoggerConfigBuilder.DEFAULT_LOG_FILE_EXT;
+    }
+
+    /**
+     * Returns the log level that will be used if not overridden
+     * @returns {string} - the default log level
+     */
+    public static getDefaultLogLevel(): string {
+        return process.env.NODE_ENV === "development" ? "DEBUG" : "WARN";
     }
 }


### PR DESCRIPTION
Resolves #634. This is a breaking change.

When the environment variable `NODE_ENV=development` is set:
* Restores the old logging behavior (default log level of DEBUG)
* Disables web help caching (so that it always gets regenerated)