### PR TITLE
Fix Keytar not found outside top-level node_modules folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,10 @@ All notable changes to the Imperative package will be documented in this file.
 
 - Enhancement: add support for CLIs that want to run as a persistent process (daemon mode).
 
+## `4.18.1`
+
+- BugFix: Fixed AbstractRestClient returning compressed data in `causeErrors` property for streamed responses. [#753](https://github.com/zowe/imperative/issues/753)
+
 ## `4.18.0`
 
 - Enhancement: Sorted output of `plugins list` command in alphabetical order to make it easier to read. [#489](https://github.com/zowe/imperative/issues/489)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Reverted unintentional breaking change that prevented `DefaultCredentialManager` from finding Keytar outside of calling CLI's node_modules folder.
+
 ## `5.0.0-next.202203211501`
 
 - Enhancement: Enhanced secure ProfileInfo APIs with user-defined secure properties. [#739](https://github.com/zowe/imperative/issues/739)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14536,9 +14536,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.5",
@@ -31664,9 +31664,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.5",

--- a/packages/rest/__tests__/client/AbstractRestClient.test.ts
+++ b/packages/rest/__tests__/client/AbstractRestClient.test.ts
@@ -842,6 +842,9 @@ describe("AbstractRestClient tests", () => {
                 return emitter;
             });
 
+            (https.request as any) = requestFnc;
+            (AbstractRestClient.prototype as any).mDecode = true;
+
             const responseStream = new PassThrough();
             await RestClient.getStreamed(new Session({
                 hostname: "test"

--- a/packages/security/src/DefaultCredentialManager.ts
+++ b/packages/security/src/DefaultCredentialManager.ts
@@ -121,7 +121,7 @@ export class DefaultCredentialManager extends AbstractCredentialManager {
             // within our caller's path.
             const requireOpts: any = {};
             if (process.mainModule?.filename != null) {
-                requireOpts.paths = [process.mainModule.filename];
+                requireOpts.paths = [process.mainModule.filename, ...require.resolve.paths("keytar")];
             }
             const keytarPath = require.resolve("keytar", requireOpts);
             Logger.getImperativeLogger().debug("Loading Keytar module from", keytarPath);


### PR DESCRIPTION
This is part of the fix for https://github.com/zowe/zowe-cli/issues/1314.

The remainder of the fix is https://github.com/zowe/zowe-cli/pull/1347 (will need to be ported to `next` branch).

Once both these fixes are published, it should be possible to `import { imperative } from "@zowe/cli"` and use the ProfileInfo API from the shrinkwrapped CLI package without any duplicated Imperative or Keytar dependencies.