### PR TITLE
Fix auto-init activating config layer too late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed issue where `config auto-init` may fail to create project config when global config already exists. [#810](https://github.com/zowe/imperative/issues/810)
+
 ## `5.1.0`
 
 - Enhancement: Introduced flag `--show-inputs-only` to show the inputs of the command

--- a/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
+++ b/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
@@ -89,19 +89,14 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
             sessCfg, params.arguments, { parms: params, doPrompting: true, serviceDescription: this.mServiceDescription },
         );
         this.mSession = new Session(sessCfgWithCreds);
-        const profileConfig = await this.doAutoInit(this.mSession, params);
-        let global = false;
-        let user = false;
 
         // Use params to set which config layer to apply to
         await OverridesLoader.ensureCredentialManagerLoaded();
-        if (params.arguments.globalConfig && params.arguments.globalConfig === true) {
-            global = true;
-        }
-        if (params.arguments.userConfig && params.arguments.userConfig === true) {
-            user = true;
-        }
-        ImperativeConfig.instance.config.api.layers.activate(user, global);
+        const configDir = params.arguments.globalConfig ? null : process.cwd();
+        ImperativeConfig.instance.config.api.layers.activate(params.arguments.userConfig, params.arguments.globalConfig, configDir);
+
+        // Call handler's implementation of auto-init
+        const profileConfig = await this.doAutoInit(this.mSession, params);
 
         if (params.arguments.dryRun && params.arguments.dryRun === true) {
             // Merge and display, do not save


### PR DESCRIPTION
Fixes #810

The `ApimlAutoInitHandler.doAutoInit` method defined in Zowe CLI expects that the starting config layer has been set correctly before it is invoked, but we weren't activating the config layer until after invoking it.
https://github.com/zowe/zowe-cli/blob/ed2128b7660b248f83f1486253c2635387660598/packages/cli/src/config/auto-init/ApimlAutoInitHandler.ts#L267-L273