### PR TITLE
[next] 2-way JSON communication for daemon mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Imperative package will be documented in this file.
 - Enhancement: Replaced hidden `--dcd` option used by CommandProcessor in daemon mode with IDaemonResponse object.
 - **Next Breaking**
     - Changed the "args" type on the `Imperative.parse` method to allow a string array.
-    - Renamed the "reply" property to "stdin" on the IDaemonResponse interface.
+    - Restructured the IDaemonResponse interface to provide information to CommandProcessor.
 
 ## `5.0.0-next.202112221912`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Replaced hidden `--dcd` option used by CommandProcessor in daemon mode with IDaemonResponse object.
+- **Next Breaking**
+    - Changed the "args" type on the `Imperative.parse` method to allow a string array.
+    - Renamed the "reply" property to "stdin" on the IDaemonResponse interface.
+
 ## `5.0.0-next.202112221912`
 
 - Enhancement: Added `delete` option to `config convert-profiles` command.

--- a/packages/cmd/__tests__/CommandProcessor.test.ts
+++ b/packages/cmd/__tests__/CommandProcessor.test.ts
@@ -1384,7 +1384,7 @@ describe("Command Processor", () => {
             promptPhrase: "dummydummy",
             daemonResponse: {
                 cwd: process.cwd(),
-                env: { FRUIT_ENV: "test" }
+                env: { UNIT_TEST_ENV: "new" }
             }
         });
 
@@ -1416,13 +1416,19 @@ describe("Command Processor", () => {
             },
             silent: true
         };
-        expect(process.env.FRUIT_ENV).toBeUndefined();
-        const commandResponse: ICommandResponse = await processor.invoke(parms);
-        expect(commandResponse).toBeDefined();
-        expect(commandResponse).toMatchSnapshot();
-        expect(process.chdir).toHaveBeenCalledTimes(1);
-        expect(process.env.FRUIT_ENV).toBe("test");
-        expect(mockConfigReload).toHaveBeenCalledTimes(1);
+        process.env.UNIT_TEST_ENV = "old";
+        try {
+            const envVarCount = Object.keys(process.env).length;
+            const commandResponse: ICommandResponse = await processor.invoke(parms);
+            expect(commandResponse).toBeDefined();
+            expect(commandResponse).toMatchSnapshot();
+            expect(process.chdir).toHaveBeenCalledTimes(1);
+            expect(process.env.UNIT_TEST_ENV).toBe("new");
+            expect(Object.keys(process.env).length).toBe(envVarCount);  // Ensure that env vars were preserved
+            expect(mockConfigReload).toHaveBeenCalledTimes(1);
+        } finally {
+            delete process.env.UNIT_TEST_ENV;
+        }
     });
 
     it("should extract arguments not specified on invoke from a profile and merge with args", async () => {

--- a/packages/cmd/__tests__/__snapshots__/CommandPreparer.test.ts.snap
+++ b/packages/cmd/__tests__/__snapshots__/CommandPreparer.test.ts.snap
@@ -42,14 +42,6 @@ Object {
       "type": "boolean",
     },
     Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
-    },
-    Object {
       "aliases": Array [
         "rff",
       ],
@@ -165,14 +157,6 @@ Object {
       "type": "boolean",
     },
     Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
-    },
-    Object {
       "aliases": Array [
         "apple-p",
       ],
@@ -244,14 +228,6 @@ Object {
       "type": "boolean",
     },
     Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
-    },
-    Object {
       "aliases": Array [
         "fruit-p",
       ],
@@ -321,14 +297,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
     Object {
       "aliases": Array [
@@ -431,14 +399,6 @@ Object {
               "name": "help-web",
               "type": "boolean",
             },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
           ],
           "passOn": Array [],
           "positionals": Array [
@@ -503,14 +463,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
           ],
           "passOn": Array [],
@@ -577,14 +529,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
             Object {
               "aliases": Array [
@@ -655,14 +599,6 @@ Object {
           "name": "help-web",
           "type": "boolean",
         },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
       ],
       "passOn": Array [],
       "positionals": Array [],
@@ -705,14 +641,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [],
@@ -782,14 +710,6 @@ Object {
               "name": "help-web",
               "type": "boolean",
             },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
           ],
           "passOn": Array [],
           "positionals": Array [
@@ -854,14 +774,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
           ],
           "passOn": Array [],
@@ -930,14 +842,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "apple-p",
               ],
@@ -1000,14 +904,6 @@ Object {
           "name": "help-web",
           "type": "boolean",
         },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
       ],
       "passOn": Array [],
       "positionals": Array [],
@@ -1057,14 +953,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -1153,14 +1041,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "pipe",
               ],
