### PR TITLE
[next] Don't show obsolete plugins that are not installed

### DIFF
--- a/packages/imperative/__tests__/config/cmd/convert-profiles/convert-profiles.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/convert-profiles/convert-profiles.handler.test.ts
@@ -259,7 +259,7 @@ describe("Configuration Convert Profiles command handler", () => {
         });
 
         const handler = new ConvertProfilesHandler();
-        jest.spyOn(handler as any, "getObsoletePlugins").mockReturnValueOnce([]);
+        jest.spyOn(handler as any, "getOldPluginInfo").mockReturnValueOnce({ plugins: [], overrides: [] });
         jest.spyOn(handler as any, "getOldProfileCount").mockReturnValueOnce(3);
         const findOldSecurePropsSpy = jest.spyOn(handler as any, "findOldSecureProps");
         const deleteOldSecurePropsSpy = jest.spyOn(handler as any, "deleteOldSecureProps");
@@ -305,7 +305,7 @@ describe("Configuration Convert Profiles command handler", () => {
         });
 
         const handler = new ConvertProfilesHandler();
-        jest.spyOn(handler as any, "getObsoletePlugins").mockReturnValueOnce([]);
+        jest.spyOn(handler as any, "getOldPluginInfo").mockReturnValueOnce({ plugins: [], overrides: [] });
         jest.spyOn(handler as any, "getOldProfileCount").mockReturnValueOnce(3);
         const findOldSecurePropsSpy = jest.spyOn(handler as any, "findOldSecureProps");
         const deleteOldSecurePropsSpy = jest.spyOn(handler as any, "deleteOldSecureProps");

--- a/packages/imperative/src/config/cmd/convert-profiles/convert-profiles.handler.ts
+++ b/packages/imperative/src/config/cmd/convert-profiles/convert-profiles.handler.ts
@@ -169,7 +169,7 @@ export default class ConvertProfilesHandler implements ICommandHandler {
     }
 
     /**
-     * Retrieves info about old plug-ins and their overrides.
+     * Retrieve info about old plug-ins and their overrides.
      *  - `plugins` - List of CLI plug-ins to uninstall
      *  - `overrides` - List of overrides to remove from app settings
      */


### PR DESCRIPTION
⚠️ Before merging this PR, merge latest changes from #708 into this branch and ensure that all tests pass

Fix inaccurate message "Detected 1 obsolete plug-in(s)" showing when there are no CLI plug-ins installed.