### PR TITLE
Fix secure properties not loaded in daemon mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed daemon mode not loading secure properties in team config. [zowe/zowe-cli#1232](https://github.com/zowe/zowe-cli/issues/1232)
+
 ## `5.0.0-next.202112021611`
 
 - BugFix: Fixed `config import` and `config init` behaving incorrectly when config JSON exists in higher level directory. [zowe/zowe-cli#1218](https://github.com/zowe/zowe-cli/issues/1218)

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -153,10 +153,10 @@ export class Config {
         myNewConfig.mSecure = {};
 
         // Populate configuration file layers
-        await myNewConfig.reload(opts);
+        await myNewConfig.reload({ ...opts, noSecureLoad: true });
 
         // Load secure fields
-        if (!opts.noLoad) { await myNewConfig.api.secure.load(); }
+        if (!opts?.noLoad && !opts?.noSecureLoad) { await myNewConfig.api.secure.load(); }
 
         return myNewConfig;
     }
@@ -209,6 +209,8 @@ export class Config {
                 throw new ImperativeError({ msg: `An unexpected error occurred during config load: ${e.message}` });
             }
         }
+
+        if (!opts?.noSecureLoad) { this.api.secure.loadSecureProps(); }
     }
 
     // _______________________________________________________________________

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -153,10 +153,7 @@ export class Config {
         myNewConfig.mSecure = {};
 
         // Populate configuration file layers
-        await myNewConfig.reload({ ...opts, noSecureLoad: true });
-
-        // Load secure fields
-        if (!opts?.noLoad && !opts?.noSecureLoad) { await myNewConfig.api.secure.load(); }
+        await myNewConfig.reload(opts);
 
         return myNewConfig;
     }
@@ -210,7 +207,8 @@ export class Config {
             }
         }
 
-        if (!opts?.noSecureLoad) { this.api.secure.loadSecureProps(); }
+        // Load secure fields
+        if (!opts?.noLoad && !this.api.secure.loadFailed) { await this.api.secure.load(); }
     }
 
     // _______________________________________________________________________

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -207,8 +207,10 @@ export class Config {
             }
         }
 
-        // Load secure fields
-        if (!opts?.noLoad && !this.api.secure.loadFailed) { await this.api.secure.load(); }
+        // Load secure fields unless we have already failed to load them from the vault
+        if (!opts?.noLoad && (opts?.vault != null || !this.api.secure.loadFailed)) {
+            await this.api.secure.load(opts?.vault);
+        }
     }
 
     // _______________________________________________________________________

--- a/packages/config/src/api/ConfigSecure.ts
+++ b/packages/config/src/api/ConfigSecure.ts
@@ -49,7 +49,36 @@ export class ConfigSecure extends ConfigApi {
         }
         this.mLoadFailed = false;
 
