### PR TITLE
Design Discussion - `osLoc` with more information

### DIFF
--- a/packages/config/__tests__/ProfileInfo.OldProfiles.test.ts
+++ b/packages/config/__tests__/ProfileInfo.OldProfiles.test.ts
@@ -107,7 +107,7 @@ describe("Old-school ProfileInfo tests", () => {
             expect(profAttrs.profType).toBe(desiredProfType);
             expect(profAttrs.profLoc.locType).not.toBeNull();
 
-            const retrievedOsLoc = path.normalize(profAttrs.profLoc.osLoc[0]);
+            const retrievedOsLoc = path.normalize(profAttrs.profLoc.osLoc[0].path);
             const expectedOsLoc = path.join(homeDirPath, "profiles",
                 desiredProfType, profAttrs.profName + ".yaml"
             );
@@ -149,7 +149,7 @@ describe("Old-school ProfileInfo tests", () => {
                 expect(prof.profLoc.locType).toEqual(ProfLocType.OLD_PROFILE);
                 expect(prof.profLoc.osLoc).toBeDefined();
                 expect(prof.profLoc.osLoc.length).toEqual(1);
-                expect(prof.profLoc.osLoc[0]).toEqual(path.join(homeDirPath, "profiles", prof.profType, prof.profName + ".yaml"));
+                expect(prof.profLoc.osLoc[0].path).toEqual(path.join(homeDirPath, "profiles", prof.profType, prof.profName + ".yaml"));
                 expectedProfileNames = expectedProfileNames.filter(obj => obj !== prof.profName);
             }
             expect(actualDefaultProfiles).toEqual(expectedDefaultProfiles);
@@ -179,7 +179,7 @@ describe("Old-school ProfileInfo tests", () => {
                 expect(prof.profLoc.locType).toEqual(ProfLocType.OLD_PROFILE);
                 expect(prof.profLoc.osLoc).toBeDefined();
                 expect(prof.profLoc.osLoc.length).toEqual(1);
-                expect(prof.profLoc.osLoc[0]).toEqual(path.join(homeDirPath, "profiles", prof.profType, prof.profName + ".yaml"));
+                expect(prof.profLoc.osLoc[0].path).toEqual(path.join(homeDirPath, "profiles", prof.profType, prof.profName + ".yaml"));
                 expectedProfileNames = expectedProfileNames.filter(obj => obj !== prof.profName);
             }
             expect(actualDefaultProfiles).toEqual(expectedDefaultProfiles);
@@ -230,7 +230,7 @@ describe("Old-school ProfileInfo tests", () => {
                 expect(arg).toMatchObject(expectedArgs[idx]);
                 expect(arg.secure || arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.OLD_PROFILE);
-                expect(arg.argLoc.osLoc[0]).toMatch(/lpar1_zosmf\.yaml$/);
+                expect(arg.argLoc.osLoc[0].path).toMatch(/lpar1_zosmf\.yaml$/);
             }
         });
 
@@ -256,7 +256,7 @@ describe("Old-school ProfileInfo tests", () => {
                 expect(arg).toMatchObject(expectedArgs[idx]);
                 expect(arg.secure || arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.OLD_PROFILE);
-                expect(arg.argLoc.osLoc[0]).toMatch(/(base_apiml|lpar1_zosmf)\.yaml$/);
+                expect(arg.argLoc.osLoc[0].path).toMatch(/(base_apiml|lpar1_zosmf)\.yaml$/);
             }
         });
 
@@ -280,7 +280,7 @@ describe("Old-school ProfileInfo tests", () => {
                 expect(arg).toMatchObject(expectedArgs[idx]);
                 expect(arg.secure || arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.OLD_PROFILE);
-                expect(arg.argLoc.osLoc[0]).toMatch(/lpar2_zosmf\.yaml$/);
+                expect(arg.argLoc.osLoc[0].path).toMatch(/lpar2_zosmf\.yaml$/);
             }
         });
 
@@ -383,7 +383,7 @@ describe("Old-school ProfileInfo tests", () => {
                 expect(arg).toMatchObject(expectedArgs[idx]);
                 expect(arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.OLD_PROFILE);
-                expect(arg.argLoc.osLoc[0]).toMatch(/base_for_userNm\.yaml$/);
+                expect(arg.argLoc.osLoc[0].path).toMatch(/base_for_userNm\.yaml$/);
             }
         });
     });

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -79,7 +79,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 profType: "profType1",
                 profLoc: {
                     locType: ProfLocType.TEAM_CONFIG,
-                    osLoc: ["somewhere in the OS 1", "somewhere in the OS 2"],
+                    osLoc: [{ path: "somewhere in the OS 1" }, { path: "somewhere in the OS 2" }],
                     jsonLoc: "somewhere in the JSON file"
                 },
                 isDefaultProfile: true
