### PR TITLE
Fix `config secure` not respecting rejectUnauthorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `config secure` not respecting the `rejectUnauthorized` property in team config. [#813](https://github.com/zowe/imperative/issues/813)
+
 ## `5.1.0`
 
 - Enhancement: Introduced flag `--show-inputs-only` to show the inputs of the command

--- a/packages/config/__tests__/ConfigAutoStore.test.ts
+++ b/packages/config/__tests__/ConfigAutoStore.test.ts
@@ -632,10 +632,10 @@ describe("ConfigAutoStore tests", () => {
         it("should fetch token when auth handler is found", async () => {
             const mockLoginHandler = jest.fn();
             jest.spyOn(ConfigAutoStore as any, "_findAuthHandlerForProfile").mockReturnValueOnce({
-                getPromptParams: () => [
-                    { defaultTokenType: SessConstants.TOKEN_TYPE_JWT },
-                    mockLoginHandler
-                ]
+                getAuthHandlerApi: () => ({
+                    promptParams: { defaultTokenType: SessConstants.TOKEN_TYPE_JWT },
+                    sessionLogin: mockLoginHandler
+                })
             } as any);
 
             const fetched = await (ConfigAutoStore as any).fetchTokenForSessCfg({}, {

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -105,8 +105,7 @@ export class ConfigAutoStore {
             const authHandlerClass = new authHandler.default();
 
             if (authHandlerClass instanceof AbstractAuthHandler) {
-                const promptParams = authHandlerClass.getPromptParams()[0];
-
+                const { promptParams } = authHandlerClass.getAuthHandlerApi();
                 if (profile.tokenType === promptParams.defaultTokenType) {
                     return authHandlerClass;  // Auth service must have matching token type
                 }
@@ -231,9 +230,9 @@ export class ConfigAutoStore {
             return false;
         }
 
-        const [promptParams, loginHandler] = authHandlerClass.getPromptParams();
+        const api = authHandlerClass.getAuthHandlerApi();
         opts.sessCfg.type = AUTH_TYPE_TOKEN;
-        opts.sessCfg.tokenType = promptParams.defaultTokenType;
+        opts.sessCfg.tokenType = api.promptParams.defaultTokenType;
         const baseSessCfg: ISession = { type: opts.sessCfg.type };
 
         for (const propName of Object.keys(ImperativeConfig.instance.loadedConfig.baseProfile.schema.properties)) {
@@ -244,7 +243,7 @@ export class ConfigAutoStore {
         }
 
         Logger.getAppLogger().info(`Fetching ${opts.sessCfg.tokenType} for ${opts.profilePath}`);
-        opts.sessCfg.tokenValue = await loginHandler(new Session(baseSessCfg));
+        opts.sessCfg.tokenValue = await api.sessionLogin(new Session(baseSessCfg));
         return true;
     }
 }

--- a/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
@@ -461,10 +461,7 @@ describe("Configuration Secure command handler", () => {
         beforeAll(() => {
             mockAuthHandlerApi = {
                 promptParams: { defaultTokenType: SessConstants.TOKEN_TYPE_JWT },
-                createSessCfg: jest.fn(args => ({
-                    hostname: args.host,
-                    port: args.port
-                })),
+                createSessCfg: jest.fn(x => x),
                 sessionLogin: jest.fn().mockResolvedValue("fakeLoginData")
             };
 

--- a/packages/imperative/src/auth/doc/IAuthHandlerApi.ts
+++ b/packages/imperative/src/auth/doc/IAuthHandlerApi.ts
@@ -1,0 +1,43 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandArguments } from "../../../../cmd";
+import { AbstractSession, IOptionsForAddConnProps, ISession } from "../../../../rest";
+
+/**
+ * Auth handler API that provides convenient functions to create a session from
+ * args, and use it to login or logout of an auth service.
+ */
+export interface IAuthHandlerApi {
+    /**
+     * Prompting options for adding connection properties.
+     * The properties `defaultTokenType` and `serviceDescription` should be defined.
+     */
+    promptParams: IOptionsForAddConnProps;
+
+    /**
+     * Method to create a session config object from CLI arguments.
+     * This is equivalent to the handler method `createSessCfgFromArgs`.
+     */
+    createSessCfg: (args: ICommandArguments) => ISession;
+
+    /**
+     * Method to login to authentication service with a session.
+     * This is equivalent to the handler method `doLogin`.
+     */
+    sessionLogin: (session: AbstractSession) => Promise<string>;
+
+    /**
+     * Method to logout of authentication service with a session.
+     * This is equivalent to the handler method `doLogout`.
+     */
+    sessionLogout: (session: AbstractSession) => Promise<void>;
+}

--- a/packages/imperative/src/auth/handlers/AbstractAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/AbstractAuthHandler.ts
@@ -13,6 +13,7 @@ import { ICommandHandler, IHandlerParameters, ICommandArguments } from "../../..
 import { Constants } from "../../../../constants";
 import { AbstractSession, IOptionsForAddConnProps, ISession, SessConstants } from "../../../../rest";
 import { ImperativeError } from "../../../../error";
+import { IAuthHandlerApi } from "../doc/IAuthHandlerApi";
 
 /**
  * This class is used by the auth command handlers as the base class for their implementation.
@@ -60,11 +61,18 @@ export abstract class AbstractAuthHandler implements ICommandHandler {
     /**
      * This is called by the "config secure" handler when it needs to prompt
      * for connection info to obtain an auth token.
+     * @deprecated Use `getAuthHandlerApi` instead
      * @returns A tuple containing:
      *  - Options for adding connection properties
      *  - The login handler
      */
     public abstract getPromptParams(): [IOptionsForAddConnProps, (session: AbstractSession) => Promise<string>];
+
+    /**
+     * Returns auth handler API that provides convenient functions to create a
+     * session from args, and use it to login or logout of an auth service.
+     */
+    public abstract getAuthHandlerApi(): IAuthHandlerApi;
 
     /**
      * This is called by the {@link AbstractAuthHandler#process} when it needs a

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -18,6 +18,7 @@ import { ISaveProfileFromCliArgs } from "../../../../profiles";
 import { ImperativeConfig } from "../../../../utilities";
 import { getActiveProfileName, secureSaveError } from "../../../../config/src/ConfigUtils";
 import { AbstractAuthHandler } from "./AbstractAuthHandler";
+import { IAuthHandlerApi } from "../doc/IAuthHandlerApi";
 
 /**
  * This class is used by the auth command handlers as the base class for their implementation.
@@ -48,6 +49,7 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
     /**
      * This is called by the "config secure" handler when it needs to prompt
      * for connection info to obtain an auth token.
+     * @deprecated Use `getAuthHandlerApi` instead
      * @returns A tuple containing:
      *  - Options for adding connection properties
      *  - The login handler
@@ -57,6 +59,22 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
             defaultTokenType: this.mDefaultTokenType,
             serviceDescription: this.mServiceDescription
         }, this.doLogin];
+    }
+
+    /**
+     * Returns auth handler API that provides convenient functions to create a
+     * session from args, and use it to login or logout of an auth service.
+     */
+    public getAuthHandlerApi(): IAuthHandlerApi {
+        return {
+            promptParams: {
+                defaultTokenType: this.mDefaultTokenType,
+                serviceDescription: this.mServiceDescription
+            },
+            createSessCfg: this.createSessCfgFromArgs,
+            sessionLogin: this.doLogin,
+            sessionLogout: this.doLogout
+        };
     }
 
     /**

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -99,7 +99,7 @@ export default class SecureHandler implements ICommandHandler {
 
             const profile = config.api.profiles.get(profilePath.replace(/profiles\./g, ""), false);
             const sessCfg: ISession = api.createSessCfg(profile as ICommandArguments);
-            const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt(sessCfg, this.params.arguments,
+            const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt(sessCfg, profile as ICommandArguments,
                 { parms: this.params, doPrompting: true, requestToken: true, ...api.promptParams });
             Logger.getAppLogger().info(`Fetching ${profile.tokenType} for ${propPath}`);
 
@@ -107,7 +107,7 @@ export default class SecureHandler implements ICommandHandler {
                 return await api.sessionLogin(new Session(sessCfgWithCreds));
             } catch (error) {
                 throw new ImperativeError({
-                    msg: `Failed to fetch ${profile.tokenType} for ${propPath}`,
+                    msg: `Failed to fetch ${profile.tokenType} for ${propPath}: ${error.message}`,
                     causeErrors: error
                 });
             }

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -92,19 +92,19 @@ export default class SecureHandler implements ICommandHandler {
         const authHandlerClass = ConfigAutoStore.findAuthHandlerForProfile(profilePath, this.params.arguments);
 
         if (authHandlerClass != null) {
-            const [promptParams, loginHandler] = authHandlerClass.getPromptParams();
-
-            if (promptParams.serviceDescription != null) {
-                this.params.response.console.log(`Logging in to ${promptParams.serviceDescription}`);
+            const api = authHandlerClass.getAuthHandlerApi();
+            if (api.promptParams.serviceDescription != null) {
+                this.params.response.console.log(`Logging in to ${api.promptParams.serviceDescription}`);
             }
 
             const profile = config.api.profiles.get(profilePath.replace(/profiles\./g, ""), false);
-            const sessCfg: ISession = await ConnectionPropsForSessCfg.addPropsOrPrompt({}, profile as ICommandArguments,
-                { parms: this.params, doPrompting: true, requestToken: true, ...promptParams });
+            const sessCfg: ISession = api.createSessCfg(profile as ICommandArguments);
+            const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt(sessCfg, this.params.arguments,
+                { parms: this.params, doPrompting: true, requestToken: true, ...api.promptParams });
             Logger.getAppLogger().info(`Fetching ${profile.tokenType} for ${propPath}`);
 
             try {
-                return await loginHandler(new Session(sessCfg));
+                return await api.sessionLogin(new Session(sessCfgWithCreds));
             } catch (error) {
                 throw new ImperativeError({
                     msg: `Failed to fetch ${profile.tokenType} for ${propPath}`,


### PR DESCRIPTION
When `config secure` prompts for user and password to obtain a token, it was not respecting the `rejectUnauthorized` property on the associated profile.

To fix this we need access to the `BaseAuthHandler.createSessCfgFromArgs` method. I've deprecated `getPromptParams` and replaced it with `getAuthHandlerApi` to expose this method. This works but not sure if it is the best implementation, so opening this PR in draft mode to get feedback.