### PR TITLE
[next] Add stdin to handler parameters for daemon mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## `5.0.0-next.202110191937`
 
-- **Breaking**: Added the new, required, abstract method 'displayAutoInitChanges' to the 'BaseAutoInitHandler' class.
+- **Next Breaking**: Added the new, required, abstract method 'displayAutoInitChanges' to the 'BaseAutoInitHandler' class.
 
 ## `5.0.0-next.202110071645`
 
@@ -126,7 +126,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## `5.0.0-next.202110011948`
 
-- Breaking: Changed default log level from DEBUG to WARN for Imperative logger and app logger to reduce the volume of logs written to disk. [#634](https://github.com/zowe/imperative/issues/634)
+- **LTS Breaking**: Changed default log level from DEBUG to WARN for Imperative logger and app logger to reduce the volume of logs written to disk. [#634](https://github.com/zowe/imperative/issues/634)
 
 ## `5.0.0-next.202109281439`
 
@@ -139,12 +139,12 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## `5.0.0-next.202108181618`
 
-- Breaking: Make `fail-on-error` option true by default on `zowe plugins validate` command.
+- **LTS Breaking**: Make `fail-on-error` option true by default on `zowe plugins validate` command.
 
 ## `5.0.0-next.202108121732`
 
 - Enhancement: Flattened the default profiles structure created by the `config init` command.
-- Breaking: Split up authToken property in team config into tokenType and tokenValue properties to be consistent with Zowe v1 profiles.
+- **Next Breaking**: Split up authToken property in team config into tokenType and tokenValue properties to be consistent with Zowe v1 profiles.
 
 ## `5.0.0-next.202108062025`
 
@@ -175,7 +175,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## `5.0.0-next.202106041929`
 
-- **Breaking**: Removed the following previously deprecated items:
+- **LTS Breaking**: Removed the following previously deprecated items:
     - ICliLoadProfile.ICliILoadProfile -- use ICliLoadProfile.ICliLoadProfile
     - IImperativeErrorParms.suppressReport -- has not been used since 10/17/2018
     - IImperativeConfig.pluginBaseCliVersion -- has not been used since version 1.0.1
@@ -190,7 +190,7 @@ All notable changes to the Imperative package will be documented in this file.
 ## `5.0.0-next.202104262004`
 
 - Enhancement: Remove message about NPM peer dep warnings that no longer applies to npm@7.
-- **Breaking:** Imperative no longer requires plug-ins to include CLI package as a peer dependency. It is recommended that CLI plug-ins remove their peer dependency on @zowe/cli for improved compatibility with npm@7. This is a breaking change for plug-ins, as older versions of Imperative will fail to install a plug-in that lacks the CLI peer dependency.
+- **LTS Breaking**: Imperative no longer requires plug-ins to include CLI package as a peer dependency. It is recommended that CLI plug-ins remove their peer dependency on @zowe/cli for improved compatibility with npm@7. This is a breaking change for plug-ins, as older versions of Imperative will fail to install a plug-in that lacks the CLI peer dependency.
 
 ## `5.0.0-next.202104140156`
 
@@ -221,7 +221,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 - Enhancement: Added new config API intended to replace the profiles API, and new "config" command group to manage config JSON files. The new API makes it easier for users to create, share, and switch between profile configurations.
 - Deprecated: The "profiles" command group for managing global profiles in "{cliHome}/profiles". Use the new "config" command group instead.
-- **Breaking**: Removed "config" command group for managing app settings in "{cliHome}/imperative/settings.json". If app settings already exist they are still loaded for backwards compatibility. For storing app settings use the new config API instead.
+- **LTS Breaking**: Removed "config" command group for managing app settings in "{cliHome}/imperative/settings.json". If app settings already exist they are still loaded for backwards compatibility. For storing app settings use the new config API instead.
 - Enhancement: Added support for secure credential storage without any plug-ins required. Include the "keytar" package as a dependency in your CLI to make use of it.
 - Enhancement: Added `deprecatedReplacement` property to `ICommandDefinition` to deprecate a command.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added `stdin` property to `IHandlerParameters` which defaults to `process.stdin` and can be overridden with another readable stream in daemon mode.
+  - This may be a breaking change for unit tests that mock the `IHandlerParameters` interface since a required property has been added.
+- **Next Breaking**: Replaced `IYargsContext` interface with `IDaemonContext` and renamed `yargsContext` property of `ImperativeConfig.instance` to `daemonContext`. A context object is no longer supplied to `yargs` since it gets parsed as CLI arguments which is undesired behavior.
+
 ## `5.0.0-next.202202111730`
 
 - **Next Breaking**: Changed the default behavior of `Config.save` and `ConfigSecure.save` APIs to save only the active config layer. [#732](https://github.com/zowe/imperative/issues/732)

--- a/packages/cmd/__tests__/CommandProcessor.test.ts
+++ b/packages/cmd/__tests__/CommandProcessor.test.ts
@@ -1382,9 +1382,11 @@ describe("Command Processor", () => {
             rootCommandName: SAMPLE_ROOT_COMMAND,
             commandLine: "",
             promptPhrase: "dummydummy",
-            daemonResponse: {
-                cwd: process.cwd(),
-                env: { UNIT_TEST_ENV: "new" }
+            daemonContext: {
+                request: {
+                    cwd: process.cwd(),
+                    env: { UNIT_TEST_ENV: "new" }
+                }
             }
         });
 

--- a/packages/cmd/__tests__/CommandProcessor.test.ts
+++ b/packages/cmd/__tests__/CommandProcessor.test.ts
@@ -1383,7 +1383,7 @@ describe("Command Processor", () => {
             commandLine: "",
             promptPhrase: "dummydummy",
             daemonContext: {
-                request: {
+                response: {
                     cwd: process.cwd(),
                     env: { UNIT_TEST_ENV: "new" }
                 }

--- a/packages/cmd/__tests__/response/CommandResponse.test.ts
+++ b/packages/cmd/__tests__/response/CommandResponse.test.ts
@@ -380,17 +380,12 @@ describe("Command Response", () => {
             // do nothing
         });
 
-        // we remove a listener after we add one
-        const removeListener = jest.fn((event: string, func: (data: any) => void) => {
-            // do nothing
-        });
-
         const endStream = jest.fn(() => {
             // do nothing
         });
 
         // build our pseudo socket object
-        const socket: any = {on: eventStream, write: writeStream, removeListener, end: endStream};
+        const socket: any = {once: eventStream, write: writeStream, end: endStream};
 
         // create response object
         const response = new CommandResponse({stream: socket});
@@ -411,7 +406,6 @@ describe("Command Response", () => {
 
         expect(write).not.toHaveBeenCalled();
         expect(writeStream).toHaveBeenCalled();
-        expect(removeListener).toHaveBeenCalled();
         expect(endStream).toHaveBeenCalled();
         expect(answer).toBe(responseMessage);
     });

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -395,16 +395,16 @@ export class CommandProcessor {
         try {
             // Build the response object, base args object, and the entire array of options for this command
             // Assume that the command succeed, it will be marked otherwise under the appropriate failure conditions
-            if (this.mDaemonContext?.request != null) {
+            if (this.mDaemonContext?.response != null) {
                 // NOTE(Kelosky): we adjust `cwd` and do not restore it, so that multiple simultaneous requests from the same
                 // directory will operate without unexpected chdir taking place.  Multiple simultaneous requests from different
                 // directories may cause unpredictable results
-                if (this.mDaemonContext.request.cwd != null) {
-                    process.chdir(this.mDaemonContext.request.cwd);
+                if (this.mDaemonContext.response.cwd != null) {
+                    process.chdir(this.mDaemonContext.response.cwd);
                 }
 
                 // Define environment variables received from daemon
-                if (this.mDaemonContext.request.env != null) {
+                if (this.mDaemonContext.response.env != null) {
                     // Delete environment variables that start with CLI prefix
                     for (const envVarName of Object.keys(process.env)) {
                         if (envVarName.startsWith(`${this.mEnvVariablePrefix}_`)) {
@@ -412,7 +412,7 @@ export class CommandProcessor {
                         }
                     }
                     // Load new environment variables
-                    process.env = { ...process.env, ...this.mDaemonContext.request.env };
+                    process.env = { ...process.env, ...this.mDaemonContext.response.env };
                 }
 
                 // reload config for daemon client directory

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -930,6 +930,12 @@ export class CommandProcessor {
         });
     }
 
+    /**
+     * Get stdin stream for the command handler to use. In daemon mode this is
+     * a stream of data received from the daemon client. Otherwise it defaults
+     * to `process.stdin`.
+     * @returns Readable stream containing stdin data
+     */
     private getStdinStream(): stream.Readable {
         return this.mDaemonContext?.stdinStream || process.stdin;
     }

--- a/packages/cmd/src/CommandProcessor.ts
+++ b/packages/cmd/src/CommandProcessor.ts
@@ -30,10 +30,11 @@ import { Logger } from "../../logger";
 import { IInvokeCommandParms } from "./doc/parms/IInvokeCommandParms";
 import { ICommandProcessorParms } from "./doc/processor/ICommandProcessorParms";
 import { ImperativeExpect } from "../../expect";
-import { inspect, isString } from "util";
+import { inspect } from "util";
 import { ImperativeConfig, TextUtils } from "../../utilities";
 import * as nodePath from "path";
 import * as os from "os";
+import * as stream from "stream";
 import { ICommandHandlerRequire } from "./doc/handler/ICommandHandlerRequire";
 import { IHandlerParameters } from "../../cmd";
 import { ChainedHandlerService } from "./ChainedHandlerUtils";
@@ -43,7 +44,7 @@ import { CliUtils } from "../../utilities/src/CliUtils";
 import { WebHelpManager } from "./help/WebHelpManager";
 import { ICommandProfile } from "./doc/profiles/definition/ICommandProfile";
 import { Config } from "../../config/src/Config";
-import { IDaemonResponse } from "../../utilities/src/doc/IDaemonResponse";
+import { IDaemonContext } from "../../imperative/src/doc/IDaemonContext";
 
 /**
  * The command processor for imperative - accepts the command definition for the command being issued (and a pre-built)
@@ -132,12 +133,12 @@ export class CommandProcessor {
      */
     private mConfig: Config;
     /**
-     * Daemon response object containing process info.
+     * The context object defined when in daemon mode.
      * @private
-     * @type {IDaemonResponse}
+     * @type {IDaemonContext}
      * @memberof CommandProcessor
      */
-    private mDaemonResponse?: IDaemonResponse;
+    private mDaemonContext?: IDaemonContext;
 
     /**
      * Creates an instance of CommandProcessor.
@@ -163,7 +164,7 @@ export class CommandProcessor {
         this.mEnvVariablePrefix = params.envVariablePrefix;
         this.mPromptPhrase = params.promptPhrase;
         this.mConfig = params.config;
-        this.mDaemonResponse = params.daemonResponse;
+        this.mDaemonContext = params.daemonContext;
         ImperativeExpect.keysToBeDefinedAndNonBlank(params, ["promptPhrase"], `${CommandProcessor.ERROR_TAG} No prompt phrase supplied.`);
         ImperativeExpect.keysToBeDefinedAndNonBlank(params, ["rootCommandName"], `${CommandProcessor.ERROR_TAG} No root command supplied.`);
         ImperativeExpect.keysToBeDefinedAndNonBlank(params, ["envVariablePrefix"], `${CommandProcessor.ERROR_TAG} No ENV variable prefix supplied.`);
@@ -394,16 +395,16 @@ export class CommandProcessor {
         try {
             // Build the response object, base args object, and the entire array of options for this command
             // Assume that the command succeed, it will be marked otherwise under the appropriate failure conditions
-            if (this.mDaemonResponse != null) {
+            if (this.mDaemonContext?.request != null) {
                 // NOTE(Kelosky): we adjust `cwd` and do not restore it, so that multiple simultaneous requests from the same
                 // directory will operate without unexpected chdir taking place.  Multiple simultaneous requests from different
                 // directories may cause unpredictable results
-                if (this.mDaemonResponse.cwd != null) {
-                    process.chdir(this.mDaemonResponse.cwd);
+                if (this.mDaemonContext.request.cwd != null) {
+                    process.chdir(this.mDaemonContext.request.cwd);
                 }
 
                 // Define environment variables received from daemon
-                if (this.mDaemonResponse.env != null) {
+                if (this.mDaemonContext.request.env != null) {
                     // Delete environment variables that start with CLI prefix
                     for (const envVarName of Object.keys(process.env)) {
                         if (envVarName.startsWith(`${this.mEnvVariablePrefix}_`)) {
@@ -411,7 +412,7 @@ export class CommandProcessor {
                         }
                     }
                     // Load new environment variables
-                    process.env = { ...process.env, ...this.mDaemonResponse.env };
+                    process.env = { ...process.env, ...this.mDaemonContext.request.env };
                 }
 
                 // reload config for daemon client directory
@@ -467,8 +468,8 @@ export class CommandProcessor {
                         // check if value provided
                         if (prepared.args[positionalName] != null) {
                             // string processing
-                            if ((isString(prepared.args[positionalName]) &&
-                                prepared.args[positionalName].toUpperCase() === this.promptPhrase.toUpperCase())) {
+                            if (typeof prepared.args[positionalName] === "string" &&
+                                prepared.args[positionalName].toUpperCase() === this.promptPhrase.toUpperCase()) {
                                 // prompt has been requested for a positional
                                 this.log.debug("Prompting for positional %s which was requested by passing the value %s",
                                     positionalName, this.promptPhrase);
@@ -482,7 +483,7 @@ export class CommandProcessor {
                                 if ((prepared.args[positionalName] != null &&
                                     (Array.isArray(prepared.args[positionalName])) &&
                                     prepared.args[positionalName][0] != null &&
-                                    isString(prepared.args[positionalName][0]) &&
+                                    typeof prepared.args[positionalName][0] === "string" &&
                                     (prepared.args[positionalName][0].toUpperCase() === this.promptPhrase.toUpperCase()))) {
                                     // prompt has been requested for a positional
                                     this.log.debug("Prompting for positional %s which was requested by passing the value %s",
@@ -506,8 +507,8 @@ export class CommandProcessor {
                         // check if value provided
                         if (prepared.args[option.name] != null) {
                             // string processing
-                            if ((isString(prepared.args[option.name]) &&
-                                prepared.args[option.name].toUpperCase() === this.promptPhrase.toUpperCase())) {
+                            if (typeof prepared.args[option.name] === "string" &&
+                                prepared.args[option.name].toUpperCase() === this.promptPhrase.toUpperCase()) {
                                 // prompt has been requested for an --option
                                 this.log.debug("Prompting for option %s which was requested by passing the value %s",
                                     option.name, this.promptPhrase);
@@ -528,7 +529,7 @@ export class CommandProcessor {
                             else {
                                 if (((Array.isArray(prepared.args[option.name])) &&
                                     prepared.args[option.name][0] != null &&
-                                    isString(prepared.args[option.name][0]) &&
+                                    typeof prepared.args[option.name][0] === "string" &&
                                     (prepared.args[option.name][0].toUpperCase() === this.promptPhrase.toUpperCase()))) {
                                     // prompt has been requested for an --option
                                     this.log.debug("Prompting for option %s which was requested by passing the value %s",
@@ -611,7 +612,8 @@ export class CommandProcessor {
                 arguments: prepared.args,
                 positionals: prepared.args._,
                 definition: this.definition,
-                fullDefinition: this.fullDefinition
+                fullDefinition: this.fullDefinition,
+                stdin: this.getStdinStream()
             };
             try {
                 await handler.process(handlerParms);
@@ -686,6 +688,7 @@ export class CommandProcessor {
                         positionals: prepared.args._,
                         definition: this.definition,
                         fullDefinition: this.fullDefinition,
+                        stdin: this.getStdinStream(),
                         isChained: true
                     });
                     const builtResponse = chainedResponse.buildJsonResponse();
@@ -923,8 +926,12 @@ export class CommandProcessor {
             args: params.arguments,
             silent: (params.silent == null) ? false : params.silent,
             responseFormat: params.responseFormat,
-            stream: params.arguments.stream
+            stream: ImperativeConfig.instance.daemonContext?.stream
         });
+    }
+
+    private getStdinStream(): stream.Readable {
+        return this.mDaemonContext?.stdinStream || process.stdin;
     }
 
     /**

--- a/packages/cmd/src/doc/handler/IChainedHandlerArgumentMapping.ts
+++ b/packages/cmd/src/doc/handler/IChainedHandlerArgumentMapping.ts
@@ -23,7 +23,7 @@ export interface IChainedHandlerArgumentMapping {
      * Mutually exclusive with 'value'.
      * The dot notation field is retrieved with the dataobject-parser package.
      * @type {string}
-     * @memberOf IChainedHandlerArgumentMapping
+     * @memberof IChainedHandlerArgumentMapping
      */
     from?: string;
 
@@ -32,7 +32,7 @@ export interface IChainedHandlerArgumentMapping {
      * instead of the command response of the current handler.
      * Has no meaning if paired with 'value'
      * @type {boolean}
-     * @memberOf IChainedHandlerArgumentMapping
+     * @memberof IChainedHandlerArgumentMapping
      */
     mapFromArguments?: boolean;
 
@@ -41,7 +41,7 @@ export interface IChainedHandlerArgumentMapping {
      * Unless this is true, an error will be thrown if "from" is specified and the specified
      * field is not found on the command response.
      * @type {boolean}
-     * @memberOf IChainedHandlerArgumentMapping
+     * @memberof IChainedHandlerArgumentMapping
      */
     optional?: boolean;
     /**
@@ -49,7 +49,7 @@ export interface IChainedHandlerArgumentMapping {
      * field of the handler parameters for the future chained handler.
      * Required.
      * @type {string}
-     * @memberOf IChainedHandlerArgumentMapping
+     * @memberof IChainedHandlerArgumentMapping
      */
     to: string;
     /**
@@ -59,7 +59,7 @@ export interface IChainedHandlerArgumentMapping {
      * able to be fully represented in JSON. Values that are not preserved when
      * doing JSON.parse(JSON.stringify(value)) will cause an error.
      * @type {any}
-     * @memberOf IChainedHandlerArgumentMapping
+     * @memberof IChainedHandlerArgumentMapping
      */
     value?: any;
 
@@ -71,7 +71,7 @@ export interface IChainedHandlerArgumentMapping {
      * and not "from", since the arguments will be applied before the response object from the handler is available.
      * If omitted, the mapping applies to the next handler (equivalent to a value of [1] for this field)
      * @type {number[]}
-     * @memberOf IChainedHandlerArgumentMapping
+     * @memberof IChainedHandlerArgumentMapping
      */
     applyToHandlers?: number[];
 

--- a/packages/cmd/src/doc/handler/IChainedHandlerEntry.ts
+++ b/packages/cmd/src/doc/handler/IChainedHandlerEntry.ts
@@ -22,7 +22,7 @@ export interface IChainedHandlerEntry {
      * String path to a module containing a command handler.
      * exports.default (export default class in Typescript) should be the command handler
      * @type {string}
-     * @memberOf IChainedHandlerEntry
+     * @memberof IChainedHandlerEntry
      */
     handler: string;
     /**
@@ -30,14 +30,14 @@ export interface IChainedHandlerEntry {
      * If you do, you can map properties of that object to arguments for the next handler,
      * or a handler further down the chain. See the below interface for more details.
      * @type {IChainedHandlerArgumentMapping[]}
-     * @memberOf IChainedHandlerEntry
+     * @memberof IChainedHandlerEntry
      */
     mapping?: IChainedHandlerArgumentMapping[];
     /**
      * If you set this to true, this handler will produce no output.
      * Note: if you specify "true" for the last handler in a chain, the command will not produce the final output.
      * @type {boolean}
-     * @memberOf IChainedHandlerEntry
+     * @memberof IChainedHandlerEntry
      */
     silent?: boolean;
 }

--- a/packages/cmd/src/doc/handler/IHandlerParameters.ts
+++ b/packages/cmd/src/doc/handler/IHandlerParameters.ts
@@ -9,6 +9,7 @@
 *
 */
 
+import * as stream from "stream";
 import { ICommandDefinition } from "../ICommandDefinition";
 import { CommandProfiles } from "../../profiles/CommandProfiles";
 import { IHandlerResponseApi } from "../../doc/response/api/handler/IHandlerResponseApi";
@@ -74,6 +75,13 @@ export interface IHandlerParameters {
      * @memberof IHandlerParameters
      */
     fullDefinition: ICommandDefinition;
+
+    /**
+     * The input stream that can be used by the command being issued.
+     * @type {stream.Readable}
+     * @memberof IHandlerParameters
+     */
+    stdin: stream.Readable;
 
     /**
      * Has your command been invoked from a chained handler? (see ICommandDefinition.chainedHandlers)

--- a/packages/cmd/src/doc/option/ICommandOptionAllowableValues.ts
+++ b/packages/cmd/src/doc/option/ICommandOptionAllowableValues.ts
@@ -20,13 +20,13 @@ export interface ICommandOptionAllowableValues {
      * new RegExp(value).test(theValueSpecifiedByUser) will be called during syntax validation.
      * If none of the values match, the user will get a syntax error.
      * @type {string[]}
-     * @memberOf ICommandOptionAllowableValues
+     * @memberof ICommandOptionAllowableValues
      */
     values: string[];
     /**
      * Should these values be compared in a case sensitive manner?
      * @type {boolean}
-     * @memberOf ICommandOptionAllowableValues
+     * @memberof ICommandOptionAllowableValues
      */
     caseSensitive?: boolean;
 }

--- a/packages/cmd/src/doc/option/ICommandOptionDefinition.ts
+++ b/packages/cmd/src/doc/option/ICommandOptionDefinition.ts
@@ -46,7 +46,7 @@ export interface ICommandOptionDefinition {
      * after parsing the command line arguments, so you would be able to access params.arguments.hyphenatedOptions
      * from your handler as well as params.arguments["hyphenated-options"]'
      * @type {string}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     name: string;
     /**
@@ -55,20 +55,20 @@ export interface ICommandOptionDefinition {
      * e.g.  name: "puppy", aliases: ["p", "pup"] -
      *       the user can specify --puppy, -p, or --pup
      * @type {string[]}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     aliases?: string[];
     /**
      * The description of your option - displayed in the help text
      * for your command.
      * @type {string}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     description: string;
     /**
      * What type of value will the user specify for this option?
      * @type {CommandOptionType}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     type: CommandOptionType;
     /**
@@ -81,7 +81,7 @@ export interface ICommandOptionDefinition {
      * If the user doesn't specify this option, you can specify a default value here
      * that will be filled in automatically.
      * @type {any}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     defaultValue?: any;
     /**
@@ -89,7 +89,7 @@ export interface ICommandOptionDefinition {
      * Options with the same group on the same command are grouped together
      * under a heading with this text.
      * @type {string}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     group?: string;
 
@@ -99,8 +99,8 @@ export interface ICommandOptionDefinition {
      *
      * Note: if you give a defaultValue to an option, it will always be
      * considered to have been specified.
-     * @type boolean
-     * @memberOf ICommandOptionDefinition
+     * @type {boolean}
+     * @memberof ICommandOptionDefinition
      */
     required?: boolean;
 
@@ -116,7 +116,7 @@ export interface ICommandOptionDefinition {
      *   description
      *   conflictsWith: ["A"]
      * }
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     conflictsWith?: string[];
     /**
@@ -125,7 +125,7 @@ export interface ICommandOptionDefinition {
      * e.g. if this option is "vacation", and ["seat", "meal"] is the value for "implies",
      * then the user will get a syntax error if they specify --vacation but not --seat and --meal
      * @type {string[]}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     implies?: string[];
 
@@ -135,7 +135,7 @@ export interface ICommandOptionDefinition {
      * e.g. if this option is "vacation", and ["seat", "meal"] is the value for "impliesOneOf",
      * then the user will get a syntax error if they specify --vacation but not either --seat or --meal
      * @type {string[]}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     impliesOneOf?: string[];
 
@@ -145,7 +145,7 @@ export interface ICommandOptionDefinition {
      *
      * e.g. if the user does not specify "vacation" then they must specify --job and --hours
      * @type {string[]}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     absenceImplications?: string[];
 
@@ -153,7 +153,7 @@ export interface ICommandOptionDefinition {
      * What values can be specified for this option?
      * See the type below for more details.
      * @type {ICommandOptionAllowableValues}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     allowableValues?: ICommandOptionAllowableValues;
 
@@ -163,7 +163,7 @@ export interface ICommandOptionDefinition {
      * So the value specified by the user must be  min <=  value <= max
      *
      * @type {[number, number]}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     numericValueRange?: [number, number];
     /**
@@ -172,7 +172,7 @@ export interface ICommandOptionDefinition {
      * So the length specified by the user must be  min <=  length <= max
      *
      * @type {[number, number]}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     stringLengthRange?: [number, number];
     /**
@@ -180,14 +180,14 @@ export interface ICommandOptionDefinition {
      * are allowed. Default is true.
      *
      * @type {boolean}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     arrayAllowDuplicate?: boolean;
     /**
      * If the user specifies a certain value for this option,
      * then they must also specify other options (similar to a conditional "implies")
      *  @type {{[key: string]: ICommandOptionValueImplications}}
-     * @memberOf ICommandOptionDefinition
+     * @memberof ICommandOptionDefinition
      */
     valueImplications?: {
         [key: string]: ICommandOptionValueImplications;

--- a/packages/cmd/src/doc/option/ICommandOptionValueImplications.ts
+++ b/packages/cmd/src/doc/option/ICommandOptionValueImplications.ts
@@ -17,7 +17,7 @@ export interface ICommandOptionValueImplications {
     /**
      * What option names are implied if the value in question is specified
      * @type {string[]}
-     * @memberOf ICommandOptionValueImplications
+     * @memberof ICommandOptionValueImplications
      */
     impliedOptionNames: string[];
     /**
@@ -25,7 +25,7 @@ export interface ICommandOptionValueImplications {
      * If yes, the strings will be compared with "===".
      * Otherwise they will be uppercased before comparing
      * @type {boolean}
-     * @memberOf ICommandOptionValueImplications
+     * @memberof ICommandOptionValueImplications
      */
     isCaseSensitive?: boolean;
 }

--- a/packages/cmd/src/doc/option/ICommandPositionalDefinition.ts
+++ b/packages/cmd/src/doc/option/ICommandPositionalDefinition.ts
@@ -27,38 +27,38 @@ export interface ICommandPositionalDefinition {
      * array of arguments. So if you specify `name = "abcd..."` and then
      * "a b c d" is specified for the positional argument, abcd = ["a", "b", "c", "d"]
      * @type {string}
-     * @memberOf ICommandPositionalDefinition
+     * @memberof ICommandPositionalDefinition
      */
     name: string;
     /**
      * The option type - used to validate that the user provided value is acceptable.
      * @type {CommandOptionType}
-     * @memberOf ICommandPositionalDefinition
+     * @memberof ICommandPositionalDefinition
      */
     type: CommandOptionType;
     /**
      * The description for the positional operand - used in the help and error messages.
      * @type {string}
-     * @memberOf ICommandPositionalDefinition
+     * @memberof ICommandPositionalDefinition
      */
     description: string;
     /**
      * True if this positional is required.
      * @type {boolean}
-     * @memberOf ICommandPositionalDefinition
+     * @memberof ICommandPositionalDefinition
      */
     required?: boolean;
 
     /**
      * A regex that will be used to match the input for this positional for validation.
      * @type {string}
-     * @memberOf ICommandPositionalDefinition
+     * @memberof ICommandPositionalDefinition
      */
     regex?: string;
     /**
      * What is an acceptable length range for your positional? e.g. between 1 and 8 characters: [1,8]
      * @type {[number, number]}
-     * @memberOf ICommandPositionalDefinition
+     * @memberof ICommandPositionalDefinition
      */
     stringLengthRange?: [number, number];
 }

--- a/packages/cmd/src/doc/processor/ICommandProcessorParms.ts
+++ b/packages/cmd/src/doc/processor/ICommandProcessorParms.ts
@@ -14,7 +14,7 @@ import { IHelpGenerator } from "../../help/doc/IHelpGenerator";
 import { IProfileManagerFactory } from "../../../../profiles";
 import { ICommandProfileTypeConfiguration } from "../../../src/doc/profiles/definition/ICommandProfileTypeConfiguration";
 import { Config } from "../../../../config";
-import { IDaemonResponse } from "../../../..";
+import { IDaemonContext } from "../../../../imperative/src/doc/IDaemonContext";
 
 /**
  * Parameters to create an instance of the Command Processor. Contains the command definition (for the command
@@ -81,9 +81,9 @@ export interface ICommandProcessorParms {
     // TODO Should we make this property required? (breaking change)
     config?: Config;
     /**
-     * Daemon response object containing process info.
-     * @type {IDaemonResponse}
+     * The context object defined when in daemon mode.
+     * @type {IDaemonContext}
      * @memberof ICommandProcessorParms
      */
-    daemonResponse?: IDaemonResponse;
+    daemonContext?: IDaemonContext;
 }

--- a/packages/cmd/src/profiles/CliProfileManager.ts
+++ b/packages/cmd/src/profiles/CliProfileManager.ts
@@ -507,7 +507,7 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
             // if there is a custom update profile handler, they can call mergeProfile
             // from their handler, so we will not do it for them to avoid issues
             this.log.debug("Loading custom update profile handler: " + profileConfig.updateProfileFromArgumentsHandler);
-            const response = new CommandResponse({silent: true, stream: newArguments.stream});
+            const response = new CommandResponse({silent: true});
             let handler: ICommandHandler;
             try {
                 const commandHandler: ICommandHandlerRequire = require(profileConfig.updateProfileFromArgumentsHandler);
@@ -529,7 +529,8 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
                     response,
                     fullDefinition: undefined,
                     definition: undefined,
-                    profiles: new CommandProfiles(new Map<string, IProfile[]>())
+                    profiles: new CommandProfiles(new Map<string, IProfile[]>()),
+                    stdin: process.stdin
                 });
             } catch (invokeErr) {
                 const errorMessage = this.log.error(`Error encountered updating profile of type ${this.profileType} ` +
@@ -570,7 +571,7 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
     private async createProfileFromCommandArguments(profileArguments: Arguments, starterProfile: IProfile): Promise<IProfile> {
         const profileConfig = this.profileTypeConfiguration;
         if (!isNullOrUndefined(profileConfig.createProfileFromArgumentsHandler)) {
-            const response = new CommandResponse({silent: true, args: profileArguments, stream: profileArguments.stream});
+            const response = new CommandResponse({silent: true, args: profileArguments});
             let handler: ICommandHandler;
             try {
                 const commandHandler: ICommandHandlerRequire = require(profileConfig.createProfileFromArgumentsHandler);
@@ -592,7 +593,8 @@ export class CliProfileManager extends BasicProfileManager<ICommandProfileTypeCo
                     response,
                     fullDefinition: undefined,
                     definition: undefined,
-                    profiles: new CommandProfiles(new Map<string, IProfile[]>())
+                    profiles: new CommandProfiles(new Map<string, IProfile[]>()),
+                    stdin: process.stdin
                 });
             } catch (invokeErr) {
                 const errorMessage = this.log.error("Error encountered building new profile with custom create profile handler:" + invokeErr.message);

--- a/packages/cmd/src/response/CommandResponse.ts
+++ b/packages/cmd/src/response/CommandResponse.ts
@@ -606,11 +606,7 @@ export class CommandResponse implements ICommandResponseApi {
                             outer.writeStream(daemonRequest);
 
                             // wait for a response here
-                            outer.mStream.on("data", function listener(data) {
-
-                                // remove this listener
-                                outer.mStream.removeListener("data", listener);
-
+                            outer.mStream.once("data", (data) => {
                                 // strip response header and give to content the waiting handler
                                 const response: IDaemonResponse = JSON.parse(data.toString());
                                 resolve(response.stdin.trim());

--- a/packages/cmd/src/response/CommandResponse.ts
+++ b/packages/cmd/src/response/CommandResponse.ts
@@ -789,7 +789,7 @@ export class CommandResponse implements ICommandResponseApi {
 
                         // NOTE(Kelosky): ansi escape codes for progress bar cursor and line clearing are written on the socket
                         // so we need to ensure they're emptied out before we write to the stream.
-                        if (this.mIsDaemon) outer.writeStream(DaemonRequest.create({ progress: false }));
+                        if (this.mIsDaemon) outer.writeStream(DaemonRequest.EOW_DELIMITER + DaemonRequest.create({ progress: false }));
 
                         outer.writeStdout(outer.mStdout.subarray(this.mProgressBarStdoutStartIndex));
                         outer.writeStderr(outer.mStderr.subarray(this.mProgressBarStderrStartIndex));

--- a/packages/cmd/src/response/CommandResponse.ts
+++ b/packages/cmd/src/response/CommandResponse.ts
@@ -789,7 +789,7 @@ export class CommandResponse implements ICommandResponseApi {
 
                         // NOTE(Kelosky): ansi escape codes for progress bar cursor and line clearing are written on the socket
                         // so we need to ensure they're emptied out before we write to the stream.
-                        if (this.mIsDaemon) outer.writeStream(DaemonRequest.EOW_DELIMITER);
+                        if (this.mIsDaemon) outer.writeStream(DaemonRequest.create({ progress: false }));
 
                         outer.writeStdout(outer.mStdout.subarray(this.mProgressBarStdoutStartIndex));
                         outer.writeStderr(outer.mStderr.subarray(this.mProgressBarStderrStartIndex));

--- a/packages/cmd/src/yargs/AbstractCommandYargs.ts
+++ b/packages/cmd/src/yargs/AbstractCommandYargs.ts
@@ -25,6 +25,7 @@ import { IHelpGeneratorFactory } from "../help/doc/IHelpGeneratorFactory";
 import { CommandResponse } from "../response/CommandResponse";
 import { ICommandResponse } from "../../src/doc/response/response/ICommandResponse";
 import { ICommandExampleDefinition } from "../..";
+import { IDaemonContext } from "../../../imperative/src/doc/IDaemonContext";
 
 /**
  * Callback that is invoked when a command defined to yargs completes execution.
@@ -107,6 +108,13 @@ export abstract class AbstractCommandYargs {
      */
     private mPromptPhrase: string;
 
+    /**
+     * The context object defined when in daemon mode.
+     * @private
+     * @type {IDaemonContext}
+     * @memberof CommandProcessor
+     */
+    private mDaemonContext?: IDaemonContext;
 
     /**
      * Construct the yargs command instance for imperative. Provides the ability to define Imperative commands to Yargs.
@@ -123,6 +131,7 @@ export abstract class AbstractCommandYargs {
         this.mCommandLine = yargsParms.commandLine;
         this.mEnvVariablePrefix = yargsParms.envVariablePrefix;
         this.mPromptPhrase = yargsParms.promptPhrase;
+        this.mDaemonContext = yargsParms.daemonContext;
     }
 
     /**
@@ -296,11 +305,11 @@ export abstract class AbstractCommandYargs {
                 commandLine: this.commandLine,
                 envVariablePrefix: this.envVariablePrefix,
                 promptPhrase: this.promptPhrase,
-                daemonResponse: args.daemonResponse
+                daemonContext: this.mDaemonContext
             }).help(new CommandResponse({
                 silent: false,
                 responseFormat: (args[Constants.JSON_OPTION] || false) ? "json" : "default",
-                stream: args.stream
+                stream: this.mDaemonContext?.stream
             }));
         } catch (helpErr) {
             const errorResponse: IYargsResponse = this.getBrightYargsResponse(false,
@@ -408,12 +417,12 @@ export abstract class AbstractCommandYargs {
                 commandLine: this.commandLine,
                 envVariablePrefix: this.envVariablePrefix,
                 promptPhrase: this.promptPhrase,
-                daemonResponse: args.daemonResponse
+                daemonContext: this.mDaemonContext
             }).webHelp(fullCommandName + "_" + this.definition.name,
                 new CommandResponse({
                     silent: false,
                     responseFormat: (args[Constants.JSON_OPTION] || false) ? "json" : "default",
-                    stream: args.stream
+                    stream: this.mDaemonContext?.stream
                 })
             );
         } catch (helpErr) {

--- a/packages/cmd/src/yargs/AbstractCommandYargs.ts
+++ b/packages/cmd/src/yargs/AbstractCommandYargs.ts
@@ -25,7 +25,7 @@ import { IHelpGeneratorFactory } from "../help/doc/IHelpGeneratorFactory";
 import { CommandResponse } from "../response/CommandResponse";
 import { ICommandResponse } from "../../src/doc/response/response/ICommandResponse";
 import { ICommandExampleDefinition } from "../..";
-import { IDaemonContext } from "../../../imperative/src/doc/IDaemonContext";
+import { ImperativeConfig } from "../../../utilities/src/ImperativeConfig";
 
 /**
  * Callback that is invoked when a command defined to yargs completes execution.
@@ -109,14 +109,6 @@ export abstract class AbstractCommandYargs {
     private mPromptPhrase: string;
 
     /**
-     * The context object defined when in daemon mode.
-     * @private
-     * @type {IDaemonContext}
-     * @memberof CommandProcessor
-     */
-    private mDaemonContext?: IDaemonContext;
-
-    /**
      * Construct the yargs command instance for imperative. Provides the ability to define Imperative commands to Yargs.
      * @param {IYargsParms} yargsParms - Parameter object contains parms for Imperative/Yargs and command response objects
      */
@@ -131,7 +123,6 @@ export abstract class AbstractCommandYargs {
         this.mCommandLine = yargsParms.commandLine;
         this.mEnvVariablePrefix = yargsParms.envVariablePrefix;
         this.mPromptPhrase = yargsParms.promptPhrase;
-        this.mDaemonContext = yargsParms.daemonContext;
     }
 
     /**
@@ -166,6 +157,12 @@ export abstract class AbstractCommandYargs {
         return this.mEnvVariablePrefix;
     }
 
+    /**
+     * Accessor for the CLI prompt phrase
+     * @readonly
+     * @type {string}
+     * @memberof AbstractCommandYargs
+     */
     protected get promptPhrase(): string {
         return this.mPromptPhrase;
     }
@@ -305,11 +302,11 @@ export abstract class AbstractCommandYargs {
                 commandLine: this.commandLine,
                 envVariablePrefix: this.envVariablePrefix,
                 promptPhrase: this.promptPhrase,
-                daemonContext: this.mDaemonContext
+                daemonContext: ImperativeConfig.instance.daemonContext
             }).help(new CommandResponse({
                 silent: false,
                 responseFormat: (args[Constants.JSON_OPTION] || false) ? "json" : "default",
-                stream: this.mDaemonContext?.stream
+                stream: ImperativeConfig.instance.daemonContext?.stream
             }));
         } catch (helpErr) {
             const errorResponse: IYargsResponse = this.getBrightYargsResponse(false,
@@ -417,12 +414,12 @@ export abstract class AbstractCommandYargs {
                 commandLine: this.commandLine,
                 envVariablePrefix: this.envVariablePrefix,
                 promptPhrase: this.promptPhrase,
-                daemonContext: this.mDaemonContext
+                daemonContext: ImperativeConfig.instance.daemonContext
             }).webHelp(fullCommandName + "_" + this.definition.name,
                 new CommandResponse({
                     silent: false,
                     responseFormat: (args[Constants.JSON_OPTION] || false) ? "json" : "default",
-                    stream: this.mDaemonContext?.stream
+                    stream: ImperativeConfig.instance.daemonContext?.stream
                 })
             );
         } catch (helpErr) {

--- a/packages/cmd/src/yargs/CommandYargs.ts
+++ b/packages/cmd/src/yargs/CommandYargs.ts
@@ -229,7 +229,7 @@ export class CommandYargs extends AbstractCommandYargs {
                             envVariablePrefix: this.envVariablePrefix,
                             promptPhrase: this.promptPhrase,
                             config: ImperativeConfig.instance.config,
-                            daemonResponse: argsForHandler.daemonResponse
+                            daemonContext: ImperativeConfig.instance.daemonContext
                         }).invoke({
                             arguments: argsForHandler,
                             silent: false,
@@ -260,7 +260,7 @@ export class CommandYargs extends AbstractCommandYargs {
                         const response = new CommandResponse({
                             silent: false,
                             responseFormat: (printJson) ? "json" : "default",
-                            stream: argsForHandler.stream
+                            stream: ImperativeConfig.instance.daemonContext?.stream
                         });
                         response.failed();
                         response.console.errorHeader("Internal Command Error");

--- a/packages/cmd/src/yargs/GroupCommandYargs.ts
+++ b/packages/cmd/src/yargs/GroupCommandYargs.ts
@@ -53,7 +53,7 @@ export class GroupCommandYargs extends AbstractCommandYargs {
                      * Otherwise, define the "child" command.
                      */
                     switch (child.type) {
-                    // case "provider":
+                        // case "provider":
                         case "group":
                             new GroupCommandYargs({
                                 yargsInstance: this.yargs,

--- a/packages/cmd/src/yargs/YargsConfigurer.ts
+++ b/packages/cmd/src/yargs/YargsConfigurer.ts
@@ -157,7 +157,8 @@ export class YargsConfigurer {
                 rootCommandName: this.rootCommandName,
                 commandLine: this.commandLine,
                 envVariablePrefix: this.envVariablePrefix,
-                promptPhrase: this.promptPhrase
+                promptPhrase: this.promptPhrase,
+                daemonContext: ImperativeConfig.instance.daemonContext
             });
 
             const failureMessage = this.buildFailureMessage();
@@ -167,8 +168,7 @@ export class YargsConfigurer {
                 failureMessage,
                 error,
                 _: [],
-                $0: Constants.PRIMARY_COMMAND,
-                stream: ImperativeConfig.instance.yargsContext?.stream
+                $0: Constants.PRIMARY_COMMAND
             };
 
             // Invoke the fail command

--- a/packages/cmd/src/yargs/YargsDefiner.ts
+++ b/packages/cmd/src/yargs/YargsDefiner.ts
@@ -71,7 +71,7 @@ export class YargsDefiner {
         this.mHelpFactory = helpGeneratorFactory;
         this.mProfileManagerFactory = profileManagerFactory;
         this.mExperimentalCommandDescription = experimentalCommandDescription;
-        this.mPromptPhrase= promptPhrase;
+        this.mPromptPhrase = promptPhrase;
     }
 
     /**
@@ -89,7 +89,7 @@ export class YargsDefiner {
         this.log.trace("Defining a new definition to Yargs:");
         this.log.trace(inspect(definition));
         switch (definition.type) {
-        // case "provider":
+            // case "provider":
             case "group":
                 new GroupCommandYargs({
                     yargsInstance: this.mYargsInstance,

--- a/packages/cmd/src/yargs/doc/IYargsParms.ts
+++ b/packages/cmd/src/yargs/doc/IYargsParms.ts
@@ -15,6 +15,8 @@ import { GroupCommandYargs } from "../GroupCommandYargs";
 import { ICommandResponseParms } from "../../doc/response/parms/ICommandResponseParms";
 import { IProfileManagerFactory } from "../../../../profiles";
 import { IHelpGeneratorFactory } from "../../help/doc/IHelpGeneratorFactory";
+import { IDaemonContext } from "../../../../imperative/src/doc/IDaemonContext";
+
 /**
  * Imperative Yargs parameters - used to define imperative commands to Yargs and provides guidance/parameters for
  * how response objects should be handled when yargs invokes the handlers.
@@ -87,7 +89,13 @@ export interface IYargsParms {
     /**
      * The phrase used to indicate the user wants to enter the value of an argument in a hidden text prompt
      * @type {string}
-     * @memberof ICommandProcessorParms
+     * @memberof IYargsParms
      */
     promptPhrase: string;
+    /**
+     * The context object defined when in daemon mode.
+     * @type {IDaemonContext}
+     * @memberof IYargsParms
+     */
+    daemonContext?: IDaemonContext;
 }

--- a/packages/cmd/src/yargs/doc/IYargsParms.ts
+++ b/packages/cmd/src/yargs/doc/IYargsParms.ts
@@ -15,7 +15,6 @@ import { GroupCommandYargs } from "../GroupCommandYargs";
 import { ICommandResponseParms } from "../../doc/response/parms/ICommandResponseParms";
 import { IProfileManagerFactory } from "../../../../profiles";
 import { IHelpGeneratorFactory } from "../../help/doc/IHelpGeneratorFactory";
-import { IDaemonContext } from "../../../../imperative/src/doc/IDaemonContext";
 
 /**
  * Imperative Yargs parameters - used to define imperative commands to Yargs and provides guidance/parameters for
@@ -92,10 +91,4 @@ export interface IYargsParms {
      * @memberof IYargsParms
      */
     promptPhrase: string;
-    /**
-     * The context object defined when in daemon mode.
-     * @type {IDaemonContext}
-     * @memberof IYargsParms
-     */
-    daemonContext?: IDaemonContext;
 }

--- a/packages/imperative/index.ts
+++ b/packages/imperative/index.ts
@@ -11,11 +11,11 @@
 
 export * from "./src/env/EnvironmentalVariableSettings";
 export * from "./src/doc/IApimlSvcAttrs";
+export * from "./src/doc/IDaemonContext";
 export * from "./src/doc/IImperativeEnvironmentalVariableSetting";
 export * from "./src/doc/IImperativeEnvironmentalVariableSettings";
 export * from "./src/doc/IImperativeConfig";
 export * from "./src/doc/IImperativeLoggingConfig";
-export * from "./src/doc/IYargsContext";
 export * from "./src/ConfigurationLoader";
 export * from "./src/ConfigurationValidator";
 export * from "./src/DefinitionTreeResolver";

--- a/packages/imperative/src/Imperative.ts
+++ b/packages/imperative/src/Imperative.ts
@@ -59,7 +59,7 @@ import { dirname, join } from "path";
 
 import { Console } from "../../console/src/Console";
 import { ISettingsFile } from "../../settings/src/doc/ISettingsFile";
-import { IYargsContext } from "./doc/IYargsContext";
+import { IDaemonContext } from "./doc/IDaemonContext";
 import { ICommandProfileAuthConfig } from "../../cmd/src/doc/profiles/definition/ICommandProfileAuthConfig";
 import { ImperativeExpect } from "../../expect/src/ImperativeExpect";
 import { CompleteAuthGroupBuilder } from "./auth/builders/CompleteAuthGroupBuilder";
@@ -365,7 +365,7 @@ export class Imperative {
      * Parse command line arguments and issue the user's specified command
      * @returns {Imperative} this, for chaining syntax
      */
-    public static parse(args?: string | string[], context?: IYargsContext): Imperative {
+    public static parse(args?: string | string[], context?: IDaemonContext): Imperative {
 
         const timingApi = PerfTiming.api;
 
@@ -374,10 +374,10 @@ export class Imperative {
             timingApi.mark("START_IMP_PARSE");
         }
 
-        ImperativeConfig.instance.yargsContext = context;
+        ImperativeConfig.instance.daemonContext = context;
         AbstractCommandYargs.STOP_YARGS = false;
 
-        yargs.parse(args, context);
+        yargs.parse(args);
 
         if (PerfTiming.isEnabled) {
             // Marks point END

--- a/packages/imperative/src/doc/IDaemonContext.ts
+++ b/packages/imperative/src/doc/IDaemonContext.ts
@@ -10,26 +10,34 @@
 */
 
 import * as net from "net";
+import * as stream from "stream";
 import { IDaemonResponse } from "../../../utilities";
 
 /**
- * Allow for passing our own "context" / user data through yargs
+ * Allow for passing our own "context" / user data to the Imperative parser
  * @export
- * @interface IYargsContext
+ * @interface IDaemonContext
  */
-export interface IYargsContext {
+export interface IDaemonContext {
 
     /**
      * Stream to write response to
      * @type {net.Socket}
-     * @memberof IYargsContext
+     * @memberof IDaemonContext
      */
     stream?: net.Socket;
 
     /**
+     * Stream to read input from
+     * @type {stream.Readable}
+     * @memberof IDaemonContext
+     */
+    stdinStream?: stream.Readable;
+
+    /**
      * Daemon response object from socket client
      * @type {IDaemonResponse}
-     * @memberof IYargsContext
+     * @memberof IDaemonContext
      */
-    daemonResponse?: IDaemonResponse;
+    request?: IDaemonResponse;
 }

--- a/packages/imperative/src/doc/IDaemonContext.ts
+++ b/packages/imperative/src/doc/IDaemonContext.ts
@@ -39,5 +39,5 @@ export interface IDaemonContext {
      * @type {IDaemonResponse}
      * @memberof IDaemonContext
      */
-    request?: IDaemonResponse;
+    response?: IDaemonResponse;
 }

--- a/packages/utilities/src/ImperativeConfig.ts
+++ b/packages/utilities/src/ImperativeConfig.ts
@@ -14,7 +14,7 @@ import { join } from "path";
 import { IImperativeConfig } from "../../imperative/src/doc/IImperativeConfig";
 import { ImperativeError } from "../../error";
 import { EnvironmentalVariableSettings } from "../../imperative/src/env/EnvironmentalVariableSettings";
-import { IYargsContext } from "../../imperative/src/doc/IYargsContext";
+import { IDaemonContext } from "../../imperative/src/doc/IDaemonContext";
 import { ICommandProfileSchema } from "../../cmd";
 import { Config } from "../../config";
 
@@ -31,13 +31,13 @@ export class ImperativeConfig {
     private static mInstance: ImperativeConfig = null;
 
     /**
-     * This is the yargs context needed to pass to `yargs.fail()` in the event that we cannot extract
+     * This is the daemon context needed to pass to `yargs.fail()` in the event that we cannot extract
      * context through a `yargs.parse()` call.
      * @private
-     * @type {IYargsContext}
+     * @type {IDaemonContext}
      * @memberof ImperativeConfig
      */
-    private mYargsContext: IYargsContext;
+    private mDaemonContext: IDaemonContext;
 
     /**
      * This parameter is used as the container of all loaded configuration for
@@ -234,20 +234,20 @@ export class ImperativeConfig {
     }
 
     /**
-     * Set context for yargs to retrieve if no handler is called.
-     * @type {IYargsContext}
+     * Set context for daemon to retrieve if no handler is called.
+     * @type {IDaemonContext}
      * @memberof ImperativeConfig
      */
-    public get yargsContext(): IYargsContext {
-        return this.mYargsContext;
+    public get daemonContext(): IDaemonContext {
+        return this.mDaemonContext;
     }
 
     /**
-     * Context for yargs when no handler is invoked.
+     * Context for daemon when no handler is invoked.
      * @memberof ImperativeConfig
      */
-    public set yargsContext(context: IYargsContext) {
-        this.mYargsContext = context;
+    public set daemonContext(context: IDaemonContext) {
+        this.mDaemonContext = context;
     }
 
     /**


### PR DESCRIPTION
The breaking changes around using `IHandlerParameters.stdin` instead of `process.stdin` in command handlers will be documented in the corresponding CLI PR.

In addition to the documented changes in the changelog, corrected numerous formatting errors in Typedoc.