### PR TITLE
Default `homeDir` to `cliHome` to support environmental variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added environmental variable support to the ProfileInfo APIs by defaulting `homeDir` to `cliHome`. [zowe/vscode-extension-for-zowe#1777](https://github.com/zowe/vscode-extension-for-zowe/issues/1777)
+
 ## `5.2.2`
 
 - BugFix: Fixed `config secure` not respecting the `rejectUnauthorized` property in team config. [#813](https://github.com/zowe/imperative/issues/813)

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -439,6 +439,9 @@ describe("TeamConfig ProfileInfo tests", () => {
             await profInfo.readProfilesFromDisk();
             const profAttrs = profInfo.getDefaultProfile("zosmf");
             delete profInfo.getTeamConfig().layerActive().properties.defaults.base;
+            // Since ProjectDir and HomeDir are the same (based on the ZOWE_CLI_HOME),
+            // we also need to delete the base profile from that layer (even though is't just a copy)
+            delete profInfo.getTeamConfig().findLayer(false, true).properties.defaults.base;
             const mergedArgs = profInfo.mergeArgsForProfile(profAttrs);
 
             const expectedArgs = [
@@ -462,6 +465,9 @@ describe("TeamConfig ProfileInfo tests", () => {
             await profInfo.readProfilesFromDisk();
             const profAttrs = profInfo.getDefaultProfile("tso");
             delete profInfo.getTeamConfig().layerActive().properties.defaults.base;
+            // Since ProjectDir and HomeDir are the same (based on the ZOWE_CLI_HOME),
+            // we also need to delete the base profile from that layer (even though is't just a copy)
+            delete profInfo.getTeamConfig().findLayer(false, true).properties.defaults.base;
             const mergedArgs = profInfo.mergeArgsForProfile(profAttrs);
 
             const expectedArgs = [
@@ -552,6 +558,9 @@ describe("TeamConfig ProfileInfo tests", () => {
             await profInfo.readProfilesFromDisk();
             const profAttrs = profInfo.getDefaultProfile("dummy");
             delete profInfo.getTeamConfig().layerActive().properties.defaults.base;
+            // Since ProjectDir and HomeDir are the same (based on the ZOWE_CLI_HOME),
+            // we also need to delete the base profile from that layer (even though is't just a copy)
+            delete profInfo.getTeamConfig().findLayer(false, true).properties.defaults.base;
             const mergedArgs = profInfo.mergeArgsForProfile(profAttrs);
 
             const expectedArgs = [
@@ -595,6 +604,9 @@ describe("TeamConfig ProfileInfo tests", () => {
             profInfo.getTeamConfig().set("profiles.LPAR1.properties.base-path", fakeBasePath);
             const profAttrs = profInfo.getDefaultProfile("zosmf");
             delete profInfo.getTeamConfig().layerActive().properties.defaults.base;
+            // Since ProjectDir and HomeDir are the same (based on the ZOWE_CLI_HOME),
+            // we also need to delete the base profile from that layer (even though is't just a copy)
+            delete profInfo.getTeamConfig().findLayer(false, true).properties.defaults.base;
             const mergedArgs = profInfo.mergeArgsForProfile(profAttrs);
 
             const expectedArgs = [
@@ -657,6 +669,9 @@ describe("TeamConfig ProfileInfo tests", () => {
             await profInfo.readProfilesFromDisk();
             const profAttrs = profInfo.getDefaultProfile("zosmf");
             delete profInfo.getTeamConfig().layerActive().properties.defaults.base;
+            // Since ProjectDir and HomeDir are the same (based on the ZOWE_CLI_HOME),
+            // we also need to delete the base profile from that layer (even though is't just a copy)
+            delete profInfo.getTeamConfig().findLayer(false, true).properties.defaults.base;
             jest.spyOn(profInfo as any, "loadSchema").mockReturnValueOnce(profSchema);
             const mergedArgs = profInfo.mergeArgsForProfile(profAttrs);
 
@@ -698,6 +713,9 @@ describe("TeamConfig ProfileInfo tests", () => {
             await profInfo.readProfilesFromDisk();
             const profAttrs = profInfo.getDefaultProfile("zosmf");
             delete profInfo.getTeamConfig().layerActive().properties.defaults.base;
+            // Since ProjectDir and HomeDir are the same (based on the ZOWE_CLI_HOME),
+            // we also need to delete the base profile from that layer (even though is't just a copy)
+            delete profInfo.getTeamConfig().findLayer(false, true).properties.defaults.base;
             const mergedArgs = profInfo.mergeArgsForProfile(profAttrs);
 
             const expectedArgs = [
@@ -1110,12 +1128,15 @@ describe("TeamConfig ProfileInfo tests", () => {
             await profInfo.readProfilesFromDisk();
             const profAttrs = profInfo.getDefaultProfile("zosmf");
             const osLocInfo = profInfo.getOsLocInfo(profAttrs);
+            const expectedObjs = [
+                { name: profAttrs.profName, path: profAttrs.profLoc.osLoc[0], user: false, global: false },
+                { name: profAttrs.profName, path: profAttrs.profLoc.osLoc[0], user: false, global: true }
+            ];
             expect(osLocInfo).toBeDefined();
-            expect(osLocInfo.length).toBe(1);
-            expect(osLocInfo[0].name).toEqual(profAttrs.profName);
-            expect(osLocInfo[0].path).toEqual(profAttrs.profLoc.osLoc[0]);
-            expect(osLocInfo[0].user).toBe(false);
-            expect(osLocInfo[0].global).toBe(false);
+            expect(osLocInfo.length).toBe(expectedObjs.length);
+            expectedObjs.forEach((expectedOsLocInfo, idx) => {
+                expect(osLocInfo[idx]).toEqual(expectedOsLocInfo);
+            });
         });
 
         it("should return osLoc information for a profile name that exists in project and global config", async () => {

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -1243,7 +1243,7 @@ export class ProfileInfo {
         const layers = this.mLoadedConfig.layers;
         for (const layer of layers) {
             if (excludeHomeDir && layer.global) continue;
-            if (lodash.get(layer.properties, jsonPath) !== undefined) {
+            if (lodash.get(layer.properties, jsonPath) !== undefined && !files.includes(layer.path)) {
                 files.push(layer.path);
             }
         }
@@ -1297,7 +1297,7 @@ export class ProfileInfo {
         const foundInSecureArray = secFields.indexOf(buildPath(segments, opts.propName)) >= 0;
         const _isPropInLayer = (properties: IConfig) => {
             return properties && (lodash.get(properties, jsonPath) !== undefined ||
-            (foundInSecureArray && lodash.get(properties, jsonPath.split(`.properties.${opts.propName}`)[0]) !== undefined));
+                (foundInSecureArray && lodash.get(properties, jsonPath.split(`.properties.${opts.propName}`)[0]) !== undefined));
         };
 
         let filePath: string;

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -862,7 +862,7 @@ export class ProfileInfo {
      *        profiles.
      */
     public async readProfilesFromDisk(teamCfgOpts?: IConfigOpts) {
-        this.mLoadedConfig = await Config.load(this.mAppName, teamCfgOpts);
+        this.mLoadedConfig = await Config.load(this.mAppName, { ...{ homeDir: ImperativeConfig.instance.cliHome }, ...teamCfgOpts });
         if (ImperativeConfig.instance.config == null) { ImperativeConfig.instance.config = this.mLoadedConfig; }
         this.mUsingTeamConfig = this.mLoadedConfig.exists;
 

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -862,7 +862,7 @@ export class ProfileInfo {
      *        profiles.
      */
     public async readProfilesFromDisk(teamCfgOpts?: IConfigOpts) {
-        this.mLoadedConfig = await Config.load(this.mAppName, { ...{ homeDir: ImperativeConfig.instance.cliHome }, ...teamCfgOpts });
+        this.mLoadedConfig = await Config.load(this.mAppName, { homeDir: ImperativeConfig.instance.cliHome, ...teamCfgOpts });
         if (ImperativeConfig.instance.config == null) { ImperativeConfig.instance.config = this.mLoadedConfig; }
         this.mUsingTeamConfig = this.mLoadedConfig.exists;
 


### PR DESCRIPTION
By adding support for ENV variables, a few other issues were uncovered when `ZOWE_CLI_HOME` points to the same location as the project directory (`mHomeDir === mProjectDir`).
  - OsLoc information was getting duplicated in `.knownArgs`
  - `getOsLocInfo` duplicated layer information making it look like there were two of each layer available (`min: 4`, `max: 8`)
  - Tests that deleted `.properties.defaults.base` from the active layer, also needed to delete the global counterpart
    - There is a comment for each test that needed to be modified for this
  - Tests that relied on `getOsLocInfo` needed to be updated to account for the global copy of the layer

All issues mentioned above should be resolved in this PR 😋 

---

This PR is related to https://github.com/zowe/vscode-extension-for-zowe/issues/1777