@@ -95,8 +95,8 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(profLoaded.profile.profName).toBe(profAttrs.profName);
                 expect(profLoaded.profile.profType).toBe(profAttrs.profType);
                 expect(profLoaded.profile.profLoc.locType).toBe(profAttrs.profLoc.locType);
-                expect(profLoaded.profile.profLoc.osLoc[0]).toBe(profAttrs.profLoc.osLoc[0]);
-                expect(profLoaded.profile.profLoc.osLoc[1]).toBe(profAttrs.profLoc.osLoc[1]);
+                expect(profLoaded.profile.profLoc.osLoc[0].path).toBe(profAttrs.profLoc.osLoc[0].path);
+                expect(profLoaded.profile.profLoc.osLoc[1].path).toBe(profAttrs.profLoc.osLoc[1].path);
                 expect(profLoaded.profile.profLoc.jsonLoc).toBe(profAttrs.profLoc.jsonLoc);
                 expect(profLoaded.profile.isDefaultProfile).toBe(profAttrs.isDefaultProfile);
             });
@@ -119,8 +119,8 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(profLoaded.profile.profName).toBe(profAttrs.profName);
                 expect(profLoaded.profile.profType).toBe(profAttrs.profType);
                 expect(profLoaded.profile.profLoc.locType).toBe(profAttrs.profLoc.locType);
-                expect(profLoaded.profile.profLoc.osLoc[0]).toBe(profAttrs.profLoc.osLoc[0]);
-                expect(profLoaded.profile.profLoc.osLoc[1]).toBe(profAttrs.profLoc.osLoc[1]);
+                expect(profLoaded.profile.profLoc.osLoc[0].path).toBe(profAttrs.profLoc.osLoc[0].path);
+                expect(profLoaded.profile.profLoc.osLoc[1].path).toBe(profAttrs.profLoc.osLoc[1].path);
                 expect(profLoaded.profile.profLoc.jsonLoc).toBe(profAttrs.profLoc.jsonLoc);
                 expect(profLoaded.profile.isDefaultProfile).toBe(profAttrs.isDefaultProfile);
             });
@@ -132,7 +132,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 profType: "zosmf",
                 profLoc: {
                     locType: ProfLocType.TEAM_CONFIG,
-                    osLoc: ["somewhere in the OS 1", "somewhere in the OS 1A"],
+                    osLoc: [{ path: "somewhere in the OS 1" }, { path: "somewhere in the OS 1A" }],
                     jsonLoc: "somewhere in the JSON file 1"
                 },
                 isDefaultProfile: true
@@ -152,7 +152,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                     argName: "host", dataType: "string", argValue: "testHostName",
                     argLoc: {
                         locType: ProfLocType.TEAM_CONFIG,
-                        osLoc: ["somewhere in the OS 2", "somewhere in the OS 2A"],
+                        osLoc: [{ path: "somewhere in the OS 2" }, { path: "somewhere in the OS 2A" }],
                         jsonLoc: "somewhere in the JSON file 2"
                     },
                     secure: false
@@ -161,7 +161,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                     argName: "port", dataType: "number", argValue: 12345,
                     argLoc: {
                         locType: ProfLocType.TEAM_CONFIG,
-                        osLoc: ["somewhere in the OS 3", "somewhere in the OS 3A"],
+                        osLoc: [{ path: "somewhere in the OS 3" }, { path: "somewhere in the OS 3A" }],
                         jsonLoc: "somewhere in the JSON file 3"
                     },
                     secure: false
