### PR TITLE
[next] Fix inconsistent error message in daemon mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed inconsistent error message when invalid CLI command is run in daemon mode. [zowe/zowe-cli#1081](https://github.com/zowe/zowe-cli/issues/1081)
+
 ## `5.0.0-next.202112171553`
 
 - Enhancement: Added `config convert-profiles` command that converts v1 profiles to team config. [zowe/zowe-cli#896](https://github.com/zowe/zowe-cli/issues/896)

--- a/packages/cmd/src/yargs/YargsConfigurer.ts
+++ b/packages/cmd/src/yargs/YargsConfigurer.ts
@@ -59,13 +59,6 @@ export class YargsConfigurer {
             const jsonOptionName: string = Constants.JSON_OPTION;
             jsonArg[jsonOptionName] = true;
         }
-        const failedCommandHandler = __dirname + "/../handlers/FailedCommandHandler";
-        const failedCommandDefinition: ICommandDefinition = {
-            name: this.rootCommandName + " " + ImperativeConfig.instance.commandLine,
-            handler: failedCommandHandler,
-            type: "command",
-            description: "The command you tried to invoke failed"
-        };
         this.yargs.help(false);
         this.yargs.version(false);
         this.yargs.showHelpOnFail(false);
@@ -110,6 +103,7 @@ export class YargsConfigurer {
                     const closestCommand = this.getClosestCommand(attemptedCommand);
 
                     argv.failureMessage = this.buildFailureMessage(closestCommand);
+                    const failedCommandDefinition = this.buildFailedCommandDefinition();
 
                     // Allocate a help generator from the factory
                     const rootHelpGenerator = this.helpGeneratorFactory.getHelpGenerator({
@@ -145,6 +139,7 @@ export class YargsConfigurer {
             process.exitCode = Constants.ERROR_EXIT_CODE;
             AbstractCommandYargs.STOP_YARGS = true; // todo: figure out a better way
             error = error || new Error(msg);
+            const failedCommandDefinition = this.buildFailedCommandDefinition();
 
             // Allocate a help generator from the factory
             const failHelpGenerator = this.helpGeneratorFactory.getHelpGenerator({
@@ -186,6 +181,7 @@ export class YargsConfigurer {
         });
         process.on("uncaughtException", (error: Error) => {
             process.exitCode = Constants.ERROR_EXIT_CODE;
+            const failedCommandDefinition = this.buildFailedCommandDefinition();
 
             // Allocate a help generator from the factory
             const failHelpGenerator = this.helpGeneratorFactory.getHelpGenerator({
@@ -281,6 +277,19 @@ export class YargsConfigurer {
         }
         failureMessage += `\nUse "${this.rootCommandName}${groups}--help" to view groups, commands, and options.`;
         return failureMessage;
+    }
+
+    /**
+     * Define failed command with the current command line arguments.
+     * @returns Failed command definition object
+     */
+    private buildFailedCommandDefinition(): ICommandDefinition {
+        return {
+            name: this.rootCommandName + " " + ImperativeConfig.instance.commandLine,
+            handler: __dirname + "/../handlers/FailedCommandHandler",
+            type: "command",
+            description: "The command you tried to invoke failed"
+        };
     }
 
     // /**


### PR DESCRIPTION
Fixes https://github.com/zowe/zowe-cli/issues/1081 by building `failedCommandDefinition` every time a command fails. Previously, the object was only built once when Imperative initialized, so it had a hardcoded command line of "zowe --daemon" rather than the invalid command.