### PR TITLE
[next] Deprecate v1 profiles API on IHandlerParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 - BugFix: Removed `@internal` methods from type declarations so they don't appear in IntelliSense. [#679](https://github.com/zowe/imperative/issues/679)
 - BugFix: Made the `ProfileInfo.initSessCfg` method public for easier instantiation of classes that extend AbstractSession.
+- Deprecated: All methods in the `IHandlerParameters.profiles` class. Use the `ConfigProfiles` API for team config instead.
 
 ## `5.0.0-next.202112132158`
 

--- a/packages/cmd/src/doc/handler/IHandlerParameters.ts
+++ b/packages/cmd/src/doc/handler/IHandlerParameters.ts
@@ -55,6 +55,7 @@ export interface IHandlerParameters {
      * The set of profiles loaded for this command handler - the map is built with the key being the type and it
      * returns the set of profiles loaded of that type. Multiple profiles can be loaded of the same type - depending
      * on the request and the 0th entry is the first loaded.
+     * @deprecated This API only loads v1 profiles. To load v2 profiles, use `ImperativeConfig.instance.config.api.profiles`.
      * @type {Map<string, IProfile[]>}
      * @memberof IHandlerParameters
      */

--- a/packages/cmd/src/profiles/CommandProfiles.ts
+++ b/packages/cmd/src/profiles/CommandProfiles.ts
@@ -63,6 +63,7 @@ export class CommandProfiles {
 
     /**
      * Gets the first (or by name) meta profile in the map - automatically throws an exception (unless disabled)
+     * @deprecated
      * @template T - The expected profile mapping to be returned
      * @param {string} type - The profile type
      * @param {string} [name=""] - The name of the profile to retrieve
@@ -97,6 +98,7 @@ export class CommandProfiles {
 
     /**
      * Gets the first (or by name) profile in the map - automatically throws an exception (unless disabled)
+     * @deprecated Load profile properties from `IHandlerParameters.arguments` property instead.
      * @template T - The expected profile mapping to be returned
      * @param {string} type - The profile type
      * @param {string} [name=""] - The name of the profile to retrieve
@@ -130,6 +132,7 @@ export class CommandProfiles {
 
     /**
      * Gets all profiles for the type specified,
+     * @deprecated
      * @template T - extends IProfile
      * @param {string} type - The profile type to retrieve loaded profiles
      * @returns {T[]} - The list of profile types


### PR DESCRIPTION
So that calls to `IHandlerParameters.profiles.get` will be labelled as deprecated in Zowe v2.