@@ -283,7 +283,7 @@ describe("TeamConfig ProfileInfo tests", () => {
             expect(profAttrs.profType).toBe(desiredProfType);
             expect(profAttrs.profLoc.locType).not.toBeNull();
 
-            const retrievedOsLoc = path.normalize(profAttrs.profLoc.osLoc[0]);
+            const retrievedOsLoc = path.normalize(profAttrs.profLoc.osLoc[0].path);
             const expectedOsLoc = path.join(teamProjDir, testAppNm + ".config.json");
             expect(retrievedOsLoc).toBe(expectedOsLoc);
 
@@ -324,7 +324,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(prof.profLoc.locType).toEqual(ProfLocType.TEAM_CONFIG);
                 expect(prof.profLoc.osLoc).toBeDefined();
                 expect(prof.profLoc.osLoc.length).toEqual(1);
-                expect(prof.profLoc.osLoc[0]).toEqual(path.join(teamProjDir, testAppNm + ".config.json"));
+                expect(prof.profLoc.osLoc[0].path).toEqual(path.join(teamProjDir, testAppNm + ".config.json"));
                 expect(prof.profLoc.jsonLoc).toBeDefined();
 
                 const propertiesJson = jsonfile.readFileSync(path.join(teamProjDir, testAppNm + ".config.json"));
@@ -344,7 +344,7 @@ describe("TeamConfig ProfileInfo tests", () => {
             let actualDefaultProfiles = 0;
 
             const profInfo = createNewProfInfo(teamProjDir);
-            await profInfo.readProfilesFromDisk({homeDir: teamHomeProjDir});
+            await profInfo.readProfilesFromDisk({ homeDir: teamHomeProjDir });
             const profAttrs = profInfo.getAllProfiles(desiredProfType);
 
             expect(profAttrs.length).toEqual(expectedProfileNames.length);
@@ -359,7 +359,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(prof.profLoc.osLoc).toBeDefined();
                 expect(prof.profLoc.osLoc.length).toEqual(1);
                 const profDir = path.join(prof.profName === "LPAR2_home" ? teamHomeProjDir : teamProjDir, testAppNm + ".config.json");
-                expect(prof.profLoc.osLoc[0]).toEqual(profDir);
+                expect(prof.profLoc.osLoc[0].path).toEqual(profDir);
                 expect(prof.profLoc.jsonLoc).toBeDefined();
                 const propertiesJson = jsonfile.readFileSync(profDir);
                 expect(lodash.get(propertiesJson, prof.profLoc.jsonLoc)).toBeDefined();
@@ -420,7 +420,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.TEAM_CONFIG);
                 expect(arg.argLoc.jsonLoc).toMatch(/^profiles\.LPAR1\.properties\./);
-                expect(arg.argLoc.osLoc[0]).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
+                expect(arg.argLoc.osLoc[0].path).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
             }
         });
 
@@ -450,7 +450,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.TEAM_CONFIG);
                 expect(arg.argLoc.jsonLoc).toMatch(/^profiles\.LPAR1\.(profiles|properties)\./);
-                expect(arg.argLoc.osLoc[0]).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
+                expect(arg.argLoc.osLoc[0].path).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
             }
         });
 
@@ -475,7 +475,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(arg.secure || arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.TEAM_CONFIG);
                 expect(arg.argLoc.jsonLoc).toMatch(/^profiles\.(base_glob|LPAR1)\.properties\./);
-                expect(arg.argLoc.osLoc[0]).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
+                expect(arg.argLoc.osLoc[0].path).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
             }
         });
 
@@ -550,7 +550,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.TEAM_CONFIG);
                 expect(arg.argLoc.jsonLoc).toMatch(/^profiles\.LPAR1\.properties\./);
-                expect(arg.argLoc.osLoc[0]).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
+                expect(arg.argLoc.osLoc[0].path).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
             }
         });
 
@@ -699,7 +699,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(arg.argValue).toBeDefined();
                 expect(arg.argLoc.locType).toBe(ProfLocType.TEAM_CONFIG);
                 expect(arg.argLoc.jsonLoc).toMatch(/^profiles\.base_glob\.properties\./);
-                expect(arg.argLoc.osLoc[0]).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
+                expect(arg.argLoc.osLoc[0].path).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
             }
         });
 

--- a/packages/config/src/api/ConfigLayers.ts
+++ b/packages/config/src/api/ConfigLayers.ts
@@ -15,7 +15,7 @@ import * as JSONC from "comment-json";
 import * as lodash from "lodash";
 import { ImperativeError } from "../../../error";
 import { ConfigConstants } from "../ConfigConstants";
-import { IConfigLayer } from "../doc/IConfigLayer";
+import { IConfigLayer, IConfigLayerInfo } from "../doc/IConfigLayer";
 import { ConfigApi } from "./ConfigApi";
 import { IConfig } from "../doc/IConfig";
 
