### PR TITLE
Improve Imperative logging for the Credential Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed useful debugging information missing from error message when Keytar module fails to load.
+
 ## `5.0.0-next.202201102100`
 
 - BugFix: Fixed ZOWE_CLI_HOME environment variable not respected by team config in daemon mode. [zowe/zowe-cli#1240](https://github.com/zowe/zowe-cli/issues/1240)

--- a/packages/cmd/src/yargs/CommandYargs.ts
+++ b/packages/cmd/src/yargs/CommandYargs.ts
@@ -147,7 +147,7 @@ export class CommandYargs extends AbstractCommandYargs {
                                     `Error in command ${this.definition.name}`,
                                     "command handler invoked", errorResponses);
                                 this.log.error(`Error in command ${this.definition.name}`);
-                                this.log.error(inspect(errorResponses));
+                                this.log.error(inspect(errorResponses, { depth: null }));
                                 commandExecuted(argsForHandler, response);
                             });
                     } else {

--- a/packages/config/__tests__/ProfileCredentials.test.ts
+++ b/packages/config/__tests__/ProfileCredentials.test.ts
@@ -118,7 +118,7 @@ describe("ProfileCredentials tests", () => {
             }
 
             expect(caughtError).toBeDefined();
-            expect(caughtError.message).toBe("Failed to load CredentialManager class");
+            expect(caughtError.message).toMatch(/^Failed to load CredentialManager class:/);
             expect(CredentialManagerFactory.initialize).toHaveBeenCalledTimes(1);
         });
 
@@ -164,7 +164,7 @@ describe("ProfileCredentials tests", () => {
             }
 
             expect(caughtError).toBeDefined();
-            expect(caughtError.message).toBe("Failed to load Keytar module");
+            expect(caughtError.message).toMatch(/^Failed to load Keytar module:/);
             expect(CredentialManagerFactory.initialize).toHaveBeenCalledTimes(1);
             expect(requireKeytar).toHaveBeenCalledTimes(1);
         });

--- a/packages/config/src/ProfileCredentials.ts
+++ b/packages/config/src/ProfileCredentials.ts
@@ -55,7 +55,7 @@ export class ProfileCredentials {
                         (DefaultCredentialManager.prototype as any).keytar = this.mRequireKeytar.bind(this)();
                     } catch (error) {
                         throw new ImperativeError({
-                            msg: "Failed to load Keytar module",
+                            msg: `Failed to load Keytar module: ${error.message}`,
                             causeErrors: error
                         });
                     }
@@ -68,7 +68,7 @@ export class ProfileCredentials {
                 await CredentialManagerFactory.initialize({ service: null });
             } catch (error) {
                 throw (error instanceof ImperativeError) ? error : new ImperativeError({
-                    msg: "Failed to load CredentialManager class",
+                    msg: `Failed to load CredentialManager class: ${error.message}`,
                     causeErrors: error
                 });
             }

--- a/packages/security/__tests__/DefaultCredentialManager.test.ts
+++ b/packages/security/__tests__/DefaultCredentialManager.test.ts
@@ -68,7 +68,7 @@ describe("DefaultCredentialManager", () => {
 
                 expect(privateManager.keytar).toBeUndefined();
                 expect(privateManager.loadError).toBeInstanceOf(ImperativeError);
-                expect(privateManager.loadError.message).toEqual("Failed to load Keytar module");
+                expect(privateManager.loadError.message).toMatch(/^Failed to load Keytar module:/);
             });
 
             it("should look for keytar in CLI node_modules folder", async () => {

--- a/packages/security/src/DefaultCredentialManager.ts
+++ b/packages/security/src/DefaultCredentialManager.ts
@@ -127,7 +127,7 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
             this.keytar = await import(keytarPath);
         } catch (error) {
             this.loadError = new ImperativeError({
-                msg: "Failed to load Keytar module",
+                msg: `Failed to load Keytar module: ${error.message}`,
                 causeErrors: error
             });
         }

--- a/packages/security/src/DefaultCredentialManager.ts
+++ b/packages/security/src/DefaultCredentialManager.ts
@@ -124,12 +124,14 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
                 requireOpts.paths = [process.mainModule.filename];
             }
             const keytarPath = require.resolve("keytar", requireOpts);
+            Logger.getImperativeLogger().debug("Loading Keytar module from", keytarPath);
             this.keytar = await import(keytarPath);
         } catch (error) {
             this.loadError = new ImperativeError({
                 msg: `Failed to load Keytar module: ${error.message}`,
                 causeErrors: error
             });
+            Logger.getImperativeLogger().debug("Failed to load Keytar module:\n", error.stack);
         }
     }
 
@@ -256,7 +258,7 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
      * @returns A promise for the credential string.
      */
     private async getCredentialsHelper(service: string, account: string): Promise<SecureCredential> {
-    // Try to load single-field value from vault
+        // Try to load single-field value from vault
         let value = await this.keytar.getPassword(service, account);
 
         // If not found, try to load multiple-field value on Windows
@@ -289,7 +291,7 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
      * @param value The string credential.
      */
     private async setCredentialsHelper(service: string, account: string, value: SecureCredential): Promise<void> {
-    // On Windows, save value across multiple fields if needed
+        // On Windows, save value across multiple fields if needed
         if (process.platform === "win32" && value.length > this.WIN32_CRED_MAX_STRING_LENGTH) {
             // First delete any fields previously used to store this value
             await this.keytar.deletePassword(service, account);


### PR DESCRIPTION
* Fixed `causeErrors` missing from the Imperative log file. The default behavior of `util.inspect` is to print objects up to 2 levels deep. This works fine for a single ImperativeError object where `causeErrors` is 2 levels deep, but when there is an array of ImperativeError objects then `causeErrors` is 3 levels deep.
* Added more details to the error message displayed to the user when Keytar fails to load. Thanks @gejohnston for this suggestion 🙂 