### PR TITLE
[next] Fix `config set` not respecting property types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `config set` command not respecting the property type defined in the schema. [#772](https://github.com/zowe/imperative/issues/772)
+
 ## `5.0.0-next.202203311701`
 
 - BugFix: Allowed `ProfileCredentials.isSecured` to be insecure on teamConfig based on existing secure fields. [#762](https://github.com/zowe/imperative/issues/762)

--- a/packages/config/__tests__/ConfigUtils.test.ts
+++ b/packages/config/__tests__/ConfigUtils.test.ts
@@ -1,0 +1,95 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import * as ConfigUtils from "../../config/src/ConfigUtils";
+import { CredentialManagerFactory } from "../../security";
+import { ImperativeConfig } from "../../utilities";
+
+describe("Config Utils", () => {
+    describe("coercePropValue", () => {
+        it("should parse value when type is boolean", () => {
+            expect(ConfigUtils.coercePropValue("false", "boolean")).toBe(false);
+            expect(ConfigUtils.coercePropValue("true", "boolean")).toBe(true);
+        });
+
+        it("should parse value when type is number", () => {
+            expect(ConfigUtils.coercePropValue("2", "number")).toBe(2);
+            expect(ConfigUtils.coercePropValue("3.14", "number")).toBe(3.14);
+        });
+
+        it("should parse value when type is unknown", () => {
+            expect(ConfigUtils.coercePropValue("false")).toBe(false);
+            expect(ConfigUtils.coercePropValue("2")).toBe(2);
+            expect(ConfigUtils.coercePropValue("abc")).toBe("abc");
+        });
+
+        it("should not parse value when type is string", () => {
+            expect(ConfigUtils.coercePropValue("false", "string")).toBe("false");
+            expect(ConfigUtils.coercePropValue("2", "string")).toBe("2");
+            expect(ConfigUtils.coercePropValue("abc", "string")).toBe("abc");
+        });
+    });
+
+    describe("getActiveProfileName", () => {
+        it("should get name from command arguments", () => {
+            const profileName = ConfigUtils.getActiveProfileName("fruit", {
+                "fruit-profile": "apple"
+            } as any, "coconut");
+            expect(profileName).toBe("apple");
+        });
+
+        it("should get name from default profiles", () => {
+            jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValueOnce({
+                config: {
+                    properties: {
+                        profiles: {},
+                        defaults: {
+                            fruit: "banana"
+                        }
+                    }
+                }
+            } as any);
+            const profileName = ConfigUtils.getActiveProfileName("fruit", {} as any, "coconut");
+            expect(profileName).toBe("banana");
+        });
+
+        it("should fall back to default name if provided", () => {
+            jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValueOnce({
+                config: {
+                    properties: {
+                        profiles: {},
+                        defaults: {}
+                    }
+                }
+            } as any);
+            const profileName = ConfigUtils.getActiveProfileName("fruit", {} as any, "coconut");
+            expect(profileName).toBe("coconut");
+        });
+
+        it("should fall back to profile type", () => {
+            jest.spyOn(ImperativeConfig, "instance", "get").mockReturnValueOnce({} as any);
+            const profileName = ConfigUtils.getActiveProfileName("fruit", {} as any);
+            expect(profileName).toBe("fruit");
+        });
+    });
+
+    describe("secureSaveError", () => {
+        it("should create error object with details populated", () => {
+            jest.spyOn(CredentialManagerFactory, "manager", "get").mockReturnValueOnce({
+                secureErrorDetails: jest.fn()
+            } as any);
+            const solution = "Fix the problem";
+            const error = ConfigUtils.secureSaveError(solution);
+            expect(error.message).toBe("Unable to securely save credentials.");
+            expect(error.additionalDetails).toBe(solution);
+        });
+    });
+});

--- a/packages/config/src/ConfigSchema.ts
+++ b/packages/config/src/ConfigSchema.ts
@@ -436,7 +436,7 @@ export class ConfigSchema {
 
         const pathSegments = path.split(".");
         const propertyName = pathSegments.pop();
-        const profilePath = pathSegments.slice(0, -1).join(".");  // eslint-disable-line @typescript-eslint/no-magic-numbers
+        const profilePath = pathSegments.slice(0, -1).join(".");
         const profileType: string = lodash.get(config, `${profilePath}.type`);
         if (profileType == null) {
             return;

--- a/packages/config/src/ConfigSchema.ts
+++ b/packages/config/src/ConfigSchema.ts
@@ -10,6 +10,7 @@
 */
 
 import * as path from "path";
+import * as lodash from "lodash";
 import { IExplanationMap, TextUtils } from "../../utilities/src/TextUtils";
 import { ICommandProfileProperty } from "../../cmd";
 import { IProfileProperty, IProfileSchema, IProfileTypeConfiguration } from "../../profiles";
@@ -18,6 +19,7 @@ import { ImperativeConfig } from "../../utilities/src/ImperativeConfig";
 import { Logger } from "../../logger/src/Logger";
 import { Config } from "./Config";
 import { ImperativeError } from "../../error/src/ImperativeError";
+import { IConfig } from "./doc/IConfig";
 
 export class ConfigSchema {
     /**
@@ -419,5 +421,35 @@ export class ConfigSchema {
             }
         }
         return updatedPaths;
+    }
+
+    /**
+     * Find the type of a property based on schema info.
+     * @param path Path to JSON property in config JSON
+     * @param config Team config properties
+     * @param schema Config schema definition. Defaults to profile schemas defined in Imperative config.
+     */
+    public static findPropertyType(path: string, config: IConfig, schema?: IConfigSchema): string | undefined {
+        if (!path.includes(".properties.")) {
+            return;
+        }
+
+        const pathSegments = path.split(".");
+        const propertyName = pathSegments.pop();
+        const profilePath = pathSegments.slice(0, -1).join(".");  // eslint-disable-line @typescript-eslint/no-magic-numbers
+        const profileType: string = lodash.get(config, `${profilePath}.type`);
+        if (profileType == null) {
+            return;
+        }
+
+        const profileSchemas = schema ? this.loadSchema(schema) : ImperativeConfig.instance.loadedConfig.profiles;
+        const profileSchema = profileSchemas.find(p => p.type === profileType)?.schema;
+        if (profileSchema?.properties[propertyName] == null) {
+            return;
+        }
+
+        // TODO How to handle profile property with multiple types
+        const propertyType = profileSchema.properties[propertyName].type;
+        return Array.isArray(propertyType) ? propertyType[0] : propertyType;
     }
 }

--- a/packages/config/src/ConfigUtils.ts
+++ b/packages/config/src/ConfigUtils.ts
@@ -17,16 +17,24 @@ import { ImperativeError } from "../../error";
 /**
  * Coeerces string property value to a boolean or number type.
  * @param value String value
+ * @param type Property type defined in the schema
  * @returns Boolean, number, or string
  */
-export function coercePropValue(value: any) {
-    if (value === "true")
-        return true;
-    if (value === "false")
-        return false;
-    if (!isNaN(value) && !isNaN(parseFloat(value)))
-        return parseInt(value, 10);
-    return value;
+export function coercePropValue(value: any, type?: string) {
+    if (type === "boolean" || type === "number") {
+        // For boolean or number, parse the string and throw on failure
+        return JSON.parse(value);
+    } else if (type == null) {
+        // For unknown type, try to parse the string and ignore failure
+        try {
+            return JSON.parse(value);
+        } catch {
+            return value;
+        }
+    } else {
+        // For string or other type, don't do any parsing
+        return value.toString();
+    }
 }
 
 /**

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -10,8 +10,8 @@
 */
 
 import { ICommandArguments, ICommandHandler, IHandlerParameters } from "../../../../../cmd";
-import { Config, ConfigAutoStore } from "../../../../../config";
-import { secureSaveError } from "../../../../../config/src/ConfigUtils";
+import { Config, ConfigAutoStore, ConfigSchema } from "../../../../../config";
+import { coercePropValue, secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { ImperativeError } from "../../../../../error";
 import { Logger } from "../../../../../logger";
 import { ConnectionPropsForSessCfg, ISession, Session } from "../../../../../rest";
@@ -56,11 +56,12 @@ export default class SecureHandler implements ICommandHandler {
                 continue;
             }
 
-            const propValue = await params.response.console.prompt(`Enter ${propName} - blank to skip: `, {hideText: true});
+            let propValue = await params.response.console.prompt(`Enter ${propName} - blank to skip: `, { hideText: true });
 
             // Save the value in the config securely
             if (propValue) {
-                config.set(propName, propValue, { parseString: true, secure: true });
+                propValue = coercePropValue(propValue, ConfigSchema.findPropertyType(propName, config.properties));
+                config.set(propName, propValue, { secure: true });
             }
         }
 

--- a/packages/imperative/src/config/cmd/set/set.handler.ts
+++ b/packages/imperative/src/config/cmd/set/set.handler.ts
@@ -11,7 +11,8 @@
 
 import * as JSONC from "comment-json";
 import { ICommandHandler, IHandlerParameters } from "../../../../../cmd";
-import { secureSaveError } from "../../../../../config/src/ConfigUtils";
+import { ConfigSchema } from "../../../../../config";
+import { coercePropValue, secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { ImperativeError } from "../../../../../error";
 import { ImperativeConfig } from "../../../../../utilities";
 
@@ -46,7 +47,7 @@ export default class SetHandler implements ICommandHandler {
         if (params.arguments.value) {
             value = params.arguments.value;
         } else {
-            value = await params.response.console.prompt(`Please enter the value for ${params.arguments.property}: `, {hideText: secure});
+            value = await params.response.console.prompt(`Please enter the value for ${params.arguments.property}: `, { hideText: secure });
         }
 
         if (params.arguments.json) {
@@ -55,10 +56,12 @@ export default class SetHandler implements ICommandHandler {
             } catch (e) {
                 throw new ImperativeError({ msg: `could not parse JSON value: ${e.message}` });
             }
+        } else {
+            value = coercePropValue(value, ConfigSchema.findPropertyType(params.arguments.property, config.properties));
         }
 
         // Set the value in the config, save the secure values, write the config layer
-        config.set(params.arguments.property, value, { parseString: true, secure });
+        config.set(params.arguments.property, value, { secure });
 
         await config.save();
     }


### PR DESCRIPTION
Resolves #772

I've attempted to make the new method `ConfigSchema.findPropertyType` flexible and easy to use not only in the CLI, but also in apps that use the ProfileInfo API like Zowe Explorer.