@@ -1234,14 +1114,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
             Object {
               "aliases": Array [
@@ -1319,14 +1191,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "apple-p",
               ],
@@ -1400,14 +1264,6 @@ Object {
           "type": "boolean",
         },
         Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
-        Object {
           "aliases": Array [
             "pipe",
           ],
@@ -1465,14 +1321,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -1546,14 +1394,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
             Object {
               "aliases": Array [
@@ -1633,14 +1473,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
             Object {
               "aliases": Array [
@@ -1723,14 +1555,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "banana-p",
               ],
@@ -1792,14 +1616,6 @@ Object {
           "group": "Global options",
           "name": "help-web",
           "type": "boolean",
-        },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
         },
         Object {
           "aliases": Array [
@@ -1864,14 +1680,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -1951,14 +1759,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "banana-p",
               ],
@@ -2036,14 +1836,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
             Object {
               "aliases": Array [
@@ -2126,14 +1918,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "banana-p",
               ],
@@ -2196,14 +1980,6 @@ Object {
           "name": "help-web",
           "type": "boolean",
         },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
       ],
       "passOn": Array [],
       "positionals": Array [],
@@ -2253,14 +2029,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -2345,14 +2113,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "banana-p",
               ],
@@ -2430,14 +2190,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
             Object {
               "aliases": Array [
@@ -2520,14 +2272,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "banana-p",
               ],
@@ -2589,14 +2333,6 @@ Object {
           "group": "Global options",
           "name": "help-web",
           "type": "boolean",
-        },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
         },
         Object {
           "aliases": Array [
@@ -2661,14 +2397,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -2760,14 +2488,6 @@ Object {
               "name": "help-web",
               "type": "boolean",
             },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
           ],
           "passOn": Array [],
           "positionals": Array [
@@ -2839,14 +2559,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
           ],
           "passOn": Array [],
@@ -2922,14 +2634,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "apple-p",
               ],
@@ -2999,14 +2703,6 @@ Object {
           "name": "help-web",
           "type": "boolean",
         },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
       ],
       "passOn": Array [],
       "positionals": Array [],
@@ -3056,14 +2752,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -3152,14 +2840,6 @@ Object {
               "name": "help-web",
               "type": "boolean",
             },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
           ],
           "passOn": Array [],
           "positionals": Array [
@@ -3231,14 +2911,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
           ],
           "passOn": Array [],
@@ -3314,14 +2986,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "apple-p",
               ],
@@ -3384,14 +3048,6 @@ Object {
           "name": "help-web",
           "type": "boolean",
         },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
       ],
       "passOn": Array [],
       "positionals": Array [],
@@ -3441,14 +3097,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -3542,14 +3190,6 @@ Object {
               "name": "help-web",
               "type": "boolean",
             },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
           ],
           "passOn": Array [],
           "positionals": Array [
@@ -3621,14 +3261,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
           ],
           "passOn": Array [],
@@ -3704,14 +3336,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "apple-p",
               ],
@@ -3781,14 +3405,6 @@ Object {
           "name": "help-web",
           "type": "boolean",
         },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
       ],
       "passOn": Array [],
       "positionals": Array [],
@@ -3838,14 +3454,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [
@@ -3928,14 +3536,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "banana-p",
               ],
