### PR TITLE
Fix angle brackets escaped in web help code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed web help wrongly escaping characters inside code blocks. [#730](https://github.com/zowe/imperative/issues/730)
+
 ## `4.17.5`
 
 - BugFix: Updated log4js and nanoid for improved security.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "progress": "2.0.3",
         "readline-sync": "1.4.10",
         "rimraf": "2.6.3",
-        "sanitize-html": "2.3.2",
         "semver": "5.7.0",
         "stack-trace": "0.0.10",
         "wrap-ansi": "7.0.0",
@@ -5824,30 +5823,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ]
-    },
     "node_modules/domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -5855,33 +5830,6 @@
       "dev": true,
       "dependencies": {
         "webidl-conversions": "^4.0.2"
-      }
-    },
-    "node_modules/domhandler": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
-      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/duplexer": {
@@ -9247,24 +9195,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -9887,6 +9817,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13220,14 +13151,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/klona": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
-      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -14348,6 +14271,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
       "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -15437,11 +15361,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
-    },
     "node_modules/parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -15788,6 +15707,7 @@
       "version": "8.3.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.8.tgz",
       "integrity": "sha512-GT5bTjjZnwDifajzczOC+r3FI3Cu+PgPvrsjhQdRqa2kTJ4968/X9CUce9xttIB0xOs5c6xf0TCWZo/y9lF6bA==",
+      "dev": true,
       "dependencies": {
         "nanocolors": "^0.2.2",
         "nanoid": "^3.1.25",
@@ -15860,7 +15780,8 @@
     "node_modules/postcss/node_modules/nanocolors": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
-      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug=="
+      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
+      "dev": true
     },
     "node_modules/prebuild-install": {
       "version": "6.1.4",
@@ -17050,39 +16971,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sanitize-html": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.3.2.tgz",
-      "integrity": "sha512-p7neuskvC8pSurUjdVmbWPXmc9A4+QpOXIL+4gwFC+av5h+lYCXFT8uEneqsFQg/wEA1IH+cKQA60AaQI6p3cg==",
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^6.0.0",
-        "is-plain-object": "^5.0.0",
-        "klona": "^2.0.3",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.0.2"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/sass-lookup": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-3.0.0.tgz",
@@ -17660,6 +17548,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24192,21 +24081,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      }
-    },
-    "domelementtype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
-    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -24214,24 +24088,6 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
-      }
-    },
-    "domhandler": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
-      "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
-      "requires": {
-        "domelementtype": "^2.2.0"
-      }
-    },
-    "domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "requires": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
       }
     },
     "duplexer": {
@@ -26858,17 +26714,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -27322,7 +27167,8 @@
     "is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true
     },
     "is-regex": {
       "version": "1.1.4",
@@ -29999,11 +29845,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "klona": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
-      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
-    },
     "last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -30876,7 +30717,8 @@
     "nanoid": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -31723,11 +31565,6 @@
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
-    },
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -31994,6 +31831,7 @@
       "version": "8.3.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.8.tgz",
       "integrity": "sha512-GT5bTjjZnwDifajzczOC+r3FI3Cu+PgPvrsjhQdRqa2kTJ4968/X9CUce9xttIB0xOs5c6xf0TCWZo/y9lF6bA==",
+      "dev": true,
       "requires": {
         "nanocolors": "^0.2.2",
         "nanoid": "^3.1.25",
@@ -32003,7 +31841,8 @@
         "nanocolors": {
           "version": "0.2.12",
           "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
-          "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug=="
+          "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
+          "dev": true
         }
       }
     },
@@ -32978,32 +32817,6 @@
         }
       }
     },
-    "sanitize-html": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.3.2.tgz",
-      "integrity": "sha512-p7neuskvC8pSurUjdVmbWPXmc9A4+QpOXIL+4gwFC+av5h+lYCXFT8uEneqsFQg/wEA1IH+cKQA60AaQI6p3cg==",
-      "requires": {
-        "deepmerge": "^4.2.2",
-        "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^6.0.0",
-        "is-plain-object": "^5.0.0",
-        "klona": "^2.0.3",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^8.0.2"
-      },
-      "dependencies": {
-        "deepmerge": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
-        },
-        "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
-        }
-      }
-    },
     "sass-lookup": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-3.0.0.tgz",
@@ -33454,7 +33267,8 @@
     "source-map-js": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "progress": "2.0.3",
     "readline-sync": "1.4.10",
     "rimraf": "2.6.3",
-    "sanitize-html": "2.3.2",
     "semver": "5.7.0",
     "stack-trace": "0.0.10",
     "wrap-ansi": "7.0.0",

--- a/packages/cmd/__tests__/help/WebHelpGenerator.test.ts
+++ b/packages/cmd/__tests__/help/WebHelpGenerator.test.ts
@@ -155,8 +155,8 @@ describe("WebHelpGenerator", () => {
             expect(fileText).toContain(`
 <li>
 <p>${lorenIpsum.split("\n").join("<br>\n")}</p>
-<p>Default value: banana</p>
-<p>Allowed values: banana, coconut</p>
+<p>Default value: banana<br>
+Allowed values: banana, coconut</p>
 </li>
 `);
 

--- a/packages/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/cmd/src/help/DefaultHelpGenerator.ts
@@ -244,7 +244,8 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
                 return DefaultHelpGenerator.HELP_INDENT + line; // indent the table
             }).join("\n");
 
