### PR TITLE
Document strange behind the scenes behavior for secure protocol.

### DIFF
--- a/packages/rest/src/session/AbstractSession.ts
+++ b/packages/rest/src/session/AbstractSession.ts
@@ -141,6 +141,7 @@ export abstract class AbstractSession {
      * @memberof AbstractSession
      */
     public static readonly DEFAULT_SECURE_PROTOCOL = "SSLv23_method";
+    // TODO: Investigate - this does not seem to do anything, and Node defaults to TLS_method w/ TLS 1.3 support
 
     /**
      * Regex to extract basic from base64 encoded auth

--- a/packages/rest/src/session/doc/ISession.ts
+++ b/packages/rest/src/session/doc/ISession.ts
@@ -162,6 +162,7 @@ export interface ISession {
      * @memberof ISession
      */
     secureProtocol?: string;
+    // TODO: Investigate - this does not seem to do anything, and Node defaults to TLS_method w/ TLS 1.3 support
 
     /**
      * Decide whether or not to store a returned cookie.


### PR DESCRIPTION
Adds comments to document Node's behind the scenes behavior of using TLS_method instead of SSLv23_method. Luckily, that means we get TLS 1.3 support, and sticking with Node's default is probably for the best.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>