### PR TITLE
Use base from operating layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed ProfileInfo API targeting default base profile instead of the operating layer's base profile. [#791](https://github.com/zowe/imperative/issues/791)
+
+## `5.0.0`
+
+- Major: Introduced Team Profiles, Daemon mode, and more. See the prerelease items below for more details.
+
 ## `5.0.0-next.202204142147`
 
 - BugFix: Fixed missing `osLoc` information from `ProfileInfo.getAllProfiles()`. [#771](https://github.com/zowe/imperative/issues/771)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@zowe/imperative",
   "version": "5.0.0",
   "description": "framework for building configurable CLIs",
-  "author": "Broadcom",
+  "author": "Zowe",
   "license": "EPL-2.0",
   "homepage": "https://github.com/zowe/imperative#readme",
   "bugs": {

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -517,7 +517,6 @@ describe("TeamConfig ProfileInfo tests", () => {
             await profInfo.readProfilesFromDisk({homeDir: teamHomeProjDir});
 
             const profAttrs = profInfo.getAllProfiles("zosmf").find(p => p.profName === "LPAR2_home");
-            console.log(profAttrs, profInfo.getOsLocInfo(profAttrs))
             const mergedArgs = profInfo.mergeArgsForProfile(profAttrs, {getSecureVals: true});
 
             const expectedArgs = [

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -512,6 +512,33 @@ describe("TeamConfig ProfileInfo tests", () => {
             }
         });
 
+        it("should find known args in service profile and its corresponding base", async () => {
+            const profInfo = createNewProfInfo(teamProjDir);
+            await profInfo.readProfilesFromDisk({homeDir: teamHomeProjDir});
+
+            const profAttrs = profInfo.getAllProfiles("zosmf").find(p => p.profName === "LPAR2_home");
+            console.log(profAttrs, profInfo.getOsLocInfo(profAttrs))
+            const mergedArgs = profInfo.mergeArgsForProfile(profAttrs, {getSecureVals: true});
+
+            const expectedArgs = [
+                { argName: "host", dataType: "string", argValue: "LPAR2.your.domain.net" },
+                { argName: "port", dataType: "number", argValue: 6789 },
+                { argName: "responseFormatHeader", dataType: "boolean", argValue: true },
+                { argName: "user", dataType: "string", argValue: "globalUser" },
+                { argName: "password", dataType: "string", argValue: "globalPassword" },
+                { argName: "rejectUnauthorized", dataType: "boolean", argValue: false }
+            ];
+
+            expect(mergedArgs.knownArgs.length).toBe(expectedArgs.length);
+            for (const [idx, arg] of mergedArgs.knownArgs.entries()) {
+                expect(arg).toMatchObject(expectedArgs[idx]);
+                expect(arg.argValue).toEqual(expectedArgs[idx].argValue);
+                expect(arg.argLoc.locType).toBe(ProfLocType.TEAM_CONFIG);
+                expect(arg.argLoc.jsonLoc).toMatch(/^profiles\.(base_glob_home|LPAR2_home)\.properties\./);
+                expect(arg.argLoc.osLoc[0]).toMatch(new RegExp(`${testAppNm}\\.config\\.json$`));
+            }
+        });
+
         it("should override not known args in service and base profile with environment variables", async () => {
             const fakePort = 12345;
             const teamConfigHost = "LPAR4.your.domain.net";

--- a/packages/config/__tests__/__resources__/ProfInfoApp_home_team_config_proj/ProfInfoApp.config.json
+++ b/packages/config/__tests__/__resources__/ProfInfoApp_home_team_config_proj/ProfInfoApp.config.json
@@ -4,8 +4,8 @@
         "base_glob_home": {
             "type": "base",
             "properties": {
-                "user": "userNameBase",
-                "password": "passwordBase",
+                "user": "globalUser",
+                "password": "globalPassword",
                 "rejectUnauthorized": false
             }
         },

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -741,7 +741,11 @@ export class ProfileInfo {
         // did our caller request the actual values of secure arguments?
         if (mergeOpts.getSecureVals) {
             mergedArgs.knownArgs.forEach((nextArg) => {
-                if (nextArg.secure) nextArg.argValue = this.loadSecureArg(nextArg);
+                try {
+                    if (nextArg.secure) nextArg.argValue = this.loadSecureArg(nextArg);
+                } catch(_argValueNotDefined) {
+                    nextArg.argValue = undefined;
+                }
             });
         }
 

--- a/packages/config/src/api/ConfigProfiles.ts
+++ b/packages/config/src/api/ConfigProfiles.ts
@@ -119,7 +119,7 @@ export class ConfigProfiles extends ConfigApi {
      *
      * @returns The desired profile object. An empty object if profiles is empty.
      */
-    private buildProfile(path: string, profiles: { [key: string]: IConfigProfile }): { [key: string]: string } {
+    public buildProfile(path: string, profiles: { [key: string]: IConfigProfile }): { [key: string]: string } {
         const segments: string[] = path.split(".");
         let properties = {};
         for (const [n, p] of Object.entries(profiles)) {


### PR DESCRIPTION
Since there is already a feature merged into `next`, I believe I can switch the base to `master` and have this PR go out as a 5.0.1 (if needed)
I don't think the feature in next will cause any harm to the ProfileInfo APIs, so they could both be added in a 5.1.0.
Please keep in mind that ZE needs this for Zowe RC2.