@@ -31,7 +31,7 @@ export class ConfigLayers extends ConfigApi {
      * @param opts The user and global flags that indicate which of the four
      *             config files (aka layers) is to be read.
      */
-    public async read(opts?: { user: boolean; global: boolean }) {
+    public async read(opts?: IConfigLayerInfo) {
         // Attempt to populate the layer
         const layer = opts ? this.mConfig.findLayer(opts.user, opts.global) : this.mConfig.layerActive();
         if (fs.existsSync(layer.path)) {
@@ -71,7 +71,7 @@ export class ConfigLayers extends ConfigApi {
      * @param opts The user and global flags that indicate which of the four
      *             config files (aka layers) is to be written.
      */
-    public async write(opts?: { user: boolean; global: boolean }) {
+    public async write(opts?: IConfigLayerInfo) {
         // TODO: should we prevent a write if there is no vault
         // TODO: specified and there are secure fields??
 
@@ -203,7 +203,7 @@ export class ConfigLayers extends ConfigApi {
      * @param profileName Profile name to search for
      * @returns User and global properties, or undefined if profile does not exist
      */
-    public find(profileName: string): { user: boolean, global: boolean } {
+    public find(profileName: string): IConfigLayer {
         const profilePath = this.mConfig.api.profiles.expandPath(profileName);
         for (const layer of this.mConfig.layers) {
             if (lodash.get(layer.properties, profilePath) != null) {

--- a/packages/config/src/api/ConfigSecure.ts
+++ b/packages/config/src/api/ConfigSecure.ts
@@ -17,6 +17,7 @@ import { IConfigSecureProperties } from "../doc/IConfigSecure";
 import { ConfigConstants } from "../ConfigConstants";
 import { IConfigProfile } from "../doc/IConfigProfile";
 import { CredentialManagerFactory } from "../../../security";
+import { IConfigLayerInfo } from "../doc/IConfigLayer";
 
 /**
  * API Class for manipulating config layers.
@@ -139,7 +140,7 @@ export class ConfigSecure extends ConfigApi {
      * @returns Array of secure property paths
      *          (e.g., "profiles.lpar1.properties.password")
      */
-    public secureFields(opts?: { user: boolean; global: boolean }): string[] {
+    public secureFields(opts?: IConfigLayerInfo): string[] {
         const layer = opts ? this.mConfig.findLayer(opts.user, opts.global) : this.mConfig.layerActive();
         return this.findSecure(layer.properties.profiles, "profiles");
     }

--- a/packages/config/src/doc/IConfigLayer.ts
+++ b/packages/config/src/doc/IConfigLayer.ts
@@ -11,10 +11,19 @@
 
 import { IConfig } from "./IConfig";
 
-export interface IConfigLayer {
+export interface IConfigLayerInfo {
+    global: boolean;
+    user: boolean;
+}
+
+export interface IConfigLayerLoc {
+    global?: boolean;
+    user?: boolean;
+    path: string;
+}
+
+export interface IConfigLayer extends IConfigLayerInfo {
     path: string;
     exists: boolean;
     properties: IConfig;
-    global: boolean;
-    user: boolean;
 }

--- a/packages/config/src/doc/IProfLoc.ts
+++ b/packages/config/src/doc/IProfLoc.ts
@@ -9,6 +9,8 @@
 *
 */
 
+import { IConfigLayerLoc } from "./IConfigLayer";
+
 /**
  * This enum represents the type of location for a property.
  * Note that properties with location types of ENV and DEFAULT
@@ -35,7 +37,7 @@ export interface IProfLoc {
      * For ENV, this is the name of the environment variable.
      * This is not used for DEFAULT.
      */
-    osLoc?: string[];
+    osLoc?: IConfigLayerLoc[];
 
     /**
      * For SOURCE_TEAM_CONFIG, this is the dotted path into


### PR DESCRIPTION
⚠️ Do not merge ⚠️ 
Also, no need to approve this PR

**What ?**
- Enhance (break) the osLoc property to include more information about which layer each of the config paths belongs to.

**Why ?**
- To allow application developers to exclude global team profiles.

**Alternatives ?**
- Non-breaking is to implement an utility function in ProfileInfo that returns layer information based profile attributes

**Pros and Cons ?**
- Pro: More information available for future (currently unknown) use cases
- Con: Significant braking change to the API