@@ -4013,14 +3613,6 @@ Object {
               "group": "Global options",
               "name": "help-web",
               "type": "boolean",
-            },
-            Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
             },
             Object {
               "aliases": Array [
@@ -4103,14 +3695,6 @@ Object {
               "type": "boolean",
             },
             Object {
-              "aliases": Array [],
-              "description": "Daemon client directory",
-              "group": "Global options",
-              "hidden": true,
-              "name": "dcd",
-              "type": "string",
-            },
-            Object {
               "aliases": Array [
                 "apple-p",
               ],
@@ -4172,14 +3756,6 @@ Object {
           "group": "Global options",
           "name": "help-web",
           "type": "boolean",
-        },
-        Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
         },
         Object {
           "aliases": Array [
@@ -4245,14 +3821,6 @@ Object {
       "name": "help-web",
       "type": "boolean",
     },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
-    },
   ],
   "passOn": Array [
     Object {
@@ -4314,14 +3882,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
     Object {
       "aliases": Array [
@@ -4402,14 +3962,6 @@ Object {
           "type": "boolean",
         },
         Object {
-          "aliases": Array [],
-          "description": "Daemon client directory",
-          "group": "Global options",
-          "hidden": true,
-          "name": "dcd",
-          "type": "string",
-        },
-        Object {
           "aliases": Array [
             "banana-p",
           ],
@@ -4466,14 +4018,6 @@ Object {
       "group": "Global options",
       "name": "help-web",
       "type": "boolean",
-    },
-    Object {
-      "aliases": Array [],
-      "description": "Daemon client directory",
-      "group": "Global options",
-      "hidden": true,
-      "name": "dcd",
-      "type": "string",
     },
   ],
   "passOn": Array [],

--- a/packages/cmd/__tests__/__snapshots__/CommandProcessor.test.ts.snap
+++ b/packages/cmd/__tests__/__snapshots__/CommandProcessor.test.ts.snap
@@ -926,7 +926,7 @@ Object {
 }
 `;
 
-exports[`Command Processor should invoke the handler and process chdir with hidden option and then return success=true if the handler was successful 1`] = `
+exports[`Command Processor should invoke the handler and process daemon response and then return success=true if the handler was successful 1`] = `
 Object {
   "data": Object {},
   "error": undefined,

--- a/packages/cmd/__tests__/response/CommandResponse.test.ts
+++ b/packages/cmd/__tests__/response/CommandResponse.test.ts
@@ -367,7 +367,7 @@ describe("Command Response", () => {
         const responseMessage = "daemon response";
 
         // construct the response in a proper protocol header (see DaemonUtils.ts)
-        const daemonResponse: IDaemonResponse = { id: "test", reply: responseMessage };
+        const daemonResponse: IDaemonResponse = { stdin: responseMessage };
 
         // simulate a .on(data...) method
         const eventStream = jest.fn((event: string, func: (data: any) => void) => {

--- a/packages/cmd/src/CommandPreparer.ts
+++ b/packages/cmd/src/CommandPreparer.ts
@@ -451,14 +451,6 @@ export class CommandPreparer {
             type: "boolean"
         });
 
-        definition.options.push({
-            name: Constants.DAEMON_CLIENT_DIRECTORY,
-            group: Constants.GLOBAL_GROUP,
-            description: "Daemon client directory",
-            type: "string",
-            hidden: true
-        });
-
         /**
          * Append any profile related options
          */

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -43,6 +43,8 @@ import { CliUtils } from "../../utilities/src/CliUtils";
 import { WebHelpManager } from "./help/WebHelpManager";
 import { ICommandProfile } from "./doc/profiles/definition/ICommandProfile";
 import { Config } from "../../config/src/Config";
+import { IDaemonResponse } from "../../utilities/src/doc/IDaemonResponse";
+
 /**
  * The command processor for imperative - accepts the command definition for the command being issued (and a pre-built)
  * response object and validates syntax, loads profiles, instantiates handlers, & invokes the handlers.
@@ -129,6 +131,13 @@ export class CommandProcessor {
      * @memberof CommandProcessor
      */
     private mConfig: Config;
+    /**
+     * Daemon response object containing process info.
+     * @private
+     * @type {IDaemonResponse}
+     * @memberof CommandProcessor
+     */
+    private mDaemonResponse?: IDaemonResponse;
 
     /**
      * Creates an instance of CommandProcessor.
@@ -154,6 +163,7 @@ export class CommandProcessor {
         this.mEnvVariablePrefix = params.envVariablePrefix;
         this.mPromptPhrase = params.promptPhrase;
         this.mConfig = params.config;
+        this.mDaemonResponse = params.daemonResponse;
         ImperativeExpect.keysToBeDefinedAndNonBlank(params, ["promptPhrase"], `${CommandProcessor.ERROR_TAG} No prompt phrase supplied.`);
         ImperativeExpect.keysToBeDefinedAndNonBlank(params, ["rootCommandName"], `${CommandProcessor.ERROR_TAG} No root command supplied.`);
         ImperativeExpect.keysToBeDefinedAndNonBlank(params, ["envVariablePrefix"], `${CommandProcessor.ERROR_TAG} No ENV variable prefix supplied.`);
@@ -384,11 +394,22 @@ export class CommandProcessor {
         try {
             // Build the response object, base args object, and the entire array of options for this command
             // Assume that the command succeed, it will be marked otherwise under the appropriate failure conditions
-            if (params.arguments.dcd) {
+            if (this.mDaemonResponse != null) {
                 // NOTE(Kelosky): we adjust `cwd` and do not restore it, so that multiple simultaneous requests from the same
                 // directory will operate without unexpected chdir taking place.  Multiple simultaneous requests from different
                 // directories may cause unpredictable results
-                process.chdir(params.arguments.dcd as string);
+                if (this.mDaemonResponse.cwd != null) {
+                    process.chdir(this.mDaemonResponse.cwd);
+                }
+
+                for (const envVarName in Object.keys(process.env)) {
+                    if (envVarName.startsWith(`${this.mEnvVariablePrefix}_`)) {
+                        delete process.env[envVarName];
+                    }
+                }
+                if (this.mDaemonResponse.env != null) {
+                    process.env = { ...process.env, ...this.mDaemonResponse.env };
+                }
 
                 // reload config for daemon client directory
                 await ImperativeConfig.instance.config.reload();

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -402,11 +402,13 @@ export class CommandProcessor {
                     process.chdir(this.mDaemonResponse.cwd);
                 }
 
-                for (const envVarName in Object.keys(process.env)) {
+                // Delete environment variables that start with our prefix
+                for (const envVarName of Object.keys(process.env)) {
                     if (envVarName.startsWith(`${this.mEnvVariablePrefix}_`)) {
                         delete process.env[envVarName];
                     }
                 }
+                // Define environment variables received by daemon
                 if (this.mDaemonResponse.env != null) {
                     process.env = { ...process.env, ...this.mDaemonResponse.env };
                 }

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -402,13 +402,13 @@ export class CommandProcessor {
                     process.chdir(this.mDaemonResponse.cwd);
                 }
 
-                // Delete environment variables that start with our prefix
+                // Delete environment variables that start with CLI prefix
                 for (const envVarName of Object.keys(process.env)) {
                     if (envVarName.startsWith(`${this.mEnvVariablePrefix}_`)) {
                         delete process.env[envVarName];
                     }
                 }
-                // Define environment variables received by daemon
+                // Define environment variables received from daemon
                 if (this.mDaemonResponse.env != null) {
                     process.env = { ...process.env, ...this.mDaemonResponse.env };
                 }

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -402,14 +402,15 @@ export class CommandProcessor {
                     process.chdir(this.mDaemonResponse.cwd);
                 }
 
-                // Delete environment variables that start with CLI prefix
-                for (const envVarName of Object.keys(process.env)) {
-                    if (envVarName.startsWith(`${this.mEnvVariablePrefix}_`)) {
-                        delete process.env[envVarName];
-                    }
-                }
                 // Define environment variables received from daemon
                 if (this.mDaemonResponse.env != null) {
+                    // Delete environment variables that start with CLI prefix
+                    for (const envVarName of Object.keys(process.env)) {
+                        if (envVarName.startsWith(`${this.mEnvVariablePrefix}_`)) {
+                            delete process.env[envVarName];
+                        }
+                    }
+                    // Load new environment variables
                     process.env = { ...process.env, ...this.mDaemonResponse.env };
                 }
 

--- a/packages/cmd/src/doc/processor/ICommandProcessorParms.ts
+++ b/packages/cmd/src/doc/processor/ICommandProcessorParms.ts
@@ -14,6 +14,8 @@ import { IHelpGenerator } from "../../help/doc/IHelpGenerator";
 import { IProfileManagerFactory } from "../../../../profiles";
 import { ICommandProfileTypeConfiguration } from "../../../src/doc/profiles/definition/ICommandProfileTypeConfiguration";
 import { Config } from "../../../../config";
+import { IDaemonResponse } from "../../../..";
+
 /**
  * Parameters to create an instance of the Command Processor. Contains the command definition (for the command
  * being executed) and help, profiles, etc.
@@ -78,4 +80,10 @@ export interface ICommandProcessorParms {
      */
     // TODO Should we make this property required? (breaking change)
     config?: Config;
+    /**
+     * Daemon response object containing process info.
+     * @type {IDaemonResponse}
+     * @memberof ICommandProcessorParms
+     */
+    daemonResponse?: IDaemonResponse;
 }

--- a/packages/cmd/src/response/CommandResponse.ts
+++ b/packages/cmd/src/response/CommandResponse.ts
@@ -613,7 +613,7 @@ export class CommandResponse implements ICommandResponseApi {
 
                                 // strip response header and give to content the waiting handler
                                 const response: IDaemonResponse = JSON.parse(data.toString());
-                                resolve(response.reply.trim());
+                                resolve(response.stdin.trim());
                             });
                         });
                     } else {

--- a/packages/cmd/src/yargs/AbstractCommandYargs.ts
+++ b/packages/cmd/src/yargs/AbstractCommandYargs.ts
@@ -295,7 +295,8 @@ export abstract class AbstractCommandYargs {
                 rootCommandName: this.rootCommandName,
                 commandLine: this.commandLine,
                 envVariablePrefix: this.envVariablePrefix,
-                promptPhrase: this.promptPhrase
+                promptPhrase: this.promptPhrase,
+                daemonResponse: args.daemonResponse
             }).help(new CommandResponse({
                 silent: false,
                 responseFormat: (args[Constants.JSON_OPTION] || false) ? "json" : "default",
@@ -406,7 +407,8 @@ export abstract class AbstractCommandYargs {
                 rootCommandName: this.rootCommandName,
                 commandLine: this.commandLine,
                 envVariablePrefix: this.envVariablePrefix,
-                promptPhrase: this.promptPhrase
+                promptPhrase: this.promptPhrase,
+                daemonResponse: args.daemonResponse
             }).webHelp(fullCommandName + "_" + this.definition.name,
                 new CommandResponse({
                     silent: false,

--- a/packages/cmd/src/yargs/CommandYargs.ts
+++ b/packages/cmd/src/yargs/CommandYargs.ts
@@ -228,7 +228,8 @@ export class CommandYargs extends AbstractCommandYargs {
                             commandLine: ImperativeConfig.instance.commandLine,
                             envVariablePrefix: this.envVariablePrefix,
                             promptPhrase: this.promptPhrase,
-                            config: ImperativeConfig.instance.config
+                            config: ImperativeConfig.instance.config,
+                            daemonResponse: argsForHandler.daemonResponse
                         }).invoke({
                             arguments: argsForHandler,
                             silent: false,

--- a/packages/constants/src/Constants.ts
+++ b/packages/constants/src/Constants.ts
@@ -62,7 +62,6 @@ export class Constants {
     public static readonly HELP_EXAMPLES = "help-examples";
     public static readonly HELP_WEB_OPTION = "help-web";
     public static readonly HELP_WEB_OPTION_ALIAS = "hw";
-    public static readonly DAEMON_CLIENT_DIRECTORY = "dcd";
 
     public static readonly STDIN_OPTION = "stdin";
     public static readonly STDIN_OPTION_ALIAS = "pipe";

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -365,7 +365,7 @@ export class Imperative {
      * Parse command line arguments and issue the user's specified command
      * @returns {Imperative} this, for chaining syntax
      */
-    public static parse(args?: string, context?: IYargsContext): Imperative {
+    public static parse(args?: string | string[], context?: IYargsContext): Imperative {
 
         const timingApi = PerfTiming.api;
 

--- a/packages/imperative/src/doc/IYargsContext.ts
+++ b/packages/imperative/src/doc/IYargsContext.ts
@@ -10,7 +10,7 @@
 */
 
 import * as net from "net";
-import { IDaemonResponse } from "../../..";
+import { IDaemonResponse } from "../../../utilities";
 
 /**
  * Allow for passing our own "context" / user data through yargs
@@ -27,11 +27,9 @@ export interface IYargsContext {
     stream?: net.Socket;
 
     /**
-     * Current working directory from socket client
-     * @type {string}
+     * Daemon response object from socket client
+     * @type {IDaemonResponse}
      * @memberof IYargsContext
      */
-    cwd?: string;
-
     daemonResponse?: IDaemonResponse;
 }

--- a/packages/imperative/src/doc/IYargsContext.ts
+++ b/packages/imperative/src/doc/IYargsContext.ts
@@ -10,7 +10,7 @@
 */
 
 import * as net from "net";
-
+import { IDaemonResponse } from "../../..";
 
 /**
  * Allow for passing our own "context" / user data through yargs
@@ -32,4 +32,6 @@ export interface IYargsContext {
      * @memberof IYargsContext
      */
     cwd?: string;
+
+    daemonResponse?: IDaemonResponse;
 }

--- a/packages/utilities/src/doc/IDaemonResponse.ts
+++ b/packages/utilities/src/doc/IDaemonResponse.ts
@@ -9,16 +9,37 @@
 *
 */
 
-
 /**
  * Option interface to construct response from daemon client
  * @export
  * @interface IDaemonResponse
  */
 export interface IDaemonResponse {
-    argv?: string[],
+    /**
+     * List of CLI arguments received from the daemon client.
+     */
+    argv?: string[];
+
+    /**
+     * Current working directory received from the daemon client.
+     */
     cwd?: string;
+
+    /**
+     * Environment variables with CLI prefix received from the daemon client.
+     */
     env?: Record<string, string>;
+
+    /**
+     * Length of stdin data received from the daemon client.
+     * The client sends binary stdin data as a multipart request, that contains
+     * a JSON body with `stdinLength` defined, followed by the raw binary data.
+     */
     stdinLength?: number;
+
+    /**
+     * Stdin text received from the daemon client.
+     * This is used for plain text stdin data like replies to prompts.
+     */
     stdin?: string;
 }

--- a/packages/utilities/src/doc/IDaemonResponse.ts
+++ b/packages/utilities/src/doc/IDaemonResponse.ts
@@ -16,18 +16,9 @@
  * @interface IDaemonResponse
  */
 export interface IDaemonResponse {
-
-    /**
-     * Content is from daemon client, not an interactive user
-     * @type {string}
-     * @memberof IDaemonResponse
-     */
-    id: string;
-
-    /**
-     * Content is reply from daemon
-     * @type {string}
-     * @memberof IDaemonResponse
-     */
-    reply?: string;
+    argv?: string[],
+    cwd?: string;
+    env?: Record<string, string>;
+    stdinLength?: number;
+    stdin?: string;
 }


### PR DESCRIPTION
Implement JSON communication for data sent from client-to-server, similar to what already exists for server-to-client.

The format of the JSON body is documented in the corresponding PR https://github.com/zowe/zowe-cli/pull/1244.

The JSON object was added as a property that gets passed to CommandProcessor: `ICommandProcessorParms.daemonResponse`. This makes the `--dcd` argument unnecessary so it was removed.