### PR TITLE
[next] Make credentials secure by default for v1 profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Imperative package will be documented in this file.
 ## Recent Changes
 
 - BugFix: Changed credentials to be stored securely by default for v1 profiles to be consistent with the experience for v2 profiles. [zowe/zowe-cli#1128](https://github.com/zowe/zowe-cli/issues/1128)
+- **Next Breaking**
+    - Removed the `credentialServiceName` property from ImperativeConfig. The default credential manager uses the `name` property instead.
 
 ## `5.0.0-next.202111101806`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Changed credentials to be stored securely by default for v1 profiles to be consistent with the experience for v2 profiles. [zowe/zowe-cli#1128](https://github.com/zowe/zowe-cli/issues/1128)
+
 ## `5.0.0-next.202111101806`
 
 - Enhancement: Added `dry-run` option for `zowe config init` command to preview changes instead of saving them to disk. [#1037](https://github.com/zowe/zowe-cli/issues/1037)

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.logout.fruit.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.logout.fruit.integration.test.ts
@@ -17,7 +17,7 @@ import * as keytar from "keytar";
 
 // Test Environment populated in the beforeAll();
 let TEST_ENVIRONMENT: ITestEnvironment;
-describe("cmd-cli auth logout", () => {
+describe("imperative-test-cli auth logout", () => {
     async function loadSecureProp(profileName: string): Promise<string> {
         const securedValue = await keytar.getPassword("imperative-test-cli", "secure_config_props");
         const securedValueJson = JSON.parse(Buffer.from(securedValue, "base64").toString());

--- a/__tests__/__integration__/imperative/src/imperative.ts
+++ b/__tests__/__integration__/imperative/src/imperative.ts
@@ -66,7 +66,6 @@ export const config: IImperativeConfig = {
     defaultHome: "~/.imperative-test-cli",
     productDisplayName: "Imperative Package Test CLI",
     name: "imperative-test-cli",
-    credentialServiceName: "imperative-test-cli",
     envVariablePrefix: "IMPERATIVE_TEST_CLI",
     allowPlugins: false,
     configAutoInitCommandConfig: {

--- a/__tests__/src/packages/profiles/CliProfileManager.credentials.spec.ts
+++ b/__tests__/src/packages/profiles/CliProfileManager.credentials.spec.ts
@@ -297,7 +297,7 @@ describe("Cli Profile Manager", () => {
                 expect(result.stderr).toMatch(credentialManagerErrorMessage);
             });
 
-            it("should be able to isssue command", () => {
+            it("should be able to issue command", () => {
                 renameKeyTar();
 
                 const cmd = `display-non-keytar`;

--- a/packages/cmd/__tests__/__snapshots__/CommandProcessor.test.ts.snap
+++ b/packages/cmd/__tests__/__snapshots__/CommandProcessor.test.ts.snap
@@ -1245,24 +1245,6 @@ Line should not be indented",
 }
 `;
 
-exports[`Command Processor should reset noLoad on config load 1`] = `
-Object {
-  "data": Object {},
-  "error": undefined,
-  "exitCode": 0,
-  "message": "",
-  "stderr": Object {
-    "data": Array [],
-    "type": "Buffer",
-  },
-  "stdout": Object {
-    "data": Array [],
-    "type": "Buffer",
-  },
-  "success": true,
-}
-`;
-
 exports[`Command Processor should use the value specified on the CLI option, if the argument is supplied in both CLI and profile 1`] = `
 "green
 "

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -390,15 +390,8 @@ export class CommandProcessor {
                 // directories may cause unpredictable results
                 process.chdir(params.arguments.dcd as string);
 
-                // reinit config for daemon client directory
-                if (ImperativeConfig.instance.config?.opts?.noLoad != null) {
-                    delete ImperativeConfig.instance.config.opts.noLoad;
-                }
-                const newOpts = ImperativeConfig.instance.config?.opts || {};
-
-                if (newOpts.vault == null) newOpts.vault = ImperativeConfig.instance.config?.mVault;
-                ImperativeConfig.instance.config = await Config.load(ImperativeConfig.instance.rootCommandName, newOpts);
-                this.mConfig = ImperativeConfig.instance.config;
+                // reload config for daemon client directory
+                await ImperativeConfig.instance.config.reload();
             }
 
             this.log.info(`Preparing (loading profiles, reading stdin, etc.) execution of "${this.definition.name}" command...`);

--- a/packages/config/__tests__/Config.test.ts
+++ b/packages/config/__tests__/Config.test.ts
@@ -203,6 +203,34 @@ describe("Config tests", () => {
         });
     });
 
+    it("should reload config in new project directory", async () => {
+        // First load project and project user layers
+        jest.spyOn(Config, "search")
+            .mockReturnValueOnce(__dirname + "/__resources__/project.config.user.json")
+            .mockReturnValueOnce(__dirname + "/__resources__/project.config.json");
+        jest.spyOn(fs, "existsSync")
+            .mockReturnValueOnce(true)      // Project user layer
+            .mockReturnValueOnce(true)      // Project layer
+            .mockReturnValueOnce(false)     // User layer
+            .mockReturnValueOnce(false);    // Global layer
+        const config = await Config.load(MY_APP);
+        expect(config.properties.profiles.fruit.profiles.orange).toBeDefined();
+        expect(config.properties.profiles.vegetable).toBeUndefined();
+
+        // Then reload the layers with different contents
+        jest.spyOn(Config, "search")
+            .mockReturnValueOnce(__dirname + "/__resources__/my_app.config.user.json")
+            .mockReturnValueOnce(__dirname + "/__resources__/my_app.config.json");
+        jest.spyOn(fs, "existsSync")
+            .mockReturnValueOnce(true)      // Project user layer
+            .mockReturnValueOnce(true)      // Project layer
+            .mockReturnValueOnce(false)     // User layer
+            .mockReturnValueOnce(false);    // Global layer
+        await config.reload();
+        expect(config.properties.profiles.fruit.profiles.banana).toBeDefined();
+        expect(config.properties.profiles.vegetable).toBeDefined();
+    });
+
     it("should return the app name", () => {
         const config = new (Config as any)();
         config.mApp = "greatAppName";

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -148,20 +148,36 @@ export class Config {
         // Create the basic empty configuration
         const myNewConfig = new Config(opts);
         myNewConfig.mApp = app;
-        myNewConfig.mLayers = [];
-        myNewConfig.mHomeDir = opts.homeDir || path.join(os.homedir(), `.${app}`);
-        myNewConfig.mProjectDir = opts.projectDir || process.cwd();
         myNewConfig.mActive = { user: false, global: false };
         myNewConfig.mVault = opts.vault;
         myNewConfig.mSecure = {};
+
+        // Populate configuration file layers
+        await myNewConfig.reload(opts);
+
+        // Load secure fields
+        if (!opts.noLoad) { await myNewConfig.api.secure.load(); }
+
+        return myNewConfig;
+    }
+
+    /**
+     * Reload config files from disk in the current project directory.
+     * @param opts Options to control how Config class behaves
+     * @throws An ImperativeError if the configuration does not load successfully
+     */
+    public async reload(opts?: IConfigOpts) {
+        this.mLayers = [];
+        this.mHomeDir = opts?.homeDir || path.join(os.homedir(), `.${this.mApp}`);
+        this.mProjectDir = opts?.projectDir || process.cwd();
 
         // Populate configuration file layers
         for (const layer of [
             Layers.ProjectUser, Layers.ProjectConfig,
             Layers.GlobalUser, Layers.GlobalConfig
         ]) {
-            myNewConfig.mLayers.push({
-                path: myNewConfig.layerPath(layer),
+            this.mLayers.push({
+                path: this.layerPath(layer),
                 exists: false,
                 properties: Config.empty(),
                 global: layer === Layers.GlobalUser || layer === Layers.GlobalConfig,
@@ -172,13 +188,13 @@ export class Config {
         // Read and populate each configuration layer
         try {
             let setActive = true;
-            for (const currLayer of myNewConfig.mLayers) {
-                if (!opts.noLoad) { await myNewConfig.api.layers.read(currLayer); }
+            for (const currLayer of this.mLayers) {
+                if (!opts?.noLoad) { await this.api.layers.read(currLayer); }
 
                 // Find the active layer
                 if (setActive && currLayer.exists) {
-                    myNewConfig.mActive.user = currLayer.user;
-                    myNewConfig.mActive.global = currLayer.global;
+                    this.mActive.user = currLayer.user;
+                    this.mActive.global = currLayer.global;
                     setActive = false;
                 }
 
@@ -193,11 +209,6 @@ export class Config {
                 throw new ImperativeError({ msg: `An unexpected error occurred during config load: ${e.message}` });
             }
         }
-
-        // Load secure fields
-        if (!opts.noLoad) { await myNewConfig.api.secure.load(); }
-
-        return myNewConfig;
     }
 
     // _______________________________________________________________________

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -106,6 +106,16 @@ export class Config {
      */
     public mSecure: IConfigSecure;
 
+    /**
+     * Cached version of Config APIs
+     */
+    private mApi: {
+        profiles: ConfigProfiles,
+        plugins: ConfigPlugins,
+        layers: ConfigLayers,
+        secure: ConfigSecure
+    };
+
     // _______________________________________________________________________
     /**
      * Constructor for Config class. Don't use this directly. Await `Config.load` instead.
@@ -248,12 +258,15 @@ export class Config {
      * Access the config API for manipulating profiles, plugins, layers, and secure values.
      */
     get api() {
-        return {
-            profiles: new ConfigProfiles(this),
-            plugins: new ConfigPlugins(this),
-            layers: new ConfigLayers(this),
-            secure: new ConfigSecure(this)
-        };
+        if (this.mApi == null) {
+            this.mApi = {
+                profiles: new ConfigProfiles(this),
+                plugins: new ConfigPlugins(this),
+                layers: new ConfigLayers(this),
+                secure: new ConfigSecure(this)
+            };
+        }
+        return this.mApi;
     }
 
     // _______________________________________________________________________

--- a/packages/imperative/__tests__/Imperative.test.ts
+++ b/packages/imperative/__tests__/Imperative.test.ts
@@ -191,7 +191,7 @@ describe("Imperative", () => {
         });
 
         describe("AppSettings", () => {
-            const defaultSettings = { overrides: { CredentialManager: false } };
+            const defaultSettings = { overrides: { CredentialManager: "host-package" } };
             it("should initialize an app settings instance", async () => {
                 await Imperative.init();
 

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -342,7 +342,7 @@ describe("OverridesLoader", () => {
         const callerPackageJson = { name: "host-package" };
         const loadedConfig = "fakeConfig";
         const mockSecureLoad = jest.fn();
-        let loadCredMgrSpy;
+        let loadCredMgrSpy: any;
 
         beforeEach(() => {
             jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValue({

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -79,7 +79,7 @@ describe("OverridesLoader", () => {
 
             jest.spyOn(AppSettings, "initialized", "get").mockReturnValue(true);
             jest.spyOn(AppSettings, "instance", "get").mockReturnValue({
-                getNamespace: () => null
+                getNamespace: jest.fn()
             } as any);
             await OverridesLoader.load(config, packageJson);
 

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -77,7 +77,10 @@ describe("OverridesLoader", () => {
                 }
             };
 
-            jest.spyOn(AppSettings, "initialized", "get").mockReturnValueOnce(true);
+            jest.spyOn(AppSettings, "initialized", "get").mockReturnValue(true);
+            jest.spyOn(AppSettings, "instance", "get").mockReturnValue({
+                getNamespace: () => null
+            } as any);
             await OverridesLoader.load(config, packageJson);
 
             // It should not have called initialize
@@ -113,9 +116,7 @@ describe("OverridesLoader", () => {
         it("should load the default when override matches host package name and keytar is present in dependencies", async () => {
             const config: IImperativeConfig = {
                 name: "ABCD",
-                overrides: {
-                    CredentialManager: "host-package"
-                },
+                overrides: {},
                 productDisplayName: "a fake CLI"
             };
 
@@ -127,6 +128,10 @@ describe("OverridesLoader", () => {
                 }
             };
 
+            jest.spyOn(AppSettings, "initialized", "get").mockReturnValue(true);
+            jest.spyOn(AppSettings, "instance", "get").mockReturnValue({
+                getNamespace: () => ({ CredentialManager: "host-package" })
+            } as any);
             await OverridesLoader.load(config, packageJson);
 
             expect(CredentialManagerFactory.initialize).toHaveBeenCalledTimes(1);

--- a/packages/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.test.ts
@@ -19,6 +19,7 @@ import * as open from "open";
 import { ConfigSchema } from "../../../../../config";
 import { CredentialManagerFactory } from "../../../../../security";
 import { SessConstants } from "../../../../../rest";
+import { OverridesLoader } from "../../../../src/OverridesLoader";
 
 describe("BaseAutoInitHandler", () => {
     beforeEach( async () => {
@@ -71,7 +72,7 @@ describe("BaseAutoInitHandler", () => {
         };
         const mockSetSchema = jest.fn();
         const buildSchemaSpy = jest.spyOn(ConfigSchema, 'buildSchema').mockImplementation();
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         const displayAutoInitChangesSpy = jest.spyOn(handler as any, "displayAutoInitChanges");
         jest.spyOn(ImperativeConfig, 'instance', "get").mockReturnValue({
             config: {
@@ -148,7 +149,7 @@ describe("BaseAutoInitHandler", () => {
             }
         };
         const buildSchemaSpy = jest.spyOn(ConfigSchema, 'buildSchema').mockImplementation();
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         const displayAutoInitChangesSpy = jest.spyOn(handler as any, "displayAutoInitChanges");
         const mockSetSchema = jest.fn();
 
@@ -228,7 +229,7 @@ describe("BaseAutoInitHandler", () => {
             }
         };
         const buildSchemaSpy = jest.spyOn(ConfigSchema, 'buildSchema').mockImplementation();
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         const displayAutoInitChangesSpy = jest.spyOn(handler as any, "displayAutoInitChanges");
         const mockSetSchema = jest.fn();
 
@@ -308,7 +309,7 @@ describe("BaseAutoInitHandler", () => {
         });
         const mockSecureFields = jest.fn().mockReturnValue([]);
         const mockFindSecure = jest.fn().mockReturnValue([]);
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         const displayAutoInitChangesSpy = jest.spyOn(handler as any, "displayAutoInitChanges");
         const mockImperativeConfigApi = {
             layers: {
@@ -390,7 +391,7 @@ describe("BaseAutoInitHandler", () => {
             exists: true,
             properties: {}
         });
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         const displayAutoInitChangesSpy = jest.spyOn(handler as any, "displayAutoInitChanges");
         const mockImperativeConfigApi = {
             layers: {
@@ -466,7 +467,7 @@ describe("BaseAutoInitHandler", () => {
             exists: true,
             properties: {}
         });
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         const displayAutoInitChangesSpy = jest.spyOn(handler as any, "displayAutoInitChanges");
         const mockImperativeConfigApi = {
             layers: {
@@ -563,7 +564,7 @@ describe("BaseAutoInitHandler", () => {
         });
         const mockSecureFields = jest.fn().mockReturnValue(["profiles.base.properties.tokenValue"]);
         const mockFindSecure = jest.fn().mockReturnValue([]);
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         const displayAutoInitChangesSpy = jest.spyOn(handler as any, "displayAutoInitChanges");
         const mockImperativeConfigApi = {
             layers: {

--- a/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
@@ -23,6 +23,7 @@ import * as lodash from "lodash";
 import * as fs from "fs";
 import * as os from "os";
 import { CredentialManagerFactory } from "../../../../../security";
+import { OverridesLoader } from "../../../../src/OverridesLoader";
 
 jest.mock("fs");
 
@@ -108,7 +109,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -160,7 +161,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -203,7 +204,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -250,7 +251,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -291,7 +292,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -345,7 +346,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -388,7 +389,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies
@@ -437,7 +438,7 @@ describe("Configuration Initialization command handler", () => {
         searchSpy.mockReturnValueOnce(fakeProjUserPath).mockReturnValueOnce(fakeProjPath); // Give search something to return
         await setupConfigToLoad(); // Setup the config
 
-        const ensureCredMgrSpy = jest.spyOn(handler as any, "ensureCredentialManagerLoaded");
+        const ensureCredMgrSpy = jest.spyOn(OverridesLoader, "ensureCredentialManagerLoaded");
         setSchemaSpy = jest.spyOn(ImperativeConfig.instance.config, "setSchema");
 
         // We aren't testing the config initialization - clear the spies

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -480,7 +480,7 @@ export class Imperative {
 
         const defaultSettings: ISettingsFile = {
             overrides: {
-                CredentialManager: false
+                CredentialManager: ImperativeConfig.instance.hostPackageName
             }
         };
 

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -63,7 +63,6 @@ import { CompleteAuthGroupBuilder } from "./auth/builders/CompleteAuthGroupBuild
 import { Config } from "../../config/src/Config";
 import { CompleteAutoInitCommandBuilder } from "./config/cmd/auto-init/builders/CompleteAutoInitCommandBuilder";
 import { ICommandProfileAutoInitConfig } from "../../cmd/src/doc/profiles/definition/ICommandProfileAutoInitConfig";
-import * as lodash from "lodash";
 
 // Bootstrap the performance tools
 if (PerfTiming.isEnabled) {
@@ -484,9 +483,6 @@ export class Imperative {
                 CredentialManager: ImperativeConfig.instance.hostPackageName
             }
         };
-
-        ImperativeConfig.instance.loadedConfig.overrides = lodash.defaults(
-            ImperativeConfig.instance.loadedConfig.overrides, defaultSettings.overrides);
 
         AppSettings.initialize(
             cliSettingsFile,

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -63,6 +63,7 @@ import { CompleteAuthGroupBuilder } from "./auth/builders/CompleteAuthGroupBuild
 import { Config } from "../../config/src/Config";
 import { CompleteAutoInitCommandBuilder } from "./config/cmd/auto-init/builders/CompleteAutoInitCommandBuilder";
 import { ICommandProfileAutoInitConfig } from "../../cmd/src/doc/profiles/definition/ICommandProfileAutoInitConfig";
+import * as lodash from "lodash";
 
 // Bootstrap the performance tools
 if (PerfTiming.isEnabled) {
@@ -483,6 +484,9 @@ export class Imperative {
                 CredentialManager: ImperativeConfig.instance.hostPackageName
             }
         };
+
+        ImperativeConfig.instance.loadedConfig.overrides = lodash.defaults(
+            ImperativeConfig.instance.loadedConfig.overrides, defaultSettings.overrides);
 
         AppSettings.initialize(
             cliSettingsFile,

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -85,7 +85,7 @@ export class OverridesLoader {
             (!AppSettings.initialized || useTeamConfig || overrides.CredentialManager === packageJson.name);
 
         // Initialize the credential manager if an override was supplied and/or keytar was supplied in package.json
-        if (overrides.CredentialManager != null || cliHasKeytar) {
+        if ((overrides.CredentialManager != null && overrides.CredentialManager !== packageJson.name) || cliHasKeytar) {
             let Manager = overrides.CredentialManager;
             if (typeof overrides.CredentialManager === "string" && !isAbsolute(overrides.CredentialManager)) {
                 Manager = (overrides.CredentialManager !== packageJson.name) ?
@@ -104,7 +104,7 @@ export class OverridesLoader {
             });
         }
 
-        if (useTeamConfig) await OverridesLoader.loadSecureConfig();
+        await OverridesLoader.loadSecureConfig();
     }
 
     /**

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -82,8 +82,7 @@ export class OverridesLoader {
         if (overrides.CredentialManager != null || this.shouldUseKeytar(packageJson, useTeamConfig)) {
             let Manager = overrides.CredentialManager;
             if (typeof overrides.CredentialManager === "string" && !isAbsolute(overrides.CredentialManager)) {
-                Manager = (overrides.CredentialManager !== packageJson.name) ?
-                    resolve(process.mainModule.filename, "../", overrides.CredentialManager) : undefined;
+                Manager = resolve(process.mainModule.filename, "../", overrides.CredentialManager);
             }
 
             await CredentialManagerFactory.initialize({

--- a/packages/imperative/src/OverridesLoader.ts
+++ b/packages/imperative/src/OverridesLoader.ts
@@ -79,8 +79,7 @@ export class OverridesLoader {
             config.productDisplayName || config.name;
 
         // Initialize the credential manager if an override was supplied and/or keytar was supplied in package.json
-        if ((overrides.CredentialManager != null && overrides.CredentialManager !== packageJson.name) ||
-            this.shouldUseKeytar(overrides, packageJson, useTeamConfig)) {
+        if (overrides.CredentialManager != null || this.shouldUseKeytar(packageJson, useTeamConfig)) {
             let Manager = overrides.CredentialManager;
             if (typeof overrides.CredentialManager === "string" && !isAbsolute(overrides.CredentialManager)) {
                 Manager = (overrides.CredentialManager !== packageJson.name) ?
@@ -108,14 +107,13 @@ export class OverridesLoader {
      *  1. AppSettings are not initialized (SDK usage)
      *  2. Team config is active (CLI with v2 profiles)
      *  3. CredentialManager override is host package name (CLI with v1 profiles)
-     * @param overrides Imperative overrides object that includes CredentialManager
      * @param packageJson The current package.json of the CLI package
      * @param useTeamConfig Specify True if team config is active
      * @returns True if DefaultCredentialManager should be used
      */
-    private static shouldUseKeytar(overrides: IImperativeOverrides, packageJson: any, useTeamConfig: boolean): boolean {
+    private static shouldUseKeytar(packageJson: any, useTeamConfig: boolean): boolean {
         return (packageJson.dependencies?.keytar != null || packageJson.optionalDependencies?.keytar != null) &&
-            (!AppSettings.initialized || useTeamConfig || overrides.CredentialManager === packageJson.name);
+            (!AppSettings.initialized || useTeamConfig || AppSettings.instance.getNamespace("overrides")?.CredentialManager === packageJson.name);
     }
 
     /**

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -16,7 +16,6 @@ import { ImperativeExpect } from "../../../../expect";
 import { ImperativeError } from "../../../../error";
 import { ISaveProfileFromCliArgs } from "../../../../profiles";
 import { ImperativeConfig } from "../../../../utilities";
-import { CredentialManagerFactory } from "../../../../security";
 import { ConfigAutoStore } from "../../../../config/src/ConfigAutoStore";
 import { getActiveProfileName, secureSaveError } from "../../../../config/src/ConfigUtils";
 import { AbstractAuthHandler } from "./AbstractAuthHandler";
@@ -94,7 +93,7 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
         } else if (!ImperativeConfig.instance.config.exists) {
             // process login for old school profiles
             await this.processLoginOld(params, tokenValue);
-        } else if (!CredentialManagerFactory.initialized) {
+        } else if (ImperativeConfig.instance.config.api.secure.loadFailed) {
             throw secureSaveError(`Instead of secure storage, rerun this command with the "--show-token" flag to print the token to console. ` +
                 `Store the token in an environment variable ${ImperativeConfig.instance.loadedConfig.envVariablePrefix}_OPT_TOKEN_VALUE to use it ` +
                 `in future commands.`);

--- a/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
+++ b/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
@@ -17,7 +17,6 @@ import * as open from "open";
 import * as JSONC from "comment-json";
 import * as lodash from "lodash";
 import { ImperativeConfig, TextUtils } from "../../../../../../utilities";
-import { CredentialManagerFactory } from "../../../../../../security";
 import { OverridesLoader } from "../../../../OverridesLoader";
 
 import stripAnsi = require("strip-ansi");
@@ -96,7 +95,7 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
         let user = false;
 
         // Use params to set which config layer to apply to
-        await this.ensureCredentialManagerLoaded();
+        await OverridesLoader.ensureCredentialManagerLoaded();
         if (params.arguments.globalConfig && params.arguments.globalConfig === true) {
             global = true;
         }
@@ -179,17 +178,6 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
         // we only display changes if we made changes
         if (!params.arguments.dryRun || params.arguments.dryRun === false) {
             this.displayAutoInitChanges(params.response);
-        }
-    }
-
-    /**
-     * If CredentialManager was not already loaded by Imperative.init, load it
-     * now before performing config operations in the auto-init handler.
-     */
-    private async ensureCredentialManagerLoaded() {
-        if (!CredentialManagerFactory.initialized) {
-            await OverridesLoader.loadCredentialManager(ImperativeConfig.instance.loadedConfig,
-                ImperativeConfig.instance.callerPackageJson);
         }
     }
 }

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -15,7 +15,6 @@ import { Config, ConfigConstants, ConfigSchema, IConfig } from "../../../../../c
 import { IProfileProperty } from "../../../../../profiles";
 import { ConfigBuilder } from "../../../../../config/src/ConfigBuilder";
 import { IConfigBuilderOpts } from "../../../../../config/src/doc/IConfigBuilderOpts";
-import { CredentialManagerFactory } from "../../../../../security";
 import { coercePropValue, secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { OverridesLoader } from "../../../OverridesLoader";
 import * as JSONC from "comment-json";
@@ -49,7 +48,7 @@ export default class InitHandler implements ICommandHandler {
         if (params.arguments.dryRun && params.arguments.dryRun === true) {
             let dryRun = await this.initForDryRun(config, params.arguments.userConfig);
 
-            if (params.arguments.prompt !== false && !CredentialManagerFactory.initialized && config.api.secure.secureFields().length > 0) {
+            if (params.arguments.prompt !== false && config.api.secure.loadFailed && config.api.secure.secureFields().length > 0) {
                 const warning = secureSaveError();
                 params.response.console.log(TextUtils.chalk.yellow("Warning:\n") +
                     `${warning.message} Skipped prompting for credentials.\n\n${warning.additionalDetails}\n`);
@@ -99,7 +98,7 @@ export default class InitHandler implements ICommandHandler {
         } else {
             await this.initWithSchema(config, params.arguments.userConfig);
 
-            if (params.arguments.prompt !== false && !CredentialManagerFactory.initialized && config.api.secure.secureFields().length > 0) {
+            if (params.arguments.prompt !== false && config.api.secure.loadFailed && config.api.secure.secureFields().length > 0) {
                 const warning = secureSaveError();
                 params.response.console.log(TextUtils.chalk.yellow("Warning:\n") +
                     `${warning.message} Skipped prompting for credentials.\n\n${warning.additionalDetails}\n`);
@@ -158,7 +157,7 @@ export default class InitHandler implements ICommandHandler {
      */
     private async promptForProp(propName: string, property: IProfileProperty): Promise<any> {
         // skip prompting in CI environment
-        if (this.params.arguments.prompt === false || !CredentialManagerFactory.initialized) {
+        if (this.params.arguments.prompt === false || ImperativeConfig.instance.config.api.secure.loadFailed) {
             return null;
         }
 

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -40,7 +40,7 @@ export default class InitHandler implements ICommandHandler {
         this.params = params;
 
         // Load the config and set the active layer according to user options
-        await this.ensureCredentialManagerLoaded();
+        await OverridesLoader.ensureCredentialManagerLoaded();
         const config = ImperativeConfig.instance.config;
         const configDir = params.arguments.globalConfig ? null : process.cwd();
         config.api.layers.activate(params.arguments.userConfig, params.arguments.globalConfig, configDir);
@@ -108,17 +108,6 @@ export default class InitHandler implements ICommandHandler {
             // Write the active created/updated config layer
             await config.save(false);
             params.response.console.log(`Saved config template to ${layer.path}`);
-        }
-    }
-
-    /**
-     * If CredentialManager was not already loaded by Imperative.init, load it
-     * now before performing config operations in the init handler.
-     */
-    private async ensureCredentialManagerLoaded() {
-        if (!CredentialManagerFactory.initialized) {
-            await OverridesLoader.loadCredentialManager(ImperativeConfig.instance.loadedConfig,
-                ImperativeConfig.instance.callerPackageJson);
         }
     }
 

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -15,7 +15,6 @@ import { secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { ImperativeError } from "../../../../../error";
 import { Logger } from "../../../../../logger";
 import { ConnectionPropsForSessCfg, ISession, Session } from "../../../../../rest";
-import { CredentialManagerFactory } from "../../../../../security";
 import { ImperativeConfig } from "../../../../../utilities";
 
 export default class SecureHandler implements ICommandHandler {
@@ -33,14 +32,14 @@ export default class SecureHandler implements ICommandHandler {
      */
     public async process(params: IHandlerParameters): Promise<void> {
         this.params = params;
+        const config = ImperativeConfig.instance.config;
 
         // Setup the credential vault API for the config
-        if (!CredentialManagerFactory.initialized) {
+        if (config.api.secure.loadFailed) {
             throw secureSaveError();
         }
 
         // Create the config, load the secure values, and activate the desired layer
-        const config = ImperativeConfig.instance.config;
         config.api.layers.activate(params.arguments.userConfig, params.arguments.globalConfig);
         const secureProps: string[] = config.api.secure.secureFields();
 

--- a/packages/imperative/src/config/cmd/set/set.handler.ts
+++ b/packages/imperative/src/config/cmd/set/set.handler.ts
@@ -13,7 +13,6 @@ import * as JSONC from "comment-json";
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
 import { secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { ImperativeError } from "../../../../../error";
-import { CredentialManagerFactory } from "../../../../../security";
 import { ImperativeConfig } from "../../../../../utilities";
 
 export default class SetHandler implements ICommandHandler {
@@ -38,7 +37,7 @@ export default class SetHandler implements ICommandHandler {
         }
 
         // Setup the credential vault API for the config
-        if (secure && !CredentialManagerFactory.initialized) {
+        if (secure && config.api.secure.loadFailed) {
             throw secureSaveError();
         }
 

--- a/packages/imperative/src/doc/IImperativeConfig.ts
+++ b/packages/imperative/src/doc/IImperativeConfig.ts
@@ -310,14 +310,6 @@ export interface IImperativeConfig {
     webHelpCustomCssPath?: string;
 
     /**
-     * Service name that should be used in vault for secure credentials.
-     * If omitted, the default service name "Zowe" is used.
-     * @type {string}
-     * @memberof IImperativeConfig
-     */
-    credentialServiceName?: string;
-
-    /**
      * The set of attributes used to lookup (within the API Mediation Layer)
      * the connection properties for the REST service associated with this
      * command group. We use an array of such attributes in case the command

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -260,7 +260,7 @@ export class PluginManagementFacility {
         // plugin is the pluginName from which to get the setting. This is probably the ugliest piece
         // of code that I have ever written :/
         for (const [setting, pluginName] of Object.entries(AppSettings.instance.getNamespace("overrides"))) {
-            if (pluginName !== false) {
+            if (pluginName !== false && pluginName !== ImperativeConfig.instance.hostPackageName) {
                 Logger.getImperativeLogger().debug(
                     `PluginOverride: Attempting to overwrite "${setting}" with value provided by plugin "${pluginName}"`
                 );

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -256,28 +256,10 @@ export class PluginManagementFacility {
             }
         }
 
-        // First come, first serve - If we're using a config, aggregate the
-        // override specifications for each plugin - then we can add those
-        // from app settings
-        let overrideSettings: any = {};
-        if (this.pmfConst.PLUGIN_USING_CONFIG) {
-            for (const plugin of this.pmfConst.PLUGIN_CONFIG.api.plugins.get()) {
-                if (loadedOverrides[plugin] != null) {
-                    for (const key of Object.keys(loadedOverrides[plugin])) {
-                        if (overrideSettings[key] == null) {
-                            overrideSettings[key] = plugin;
-                        }
-                    }
-                }
-            }
-        }
-
-        overrideSettings = { ...AppSettings.instance.getNamespace("overrides"), ...overrideSettings };
-
         // Loop through each overrides setting here. Setting is an override that we are modifying while
         // plugin is the pluginName from which to get the setting. This is probably the ugliest piece
         // of code that I have ever written :/
-        for (const [setting, pluginName] of Object.entries(overrideSettings)) {
+        for (const [setting, pluginName] of Object.entries(AppSettings.instance.getNamespace("overrides"))) {
             if (pluginName !== false) {
                 Logger.getImperativeLogger().debug(
                     `PluginOverride: Attempting to overwrite "${setting}" with value provided by plugin "${pluginName}"`


### PR DESCRIPTION
Resolves zowe/zowe-cli#1128 by changing the default CredentialManager setting in `~/.zowe/settings/imperative.json` to the package name of the host CLI (`@zowe/cli`). Supported values for CredentialManager are:
* `CredentialManager = false` - Store credentials in plain text. This was the default setting in Zowe v1 LTS and is preserved for backwards compatibility. This setting is ignored for v2 profiles which are always secure.
* `CredentialManager = '@zowe/cli'` - Store credentials using built-in credential manager. This PR makes this the default setting in Zowe v2 LTS. In v1 profiles, values of secure fields will show up as `managed by Zowe CLI`.
* `CredentialManager = 'XXX'` - Store credentials using a custom credential manager. This was only supported for v1 profiles previously, but is also supported for v2 profiles now.
---
**TODO: Test cases**
* [x] Clean install of vNext, store credentials in v1 profile
* [x] Clean install of vNext, store credentials in v2 profile
* [x] Zowe v1 with CredentialManager false, update to vNext, load/store credentials in v1 profile
* [x] Zowe v1 with CredentialManager SCS, update to vNext, load/store credentials in v1 profile
* [x] Zowe v1 with CredentialManager SCS, update to vNext, uninstall SCS [1], load/store credentials in v1 profile
* [x] Zowe v1 with CredentialManager false, update to vNext, store credentials in v2 profile
* [x] Zowe v1 with CredentialManager SCS, update to vNext, store credentials in v2 profile
* [x] Zowe v1 with CredentialManager SCS, update to vNext, uninstall SCS [1], store credentials in v2 profile
* [x] Clean install of vNext in environment that does not support Keytar, fail to store secure credentials in v1 profile
* [x] In same environment, remove CredentialManager setting, store plain text credentials in v1 profile
* [x] Clean install of vNext in environment that does not support Keytar, fail to store secure credentials in v2 profile
* [x] In same environment, remove CredentialManager setting, fail to store secure credentials in v2 profile
* [x] Clean install of vNext in environment that does not support Keytar, bypass secure credentials in v2 profile with env vars
* [x] Repeat all of the above tests using daemon mode (will do after PR has been reviewed 😋)
  * All cases pass except for https://github.com/zowe/zowe-cli/issues/1215
* [x] Zowe v1 with CredentialManager SCS, update to vNext w/ daemon, switch from folder w/o team config to folder with it
  * Ensure no regression of https://github.com/zowe/zowe-cli/issues/984

[1] Per [Zowe docs](https://docs.zowe.org/stable/user-guide/cli-install-cli-next/), uninstall SCS plug-in, and delete ~/.zowe/settings/imperative.json where it is set as the CredentialManager. The planned migration utility should eventually automate this process.