### PR TITLE
[next] Fix Ctrl+C on prompts throwing an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed Ctrl+C (SIGINT) response to CLI prompts throwing an error rather than exiting silently.
+
 ## `5.0.0-next.202202232039`
 
 - Enhancement: Added `stdin` property to `IHandlerParameters` which defaults to `process.stdin` and can be overridden with another readable stream in daemon mode.

--- a/packages/utilities/src/CliUtils.ts
+++ b/packages/utilities/src/CliUtils.ts
@@ -595,6 +595,8 @@ export class CliUtils {
             }, (error: any, result: string) => {
                 if (error == null) {
                     resolve(result);
+                } else if (error.message === "canceled") {
+                    process.exit(2);
                 } else if (error.message === "timed out") {
                     resolve(null);
                 } else {


### PR DESCRIPTION
Prevents the following from happening when you respond to a prompt with `Ctrl+C`:
```
$ znext config secure --gc
Please enter profiles.base.properties.user: Unexpected Command Error:
Please review the message and stack below.
Contact the creator of handler:
"C:\dev\zowe-next\imperative\lib\imperative\src\config\cmd\secure\secure.handler"
Message:
canceled
Stack:
Error: canceled
```

This PR handles the "read" package throwing an error with "canceled" message when a SIGINT signal is received:
https://github.com/npm/read/blob/d9385eb85b249e2d15b54a928158ff1a07f2eb47/lib/read.js#L64-L67