-            fullTableText += this.renderHelp(this.buildHeader(type + "S") + tableText + "\n\n");
+            const properCaseType = type.charAt(0).toUpperCase() + type.slice(1).toLowerCase();
+            fullTableText += this.renderHelp(this.buildHeader(properCaseType + "s") + tableText + "\n\n");
         });
 
         // Return all the table tests

--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -159,7 +159,7 @@ export class WebHelpGenerator {
         const helpGen = new DefaultHelpGenerator({ produceMarkdown: true, rootCommandName } as any,
             { commandDefinition: uniqueDefinitions, fullCommandTree: uniqueDefinitions, skipTextWrap: true });
         rootHelpContent += this.renderMarkdown(this.buildChildrenSummaryTables(helpGen, rootCommandName) + "\n\n" +
-            helpGen.buildGlobalOptionsSection().replace(/Global options/, "Global Options"));
+            helpGen.buildGlobalOptionsSection().replace("# Global options", "# Global Options"));
         this.singlePageHtml = rootHelpContent.replace(/<h4>Groups.+?<\/ul>/s, "");
         rootHelpContent += this.genDocsFooter();
         fs.writeFileSync(rootHelpHtmlPath, rootHelpContent);
@@ -189,18 +189,17 @@ export class WebHelpGenerator {
     }
 
     /**
-     * Converts Markdown string to HTML string. Any HTML contained in the
-     * input Markdown string will be sanitized.
+     * Converts Markdown string to HTML string. Any HTML tags contained in the
+     * input Markdown string will be escaped.
      * @param markdownContent String containing Markdown content
      * @returns String containing HTML content
      */
     private renderMarkdown(markdownContent: string): string {
         if (this.markdownIt == null) {
-            this.markdownIt = require("markdown-it")({ html: true, linkify: true, breaks: true });
+            this.markdownIt = require("markdown-it")({ breaks: true, linkify: true });
         }
 
-        const sanitizeHtml = require("sanitize-html");
-        return this.markdownIt.render(sanitizeHtml(markdownContent));
+        return this.markdownIt.render(markdownContent);
     }
 
     /**
@@ -264,18 +263,14 @@ export class WebHelpGenerator {
     private buildChildrenSummaryTables(helpGen: DefaultHelpGenerator, fullCommandName: string): string {
         const hrefPrefix = fullCommandName + "_";
         return helpGen.buildChildrenSummaryTables().split(/\r?\n/g)
-            .map((line: string, index: number) => {
+            .map((line: string) => {
                 // Wrap group/command names inside links
                 const match = line.match(/^\s{0,4}([a-z0-9-]+(?:\s\|\s[a-z0-9-]+)*)\s+\S/i);
                 if (match) {
                     const href = `${hrefPrefix}${match[1].split(" ")[0]}.html`;
-                    return `\n* <a href="${href}">${match[1]}</a> -` + line.slice(match[0].length - 2);
-                } else if (/^\s*#{4}\s*COMMANDS\s*$/i.test(line)) {
-                    return `${(index > 0) ? "\n" : ""}<h4>Commands</h4>\n`;
-                } else if (/^\s*#{4}\s*GROUPS\s*$/i.test(line)) {
-                    return `${(index > 0) ? "\n" : ""}<h4>Groups</h4>\n`;
+                    return `\n* [${match[1]}](${href}) -` + line.slice(match[0].length - 2);
                 }
-                return " " + line.trim();
+                return (line.startsWith("#### ") ? "\n" : " ") + line.trim();
             }).join("");
     }
 
@@ -320,16 +315,12 @@ export class WebHelpGenerator {
             { commandDefinition: definition, fullCommandTree: this.mFullCommandTree, skipTextWrap: true });
 
         let markdownContent = helpGen.buildHelp() + "\n";
-        markdownContent = markdownContent.replace(/</g, "&lt;").replace(/>/g, "&gt;");
         if (definition.type === "group") {
             // this is disabled for the CLIReadme.md but we want to show children here
             // so we'll call the help generator's children summary function even though
             // it's usually skipped when producing markdown
             markdownContent += this.buildChildrenSummaryTables(helpGen, rootCommandName + "_" + fullCommandName);
         }
-
-        // Prevent line breaks from being lost during Markdown to HTML conversion
-        markdownContent = markdownContent.replace(/^(\s+Default value:.+$)(\s+Allowed values:.+$)/gm, "$1\n$2");
 
         let htmlContent = "<h2>" + this.genBreadcrumb(rootCommandName, fullCommandName) + this.genPrintButton() + "</h2>\n";
         htmlContent += this.renderMarkdown(markdownContent);


### PR DESCRIPTION
Both the [`markdown-it`](https://github.com/markdown-it/markdown-it/issues/167) and [`sanitize-html`](https://github.com/apostrophecms/sanitize-html/issues/249) packages used to generate web help should handle angle brackets correctly.

The problem seems to have been we were calling them in the wrong order - sanitizing an MD/HTML mix before passing it to `markdown-it` rather than sanitizing the output HTML resulted in some unexpected behavior.

While investigating this, I realized the amount of HTML tags being injected into the MD we feed to `markdown-it` was very small (only in the method `buildChildrenSummaryTables`). So this PR replaces those HTML tags with Markdown, removes the `html: true` option from the `markdown-it` parser, and no longer requires the `sanitize-html` package 🙂

Here is a diff showing the changes introduced by this branch to the `all.html` file in web help: [web-help-730.patch](https://github.com/zowe/imperative/files/7959707/web-help-730.patch.txt)