### PR TITLE
Fix plugin uninstall failing when there is space in the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `plugins uninstall` command failing when there is a space in the install path.
+
 ## `5.1.0`
 
 - Enhancement: Introduced flag `--show-inputs-only` to show the inputs of the command

--- a/packages/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.test.ts
@@ -125,7 +125,7 @@ describe("Plugin Management Facility uninstall handler", () => {
         const handler = new UninstallHandler();
 
         const params = getIHandlerParametersObject();
-        params.arguments.plugin = "a";
+        params.arguments.plugin = ["a"];
 
         await handler.process(params as IHandlerParameters);
 
@@ -140,7 +140,7 @@ describe("Plugin Management Facility uninstall handler", () => {
         const handler = new UninstallHandler();
         let expectedError: ImperativeError;
         const params = getIHandlerParametersObject();
-        params.arguments.plugin = "";
+        params.arguments.plugin = [];
 
         try {
             await handler.process(params as IHandlerParameters);

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
@@ -61,7 +61,7 @@ describe("PMF: Uninstall Interface", () => {
      */
     const wasExecSyncCallValid = (expectedPackage: string) => {
         expect(mocks.execSync).toHaveBeenCalledWith(
-            `${npmCmd} uninstall "${expectedPackage}" --prefix ${PMFConstants.instance.PLUGIN_INSTALL_LOCATION} -g`,
+            `${npmCmd} uninstall "${expectedPackage}" --prefix "${PMFConstants.instance.PLUGIN_INSTALL_LOCATION}" -g`,
             {
                 cwd  : PMFConstants.instance.PMF_ROOT,
                 stdio: ["pipe", "pipe", process.stderr]

--- a/packages/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
+++ b/packages/imperative/src/plugins/cmd/uninstall/uninstall.handler.ts
@@ -51,7 +51,9 @@ export default class UninstallHandler implements ICommandHandler {
             });
         } else {
             try {
-                uninstall(params.arguments.plugin);
+                for (const packageName of params.arguments.plugin) {
+                    uninstall(packageName);
+                }
                 params.response.console.log("Removal of the npm package(s) was successful.\n"
                 );
             } catch (e) {

--- a/packages/imperative/src/plugins/utilities/npm-interface/uninstall.ts
+++ b/packages/imperative/src/plugins/utilities/npm-interface/uninstall.ts
@@ -63,7 +63,7 @@ export function uninstall(packageName: string): void {
         iConsole.info("Uninstalling package...this may take some time.");
 
         execSync(`${npmCmd} uninstall "${npmPackage}" ` +
-                `--prefix ${PMFConstants.instance.PLUGIN_INSTALL_LOCATION} -g`, {
+            `--prefix "${PMFConstants.instance.PLUGIN_INSTALL_LOCATION}" -g`, {
             cwd: PMFConstants.instance.PMF_ROOT,
             // We need to capture stdout but apparently stderr also gives us a progress
             // bar from the npm install.

--- a/packages/imperative/src/plugins/utilities/npm-interface/uninstall.ts
+++ b/packages/imperative/src/plugins/utilities/npm-interface/uninstall.ts
@@ -9,6 +9,8 @@
 *
 */
 
+import * as fs from "fs";
+import * as path from "path";
 import { PMFConstants } from "../PMFConstants";
 import { readFileSync, writeFileSync } from "jsonfile";
 import { IPluginJson } from "../../doc/IPluginJson";
@@ -48,7 +50,7 @@ export function uninstall(packageName: string): void {
         }
     } else {
         throw new ImperativeError({
-            msg: `${chalk.yellow.bold("Plugin name '")} ${chalk.red.bold(packageName)}' is not installed.`
+            msg: `${chalk.yellow.bold("Plugin name")} '${chalk.red.bold(packageName)}' is not installed.`
         });
     }
 
@@ -69,6 +71,11 @@ export function uninstall(packageName: string): void {
             // bar from the npm install.
             stdio: pipe
         });
+
+        const installFolder = path.join(PMFConstants.instance.PLUGIN_HOME_LOCATION, npmPackage);
+        if (fs.existsSync(installFolder)) {
+            throw new Error("Failed to uninstall plugin, install folder still exists:\n  " + installFolder);
+        }
 
         iConsole.info("Uninstall complete");
 


### PR DESCRIPTION
* Check if plugin install folder still exists after uninstall, because `npm uninstall` exit code is not very dependable
* Also fix the uninstall handler which treated the `params.arguments.plugin` as a string even though it is an array