### PR TITLE
Move config load into try/catch block when --dcd specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Bugfix: Fix crashing issue related to reloading the config when `--dcd` option is specified [#943](https://github.com/zowe/zowe-cli/issues/943) [#1190](https://github.com/zowe/zowe-cli/issues/1190)
+
 ## `5.0.0-next.202111032034`
 
 - Enhancement: Added `autoStore` property to config JSON files which defaults to true. When this property is enabled and the CLI prompts you to enter connection info, the values you enter will be saved to disk (or credential vault if they are secure) for future use. [zowe/zowe-cli#923](https://github.com/zowe/zowe-cli/issues/923)

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/import/cli.imperative-test-cli.config.import.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/config/import/cli.imperative-test-cli.config.import.integration.test.ts
@@ -35,6 +35,8 @@ describe("imperative-test-cli config import", () => {
 
     // Create the test environment
     beforeAll(async () => {
+        const serverAddressRegex = /(http.*)\s/;
+
         TEST_ENVIRONMENT = await SetupTestEnvironment.createTestEnv({
             cliHomeEnvVar: "IMPERATIVE_TEST_CLI_CLI_HOME",
             testName: "imperative_test_cli_test_config_init_command"
@@ -47,7 +49,10 @@ describe("imperative-test-cli config import", () => {
         // Retrieve server URL from the end of first line printed to stdout
         localhostUrl = await new Promise((resolve, reject) => {
             pServer.stdout.on("data", (data: Buffer) => {
-                resolve(data.toString().trim().split(" ").pop());
+                const match = data.toString().match(serverAddressRegex);
+                if(match != null) {
+                    resolve(match[1]);
+                }
             });
         });
     });

--- a/packages/cmd/__tests__/__snapshots__/CommandProcessor.test.ts.snap
+++ b/packages/cmd/__tests__/__snapshots__/CommandProcessor.test.ts.snap
@@ -1245,6 +1245,24 @@ Line should not be indented",
 }
 `;
 
+exports[`Command Processor should reset noLoad on config load 1`] = `
+Object {
+  "data": Object {},
+  "error": undefined,
+  "exitCode": 0,
+  "message": "",
+  "stderr": Object {
+    "data": Array [],
+    "type": "Buffer",
+  },
+  "stdout": Object {
+    "data": Array [],
+    "type": "Buffer",
+  },
+  "success": true,
+}
+`;
+
 exports[`Command Processor should use the value specified on the CLI option, if the argument is supplied in both CLI and profile 1`] = `
 "green
 "

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -391,6 +391,9 @@ export class CommandProcessor {
                 process.chdir(params.arguments.dcd as string);
 
                 // reinit config for daemon client directory
+                if (ImperativeConfig.instance.config?.opts?.noLoad) {
+                    delete ImperativeConfig.instance.config.opts.noLoad;
+                }
                 const newOpts = ImperativeConfig.instance.config?.opts || {};
 
                 if (newOpts.vault == null) newOpts.vault = ImperativeConfig.instance.config?.mVault;

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -376,28 +376,28 @@ export class CommandProcessor {
         this.log.trace(`Invoke parameters:\n${inspect(params, { depth: null })}`);
         this.log.trace(`Command definition:\n${inspect(this.definition, { depth: null })}`);
 
-        // Build the response object, base args object, and the entire array of options for this command
-        // Assume that the command succeed, it will be marked otherwise under the appropriate failure conditions
-        if (params.arguments.dcd) {
-            // NOTE(Kelosky): we adjust `cwd` and do not restore it, so that multiple simultaneous requests from the same
-            // directory will operate without unexpected chdir taking place.  Multiple simultaneous requests from different
-            // directories may cause unpredictable results
-            process.chdir(params.arguments.dcd as string);
-
-            // reinit config for daemon client directory
-            const newOpts = ImperativeConfig.instance.config?.opts || {};
-
-            if (newOpts.vault == null) newOpts.vault = ImperativeConfig.instance.config?.mVault;
-            ImperativeConfig.instance.config = await Config.load(ImperativeConfig.instance.rootCommandName, newOpts);
-            this.mConfig = ImperativeConfig.instance.config;
-        }
-
         const prepareResponse = this.constructResponseObject(params);
         prepareResponse.succeeded();
 
         // Prepare for command processing - load profiles, stdin, etc.
         let prepared: ICommandPrepared;
         try {
+            // Build the response object, base args object, and the entire array of options for this command
+            // Assume that the command succeed, it will be marked otherwise under the appropriate failure conditions
+            if (params.arguments.dcd) {
+                // NOTE(Kelosky): we adjust `cwd` and do not restore it, so that multiple simultaneous requests from the same
+                // directory will operate without unexpected chdir taking place.  Multiple simultaneous requests from different
+                // directories may cause unpredictable results
+                process.chdir(params.arguments.dcd as string);
+
+                // reinit config for daemon client directory
+                const newOpts = ImperativeConfig.instance.config?.opts || {};
+
+                if (newOpts.vault == null) newOpts.vault = ImperativeConfig.instance.config?.mVault;
+                ImperativeConfig.instance.config = await Config.load(ImperativeConfig.instance.rootCommandName, newOpts);
+                this.mConfig = ImperativeConfig.instance.config;
+            }
+
             this.log.info(`Preparing (loading profiles, reading stdin, etc.) execution of "${this.definition.name}" command...`);
             prepared = await this.prepare(prepareResponse, params.arguments);
         } catch (prepareErr) {

--- a/packages/config/__tests__/__resources__/badproject.config.json
+++ b/packages/config/__tests__/__resources__/badproject.config.json
@@ -1,0 +1,30 @@
+{
+    "profiles": {
+        "fruit": {
+            "properties": {
+                "origin": "California"
+            },
+            "profiles": {
+                "apple": {
+                    "type": "fruit",
+                    "properties": {
+                        "color": "green"
+                    }
+                },
+                "orange": {
+                    "type": "fruit",
+                    "properties": {
+                        "color": "orange"
+                    }
+                }
+            },
+            "secure": [
+                "secret"
+            ]
+        }
+    },
+    "defaults": {
+        "fruit": "fruit.orange"
+    }
+    "plugins": []
+}

--- a/packages/config/__tests__/__snapshots__/Config.secure.test.ts.snap
+++ b/packages/config/__tests__/__snapshots__/Config.secure.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Config secure tests should not actually load config that has a bad vault when noLoad specified 1`] = `
+Object {
+  "defaults": Object {},
+  "profiles": Object {},
+}
+`;

--- a/packages/config/__tests__/__snapshots__/Config.test.ts.snap
+++ b/packages/config/__tests__/__snapshots__/Config.test.ts.snap
@@ -209,6 +209,20 @@ Object {
 }
 `;
 
+exports[`Config tests load should not actually load config that seems to exist but is malformed when noLoad specified 1`] = `
+Object {
+  "defaults": Object {},
+  "profiles": Object {},
+}
+`;
+
+exports[`Config tests load should not try to load config that seems to exist but doesn't 1`] = `
+Object {
+  "defaults": Object {},
+  "profiles": Object {},
+}
+`;
+
 exports[`Config tests set should add a new layer when one is specified in the set 1`] = `
 Object {
   "fruit": Object {

--- a/packages/config/__tests__/__snapshots__/Config.test.ts.snap
+++ b/packages/config/__tests__/__snapshots__/Config.test.ts.snap
@@ -216,13 +216,6 @@ Object {
 }
 `;
 
-exports[`Config tests load should not try to load config that seems to exist but doesn't 1`] = `
-Object {
-  "defaults": Object {},
-  "profiles": Object {},
-}
-`;
-
 exports[`Config tests set should add a new layer when one is specified in the set 1`] = `
 Object {
   "fruit": Object {

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -163,7 +163,7 @@ export class Config {
         try {
             let setActive = true;
             for (const currLayer of myNewConfig.mLayers) {
-                await myNewConfig.api.layers.read(currLayer);
+                if (!opts.noLoad) { await myNewConfig.api.layers.read(currLayer); }
 
                 // Find the active layer
                 if (setActive && currLayer.exists) {
@@ -185,7 +185,7 @@ export class Config {
         }
 
         // Load secure fields
-        await myNewConfig.api.secure.load();
+        if (!opts.noLoad) { await myNewConfig.api.secure.load(); }
 
         return myNewConfig;
     }

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -130,6 +130,7 @@ export class Config {
      * Load config files from disk and secure properties from vault.
      * @param app App name used in config filenames (e.g., *my_cli*.config.json)
      * @param opts Options to control how Config class behaves
+     * @throws An ImperativeError if the configuration does not load successfully
      */
     public static async load(app: string, opts?: IConfigOpts): Promise<Config> {
         opts = opts || {};

--- a/packages/config/src/doc/IConfigOpts.ts
+++ b/packages/config/src/doc/IConfigOpts.ts
@@ -26,4 +26,9 @@ export interface IConfigOpts {
      * Vault object with methods for loading and saving secure credentials
      */
     vault?: IConfigVault;
+
+    /**
+     * Do not attempt to load the config, meant for when the config is broken
+     */
+    noLoad?: boolean;
 }

--- a/packages/imperative/__tests__/ConfigurationLoader.test.ts
+++ b/packages/imperative/__tests__/ConfigurationLoader.test.ts
@@ -12,6 +12,12 @@
 import { ConfigurationLoader } from "..";
 import { IImperativeOverrides } from "../src/doc/IImperativeOverrides";
 import { IApimlSvcAttrs } from "../src/doc/IApimlSvcAttrs";
+import { homedir } from "os";
+import * as path from "path";
+
+function getCallerFile(file: string) {
+    return require(file);
+}
 
 describe("ConfigurationLoader", () => {
     describe("overrides", () => {
@@ -68,6 +74,57 @@ describe("ConfigurationLoader", () => {
             );
 
             expect(result.apimlConnLookup).toEqual(apimlConnLookup);
+        });
+    });
+
+    describe("ConfigurationModule", () => {
+        it("should return a config", () => {
+
+            const result = ConfigurationLoader.load(
+                {
+                    configurationModule: path.join(__dirname, "__model__", "Sample.configuration.ts")
+                },
+                {},
+                getCallerFile
+            );
+
+            expect(result.productDisplayName).toEqual("Zowe");
+            expect(result.rootCommandDescription).toEqual("Sample");
+            expect(result.envVariablePrefix).toEqual("Sample");
+            expect(result.defaultHome).toEqual(homedir());
+        });
+        it("should return a config without changing the name", () => {
+
+            const result = ConfigurationLoader.load(
+                {
+                    productDisplayName: "notZowe",
+                    configurationModule: path.join(__dirname, "__model__", "Sample.configuration.ts")
+                },
+                {},
+                getCallerFile
+            );
+
+            expect(result.productDisplayName).toEqual("Zowe");
+            expect(result.rootCommandDescription).toEqual("Sample");
+            expect(result.envVariablePrefix).toEqual("Sample");
+            expect(result.defaultHome).toEqual(homedir());
+        });
+        it("should return a config with daemonMode", () => {
+
+            const result = ConfigurationLoader.load(
+                {
+                    configurationModule: path.join(__dirname, "__model__", "Sample.configuration.ts"),
+                    daemonMode: true
+                },
+                {},
+                getCallerFile
+            );
+
+            expect(result.productDisplayName).toEqual("Zowe");
+            expect(result.rootCommandDescription).toEqual("Sample");
+            expect(result.envVariablePrefix).toEqual("Sample");
+            expect(result.defaultHome).toEqual(homedir());
+            expect(result.daemonMode).toEqual(true);
         });
     });
 });

--- a/packages/imperative/__tests__/Imperative.test.ts
+++ b/packages/imperative/__tests__/Imperative.test.ts
@@ -235,7 +235,7 @@ describe("Imperative", () => {
                 expect(ConfigManagementFacility.instance.init).toHaveBeenCalledTimes(1);
             });
 
-            it("should surface failures if daemonMode is specified", async () => {
+            it("should surface failures if daemonMode is not specified", async () => {
                 jest.spyOn(mocks.Config, "load").mockRejectedValueOnce(new ImperativeError({msg: "Config error"})).mockResolvedValue({});
                 let error;
                 try {

--- a/packages/imperative/__tests__/Imperative.test.ts
+++ b/packages/imperative/__tests__/Imperative.test.ts
@@ -18,6 +18,7 @@ import { IConfigLogging } from "../../logger";
 import { IImperativeEnvironmentalVariableSettings } from "..";
 import { ICommandDefinition } from "../../cmd/src/doc/ICommandDefinition";
 import * as yargs from "yargs";
+import { ImperativeError } from "../../error/src/ImperativeError";
 
 describe("Imperative", () => {
     const mainModule = process.mainModule;
@@ -232,6 +233,35 @@ describe("Imperative", () => {
                 await Imperative.init();
 
                 expect(ConfigManagementFacility.instance.init).toHaveBeenCalledTimes(1);
+            });
+
+            it("should surface failures if daemonMode is specified", async () => {
+                jest.spyOn(mocks.Config, "load").mockRejectedValueOnce(new ImperativeError({msg: "Config error"})).mockResolvedValue({});
+                let error;
+                try {
+                    await Imperative.init();
+                } catch (err) {
+                    error = err;
+                }
+
+                expect(error).toBeDefined();
+                expect(ConfigManagementFacility.instance.init).toHaveBeenCalledTimes(1);
+                expect(mocks.Config.load).toHaveBeenCalledTimes(1);
+            });
+
+            it("should not surface failures if daemonMode is specified", async () => {
+                mocks.ConfigurationLoader.load.mockReturnValue({...defaultConfig, daemonMode: true});
+                jest.spyOn(mocks.Config, "load").mockRejectedValueOnce(new ImperativeError({msg: "Config error"})).mockResolvedValue({});
+                let error;
+                try {
+                    await Imperative.init();
+                } catch (err) {
+                    error = err;
+                }
+
+                expect(error).not.toBeDefined();
+                expect(ConfigManagementFacility.instance.init).toHaveBeenCalledTimes(1);
+                expect(mocks.Config.load).toHaveBeenCalledTimes(2);
             });
         });
 

--- a/packages/imperative/__tests__/__model__/Sample.configuration.ts
+++ b/packages/imperative/__tests__/__model__/Sample.configuration.ts
@@ -1,0 +1,27 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { IImperativeConfig } from "../../src/doc/IImperativeConfig";
+import { homedir } from "os";
+
+const config: IImperativeConfig = {
+    productDisplayName: "Zowe",
+    commandModuleGlobs: [],
+    rootCommandDescription: "Sample",
+    defaultHome: homedir(),
+    envVariablePrefix: "Sample",
+    logging: {
+        appLogging: {
+            logFile: "fake"
+        }
+    }
+};
+module.exports = config;

--- a/packages/imperative/src/ConfigurationLoader.ts
+++ b/packages/imperative/src/ConfigurationLoader.ts
@@ -57,7 +57,7 @@ export class ConfigurationLoader {
             try {
                 const daemonMode = config.daemonMode;
                 config = callerFileRequirer(config.configurationModule);
-                config.daemonMode = daemonMode;
+                if (daemonMode) {config.daemonMode = daemonMode;}
             } catch (e) {
                 throw new ImperativeError({
                     msg:

--- a/packages/imperative/src/ConfigurationLoader.ts
+++ b/packages/imperative/src/ConfigurationLoader.ts
@@ -55,7 +55,9 @@ export class ConfigurationLoader {
         // override the config with the content of the module specified
         if (config.configurationModule != null) {
             try {
+                const daemonMode = config.daemonMode;
                 config = callerFileRequirer(config.configurationModule);
+                config.daemonMode = daemonMode;
             } catch (e) {
                 throw new ImperativeError({
                     msg:

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -191,10 +191,18 @@ export class Imperative {
                     ConfigManagementFacility.ConfigManagementFacility.instance.init();
                 }
 
-                // Load the base config
+                let delayedConfigLoadError = undefined;
+
+                // Load the base config, save any error from config load
                 const configAppName = ImperativeConfig.instance.findPackageBinName() ? this.mRootCommandName : config.name;
-                ImperativeConfig.instance.config = await Config.load(configAppName,
-                    { homeDir: ImperativeConfig.instance.cliHome });
+
+                try {
+                    ImperativeConfig.instance.config = await Config.load(configAppName,
+                        { homeDir: ImperativeConfig.instance.cliHome }
+                    );
+                } catch (err) {
+                    delayedConfigLoadError = err;
+                }
 
                 // If plugins are allowed, enable core plugins commands
                 if (config.allowPlugins) {
@@ -219,6 +227,24 @@ export class Imperative {
                  * Any other initialization added to this routine should occur after logging has been initialized.
                  */
                 this.initLogging();
+
+                /**
+                 * If there was an error trying to load the user's configuration, tell them about it now.
+                 */
+                if (delayedConfigLoadError) {
+                    if (config.daemonMode) {
+                        ImperativeConfig.instance.config = await Config.load(configAppName,
+                            {
+                                homeDir: ImperativeConfig.instance.cliHome,
+                                noLoad: true
+                            }
+                        );
+                        const imperativeLogger = Logger.getImperativeLogger();
+                        imperativeLogger.error(delayedConfigLoadError);
+                    } else {
+                        throw delayedConfigLoadError;
+                    }
+                }
 
                 /**
                  * Now we should apply any overrides to default Imperative functionality. This is where CLI

--- a/packages/imperative/src/doc/IImperativeConfig.ts
+++ b/packages/imperative/src/doc/IImperativeConfig.ts
@@ -326,4 +326,12 @@ export interface IImperativeConfig {
      * @memberof IImperativeConfig
      */
     apimlConnLookup?: IApimlSvcAttrs[];
+
+    /**
+     * If Imperative should run in Daemon mode
+     * This should only be specified for CLIs
+     * @type {boolean}
+     * @memberof IImperativeConfig
+     */
+    daemonMode?: boolean;
 }


### PR DESCRIPTION
Fixes Daemon error when an incorrect zowe.config.json file is supplied.
Updates Config.load API to have a `@throws` in the JS Doc.

Fixes zowe/zowe-cli#943
Fixes zowe/zowe-cli#1190