### PR TITLE
Fix merging of autoStore property between layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `autoStore` property not being merged properly between team config layers.
+
 ## `5.0.0-next.202204111131`
 
 - BugFix: Updated `moment` dependency.

--- a/packages/config/__tests__/Config.api.test.ts
+++ b/packages/config/__tests__/Config.api.test.ts
@@ -52,7 +52,8 @@ const mergeConfig: IConfig = {
     },
     plugins: [
         "@zowe/vegetable-for-imperative"
-    ]
+    ],
+    autoStore: false
 };
 
 describe("Config API tests", () => {
@@ -505,6 +506,7 @@ describe("Config API tests", () => {
                 expect(retrievedConfig.profiles.fruit.profiles.grape).toBeDefined();
                 expect(retrievedConfig.profiles.fruit.properties.shipDate).toBeDefined();
                 expect(retrievedConfig.profiles.fruit.secure.length).toBe(1);
+                expect(retrievedConfig.autoStore).toBe(false);
 
                 // Check that old config had priority
                 expect(retrievedConfig.defaults.fruit).toBe("fruit.apple");
@@ -525,6 +527,7 @@ describe("Config API tests", () => {
                 expect(retrievedConfig.profiles.fruit.profiles.grape).toBeDefined();
                 expect(retrievedConfig.profiles.fruit.properties.shipDate).toBeDefined();
                 expect(retrievedConfig.profiles.fruit.secure.length).toBe(1);
+                expect(retrievedConfig.autoStore).toBe(false);
 
                 // Check that old config had priority
                 expect(retrievedConfig.defaults.fruit).toBe("fruit.apple");

--- a/packages/config/__tests__/__resources__/my_app.config.json
+++ b/packages/config/__tests__/__resources__/my_app.config.json
@@ -39,5 +39,6 @@
         "fruit": "fruit.banana",
         "vegetable": "vegetable.artichoke"
     },
-    "plugins": []
+    "plugins": [],
+    "autoStore": true
 }

--- a/packages/config/__tests__/__resources__/my_app.config.user.json
+++ b/packages/config/__tests__/__resources__/my_app.config.user.json
@@ -38,5 +38,6 @@
         "fruit": "fruit.apple",
         "vegetable": "vegetable.artichoke"
     },
-    "plugins": []
+    "plugins": [],
+    "autoStore": true
 }

--- a/packages/config/__tests__/__resources__/project.config.json
+++ b/packages/config/__tests__/__resources__/project.config.json
@@ -26,5 +26,6 @@
     "defaults": {
         "fruit": "fruit.orange"
     },
-    "plugins": []
+    "plugins": [],
+    "autoStore": true
 }

--- a/packages/config/__tests__/__resources__/project.config.user.json
+++ b/packages/config/__tests__/__resources__/project.config.user.json
@@ -26,5 +26,6 @@
     },
     "plugins": [
         "@zowe/fruit-for-imperative"
-    ]
+    ],
+    "autoStore": false
 }

--- a/packages/config/__tests__/__snapshots__/Config.api.test.ts.snap
+++ b/packages/config/__tests__/__snapshots__/Config.api.test.ts.snap
@@ -6,6 +6,7 @@ Object {
   "global": false,
   "path": "project.config.user.json",
   "properties": Object {
+    "autoStore": false,
     "defaults": Object {
       "fruit": "fruit.apple",
     },
@@ -41,6 +42,7 @@ Object {
 
 exports[`Config API tests layers merge - dry run should merge config layers with correct priority 1`] = `
 Object {
+  "autoStore": false,
   "defaults": Object {
     "fruit": "fruit.apple",
   },
@@ -84,6 +86,7 @@ Object {
 
 exports[`Config API tests layers merge should merge config layers with correct priority 1`] = `
 Object {
+  "autoStore": false,
   "defaults": Object {
     "fruit": "fruit.apple",
   },
@@ -176,7 +179,8 @@ exports[`Config API tests layers write should save the active config layer 1`] =
     },
     \\"plugins\\": [
         \\"@zowe/fruit-for-imperative\\"
-    ]
+    ],
+    \\"autoStore\\": false
 }"
 `;
 

--- a/packages/config/__tests__/__snapshots__/Config.test.ts.snap
+++ b/packages/config/__tests__/__snapshots__/Config.test.ts.snap
@@ -9,6 +9,7 @@ Object {
 
 exports[`Config tests load should load global config 1`] = `
 Object {
+  "autoStore": true,
   "defaults": Object {
     "fruit": "fruit.banana",
     "vegetable": "vegetable.artichoke",
@@ -53,6 +54,7 @@ Object {
 
 exports[`Config tests load should load project config 1`] = `
 Object {
+  "autoStore": true,
   "defaults": Object {
     "fruit": "fruit.orange",
   },
@@ -85,6 +87,7 @@ Object {
 
 exports[`Config tests load should load project user config 1`] = `
 Object {
+  "autoStore": false,
   "defaults": Object {
     "fruit": "fruit.apple",
   },
@@ -118,6 +121,7 @@ Object {
 
 exports[`Config tests load should load user config 1`] = `
 Object {
+  "autoStore": true,
   "defaults": Object {
     "fruit": "fruit.apple",
     "vegetable": "vegetable.artichoke",
@@ -162,6 +166,7 @@ Object {
 
 exports[`Config tests load should merge multiple config files 1`] = `
 Object {
+  "autoStore": false,
   "defaults": Object {
     "fruit": "fruit.apple",
     "vegetable": "vegetable.artichoke",

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -531,8 +531,8 @@ export class Config {
                 c.defaults[name] = c.defaults[name] || value;
             }
 
-            if (layer.properties.autoStore) {
-                c.autoStore = true;
+            if (c.autoStore == null && layer.properties.autoStore != null) {
+                c.autoStore = layer.properties.autoStore;
             }
         });
 

--- a/packages/config/src/api/ConfigLayers.ts
+++ b/packages/config/src/api/ConfigLayers.ts
@@ -190,8 +190,8 @@ export class ConfigLayers extends ConfigApi {
             }
         }
 
-        if (cnfg.autoStore) {
-            layer.properties.autoStore = true;
+        if (cnfg.autoStore != null) {
+            layer.properties.autoStore = cnfg.autoStore;
         }
 
         if (dryRun) { return layer; }


### PR DESCRIPTION
Fixes incorrect behavior where `autoStore=true` in global config overrides `autoStore=false` in project config.