-        this.loadSecureProps();
+        // populate each layers properties
+        for (const layer of this.mConfig.mLayers) {
+
+            // Find the matching layer
+            for (const [filePath, secureProps] of Object.entries(this.mConfig.mSecure)) {
+                if (filePath === layer.path) {
+
+                    // Only set those indicated by the config
+                    for (const p of this.secureFields(layer)) {
+
+                        // Extract and set secure properties
+                        for (const [sPath, sValue] of Object.entries(secureProps)) {
+                            if (sPath === p) {
+                                const segments = sPath.split(".");
+                                let obj: any = layer.properties;
+                                for (let x = 0; x < segments.length; x++) {
+                                    const segment = segments[x];
+                                    if (x === segments.length - 1) {
+                                        obj[segment] = sValue;
+                                        break;
+                                    }
+                                    obj = obj[segment];
+                                    if (obj == null) break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // _______________________________________________________________________
@@ -134,43 +163,6 @@ export class ConfigSecure extends ConfigApi {
             }
         }
         return secureProps;
-    }
-
-    /**
-     * Merge secure property values into config layers.
-     * @internal
-     */
-    public loadSecureProps() {
-        // populate each layers properties
-        for (const layer of this.mConfig.mLayers) {
-
-            // Find the matching layer
-            for (const [filePath, secureProps] of Object.entries(this.mConfig.mSecure)) {
-                if (filePath === layer.path) {
-
-                    // Only set those indicated by the config
-                    for (const p of this.secureFields(layer)) {
-
-                        // Extract and set secure properties
-                        for (const [sPath, sValue] of Object.entries(secureProps)) {
-                            if (sPath === p) {
-                                const segments = sPath.split(".");
-                                let obj: any = layer.properties;
-                                for (let x = 0; x < segments.length; x++) {
-                                    const segment = segments[x];
-                                    if (x === segments.length - 1) {
-                                        obj[segment] = sValue;
-                                        break;
-                                    }
-                                    obj = obj[segment];
-                                    if (obj == null) break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 
     /**

--- a/packages/config/src/api/ConfigSecure.ts
+++ b/packages/config/src/api/ConfigSecure.ts
@@ -49,36 +49,7 @@ export class ConfigSecure extends ConfigApi {
         }
         this.mLoadFailed = false;
 
-        // populate each layers properties
-        for (const layer of this.mConfig.mLayers) {
-
-            // Find the matching layer
-            for (const [filePath, secureProps] of Object.entries(this.mConfig.mSecure)) {
-                if (filePath === layer.path) {
-
-                    // Only set those indicated by the config
-                    for (const p of this.secureFields(layer)) {
-
-                        // Extract and set secure properties
-                        for (const [sPath, sValue] of Object.entries(secureProps)) {
-                            if (sPath === p) {
-                                const segments = sPath.split(".");
-                                let obj: any = layer.properties;
-                                for (let x = 0; x < segments.length; x++) {
-                                    const segment = segments[x];
-                                    if (x === segments.length - 1) {
-                                        obj[segment] = sValue;
-                                        break;
-                                    }
-                                    obj = obj[segment];
-                                    if (obj == null) break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        this.loadSecureProps();
     }
 
     // _______________________________________________________________________
@@ -163,6 +134,43 @@ export class ConfigSecure extends ConfigApi {
             }
         }
         return secureProps;
+    }
+
+    /**
+     * Merge secure property values into config layers.
+     * @internal
+     */
+    public loadSecureProps() {
+        // populate each layers properties
+        for (const layer of this.mConfig.mLayers) {
+
+            // Find the matching layer
+            for (const [filePath, secureProps] of Object.entries(this.mConfig.mSecure)) {
+                if (filePath === layer.path) {
+
+                    // Only set those indicated by the config
+                    for (const p of this.secureFields(layer)) {
+
+                        // Extract and set secure properties
+                        for (const [sPath, sValue] of Object.entries(secureProps)) {
+                            if (sPath === p) {
+                                const segments = sPath.split(".");
+                                let obj: any = layer.properties;
+                                for (let x = 0; x < segments.length; x++) {
+                                    const segment = segments[x];
+                                    if (x === segments.length - 1) {
+                                        obj[segment] = sValue;
+                                        break;
+                                    }
+                                    obj = obj[segment];
+                                    if (obj == null) break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/packages/config/src/api/ConfigSecure.ts
+++ b/packages/config/src/api/ConfigSecure.ts
@@ -230,6 +230,6 @@ export class ConfigSecure extends ConfigApi {
      * it was never called because the CredentialManager failed to initialize.
      */
     public get loadFailed(): boolean {
-        return this.mLoadFailed || !CredentialManagerFactory.initialized;
+        return (this.mLoadFailed != null) ? this.mLoadFailed : !CredentialManagerFactory.initialized;
     }
 }

--- a/packages/config/src/doc/IConfigOpts.ts
+++ b/packages/config/src/doc/IConfigOpts.ts
@@ -31,9 +31,4 @@ export interface IConfigOpts {
      * Do not attempt to load the config, meant for when the config is broken
      */
     noLoad?: boolean;
-
-    /**
-     * Do not attempt to load secure fields in the config, meant for when the credential manager is broken
-     */
-    noSecureLoad?: boolean;
 }

--- a/packages/config/src/doc/IConfigOpts.ts
+++ b/packages/config/src/doc/IConfigOpts.ts
@@ -31,4 +31,9 @@ export interface IConfigOpts {
      * Do not attempt to load the config, meant for when the config is broken
      */
     noLoad?: boolean;
+
+    /**
+     * Do not attempt to load secure fields in the config, meant for when the credential manager is broken
+     */
+    noSecureLoad?: boolean;
 }


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-cli/issues/1232 by loading secure properties inside `Config.reload`