### PR TITLE
Remove moment dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Removed `moment` dependency.
+
 ## `4.18.2`
 
 - BugFix: Updated `moment` dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "lodash-deep": "2.0.0",
         "log4js": "6.4.0",
         "markdown-it": "12.3.2",
-        "moment": "2.29.2",
         "mustache": "2.3.0",
         "npm-package-arg": "8.1.1",
         "opener": "1.5.2",
@@ -14218,6 +14217,7 @@
       "version": "2.29.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
       "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -30670,7 +30670,8 @@
     "moment": {
       "version": "2.29.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "lodash-deep": "2.0.0",
     "log4js": "6.4.0",
     "markdown-it": "12.3.2",
-    "moment": "2.29.2",
     "mustache": "2.3.0",
     "npm-package-arg": "8.1.1",
     "opener": "1.5.2",

--- a/packages/console/__tests__/Console.test.ts
+++ b/packages/console/__tests__/Console.test.ts
@@ -78,4 +78,11 @@ describe("Console tests", () => {
         expect((cons as any).writeStdout).toHaveBeenCalledTimes(numberOfCalls);
         expect((cons as any).writeStderr).toHaveBeenCalledTimes(numberOfCalls);
     });
+
+    it("Should default to the same prefix as log4js", () => {
+        const cons = new Console();
+        jest.spyOn(Date.prototype, "getTimezoneOffset").mockReturnValueOnce(0);
+        jest.spyOn(Date, "now").mockReturnValueOnce(45296789);
+        expect((cons as any).buildPrefix("test")).toBe("[1970/01/01 12:34:56.789] [test] ");
+    });
 });

--- a/packages/console/src/Console.ts
+++ b/packages/console/src/Console.ts
@@ -17,8 +17,7 @@
  */
 import { IConsole } from "./doc/IConsole";
 import { TextUtils } from "../../utilities";
-import * as moment from "moment";
-import { format, isNullOrUndefined } from "util";
+import { format } from "util";
 import { ImperativeError } from "../../error";
 
 export class Console implements IConsole {
@@ -204,7 +203,7 @@ export class Console implements IConsole {
         let formatted = data;
         // TODO(Kelosky): this is not ideal, but works for simple cases of
         // .debug(%s, "sub string").
-        if (this.isFormatEnabled() && !isNullOrUndefined(args) && args.length > 0) {
+        if (this.isFormatEnabled() && args != null && args.length > 0) {
             let defined = false;
             args.forEach((arg) => {
                 arg.forEach((ntry: string[]) => {
@@ -222,7 +221,11 @@ export class Console implements IConsole {
     }
 
     private buildPrefix(type: string) {
-        return "[" + moment().format("YYYY/MM/DD HH:MM:SS") + "]" + " " + "[" + type + "]" + " ";
+        // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+        const tzOffset = new Date().getTimezoneOffset() * 60000;
+        const dateString = new Date(Date.now() - tzOffset).toISOString()
+            .replace(/(\d+)-(\d+)-(\d+)T(.+)Z/, "$1/$2/$3 $4");
+        return "[" + dateString + "]" + " " + "[" + type + "]" + " ";
     }
 
     set level(level: string) {

--- a/packages/console/src/Console.ts
+++ b/packages/console/src/Console.ts
@@ -224,7 +224,7 @@ export class Console implements IConsole {
         // eslint-disable-next-line @typescript-eslint/no-magic-numbers
         const tzOffset = new Date().getTimezoneOffset() * 60000;
         const dateString = new Date(Date.now() - tzOffset).toISOString()
-            .replace(/(\d+)-(\d+)-(\d+)T([^Z]+)Z/, "$1/$2/$3 $4");
+            .replace(/(\d{4})-(\d{2})-(\d{2})T([^Z]+)Z/, "$1/$2/$3 $4");
         return "[" + dateString + "]" + " " + "[" + type + "]" + " ";
     }
 

--- a/packages/console/src/Console.ts
+++ b/packages/console/src/Console.ts
@@ -224,7 +224,7 @@ export class Console implements IConsole {
         // eslint-disable-next-line @typescript-eslint/no-magic-numbers
         const tzOffset = new Date().getTimezoneOffset() * 60000;
         const dateString = new Date(Date.now() - tzOffset).toISOString()
-            .replace(/(\d+)-(\d+)-(\d+)T(.+)Z/, "$1/$2/$3 $4");
+            .replace(/(\d+)-(\d+)-(\d+)T([^Z]+)Z/, "$1/$2/$3 $4");
         return "[" + dateString + "]" + " " + "[" + type + "]" + " ";
     }
 


### PR DESCRIPTION
The developers of Moment.js recommend not to use it anymore: https://momentjs.com/docs/#/-project-status/

Since the package had a recent vulnerability, we only used it in one place, and it was easy to replace with native JS, I've done so in this PR.

Also added a test to verify the timestamp is correct, since the original format was wrong. It was printing the month in place of minutes, and 100ths of seconds instead of 60ths.