### PR TITLE
Fix single character options rendered in help with double dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed single character options rendered in help with double dash instead of single dash. [#638](https://github.com/zowe/imperative/issues/638)
+
 ## `4.17.6`
 
-- BugFix: Fixes an error where, in certain situations, the web help displays data for another command with the same name. [#728](https://github.com/zowe/imperative/issues/728)
+- BugFix: Fixed an error where, in certain situations, the web help displays data for another command with the same name. [#728](https://github.com/zowe/imperative/issues/728)
 - BugFix: Fixed web help wrongly escaping characters inside code blocks. [#730](https://github.com/zowe/imperative/issues/730)
 
 ## `4.17.5`

--- a/packages/cmd/__tests__/help/AbstractHelpGenerator.test.ts
+++ b/packages/cmd/__tests__/help/AbstractHelpGenerator.test.ts
@@ -124,11 +124,17 @@ describe("Abstract Help Generator Unit Tests", () => {
             description: "option_description",
             type: "string",
         };
+        const goodOptionSingleChar: ICommandOptionDefinition = {
+            name: "o",
+            description: "option_description",
+            type: "string",
+        };
         expect(abstractHelpGenerator.getOptionAndAliasesString(goodOptionMultipleAliases)).toMatchSnapshot("Good Option, multiple alias");
         goodOptionMultipleAliases.required = true;
         expect(abstractHelpGenerator.getOptionAndAliasesString(goodOptionMultipleAliases)).toMatchSnapshot("Good option, multiple alias, required");
         expect(abstractHelpGenerator.getOptionAndAliasesString(goodOptionSingleAlias)).toMatchSnapshot("Good option, single alias");
         expect(abstractHelpGenerator.getOptionAndAliasesString(goodOptionNoAlias)).toMatchSnapshot("Good option, no alias present");
+        expect(abstractHelpGenerator.getOptionAndAliasesString(goodOptionSingleChar)).toMatchSnapshot("Good option, single char");
 
         const badOptionAliasEdgeCases: ICommandOptionDefinition = {
             name: "my_option",

--- a/packages/cmd/__tests__/help/__snapshots__/AbstractHelpGenerator.test.ts.snap
+++ b/packages/cmd/__tests__/help/__snapshots__/AbstractHelpGenerator.test.ts.snap
@@ -201,6 +201,8 @@ exports[`Abstract Help Generator Unit Tests getOptionAndAliasesString test: Good
 
 exports[`Abstract Help Generator Unit Tests getOptionAndAliasesString test: Good option, single alias 1`] = `"--my_option  | --my_opt (string)"`;
 
+exports[`Abstract Help Generator Unit Tests getOptionAndAliasesString test: Good option, single char 1`] = `"-o  (string)"`;
+
 exports[`Abstract Help Generator Unit Tests getOptionAndAliasesString test: Non-existent type 1`] = `"--good_name  (notexist)"`;
 
 exports[`Abstract Help Generator Unit Tests getOptionAndAliasesString test: Null name 1`] = `"--null  (string)"`;

--- a/packages/cmd/src/help/abstract/AbstractHelpGenerator.ts
+++ b/packages/cmd/src/help/abstract/AbstractHelpGenerator.ts
@@ -150,7 +150,7 @@ export abstract class AbstractHelpGenerator implements IHelpGenerator {
         if (caseSensitive) {
             aliasString += " {{italic}}" + this.dimGrey("(case sensitive)") + "{{italic}}";
         }
-        return this.renderHelp(format("{{codeBegin}}--%s{{codeEnd}} %s", option.name, aliasString));
+        return this.renderHelp(format("{{codeBegin}}%s{{codeEnd}} %s", (option.name?.length === 1 ? "-" : "--") + option.name, aliasString));
     }
 
     public abstract buildFullCommandHelpText(includeGlobalOptions: boolean): string;


### PR DESCRIPTION
Fixes #638 