### PR TITLE
Fix bugs in ProfileInfo API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `ProfileInfo.readProfilesFromDisk` failing when team config files and old-school profile directory do not exist.
+- BugFix: Fixed `ProfileInfo.updateProperty` not updating properties that are newly present after reloading team config.
+- BugFix: Fixed ProfileInfo API not detecting secure credential manager after profiles have been reloaded.
+- **Note:** If you are developing an SDK that uses the ProfileInfo API, use the method `ProfileInfo.getTeamConfig` instead of `ImperativeConfig.instance.config` which may contain outdated config or be undefined.
+
 ## `5.3.1`
 
 - BugFix: Fixed `config init` saving empty string values to config file when prompt was skipped.

--- a/packages/config/__tests__/ProfileCredentials.test.ts
+++ b/packages/config/__tests__/ProfileCredentials.test.ts
@@ -66,14 +66,14 @@ describe("ProfileCredentials tests", () => {
             expect(profCreds.isSecured).toBe(false);
         });
 
-        it("should be cached for subsequent calls", () => {
+        it("should not be cached for subsequent calls", () => {
             const profCreds = new ProfileCredentials({
-                usingTeamConfig: false
+                usingTeamConfig: true
             } as any);
-            jest.spyOn(profCreds as any, "isCredentialManagerInAppSettings").mockReturnValueOnce(false).mockReturnValueOnce(true);
+            jest.spyOn(profCreds as any, "isTeamConfigSecure").mockReturnValueOnce(false).mockReturnValueOnce(true);
             expect(profCreds.isSecured).toBe(false);
-            // expect a 2nd time to ensure value has not changed
-            expect(profCreds.isSecured).toBe(false);
+            // expect a 2nd time to ensure value has changed
+            expect(profCreds.isSecured).toBe(true);
         });
     });
 

--- a/packages/config/__tests__/ProfileInfo.OldProfiles.test.ts
+++ b/packages/config/__tests__/ProfileInfo.OldProfiles.test.ts
@@ -95,6 +95,15 @@ describe("Old-school ProfileInfo tests", () => {
             expect(warnSpy).toHaveBeenLastCalledWith("Found no old-school profiles.");
         });
 
+        it("should return null if profile root dir does not exist", async () => {
+            const invalidHomeDir = homeDirPath + "_does_not_exist";
+            process.env[testEnvPrefix + "_CLI_HOME"] = invalidHomeDir;
+            const profInfo = new ProfileInfo(testAppNm);
+            jest.spyOn((profInfo as any).mCredentials, "isSecured", "get").mockReturnValue(false);
+            await profInfo.readProfilesFromDisk();
+            expect(profInfo.getDefaultProfile("zosmf")).toBeNull();
+        });
+
         it("should return a profile if one exists", async () => {
             const profInfo = createNewProfInfo(homeDirPath);
             await profInfo.readProfilesFromDisk();

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -936,6 +936,7 @@ describe("TeamConfig ProfileInfo tests", () => {
             expect(ImperativeConfig.instance.loadedConfig.profiles).toEqual(profiles);
             expect(ImperativeConfig.instance.loadedConfig.baseProfile).toEqual(profiles[0]);
             expect(storageSpy).toHaveBeenCalledWith({
+                config: profInfo.getTeamConfig(),
                 defaultBaseProfileName: "base_glob",
                 sessCfg: { hostname: "test" },
                 propsToStore: ["host"],
@@ -963,6 +964,7 @@ describe("TeamConfig ProfileInfo tests", () => {
             expect(ImperativeConfig.instance.loadedConfig.profiles).toContain(profiles[0]);
             expect(ImperativeConfig.instance.loadedConfig.baseProfile).toBeDefined();
             expect(storageSpy).toHaveBeenCalledWith({
+                config: profInfo.getTeamConfig(),
                 defaultBaseProfileName: "base_glob",
                 sessCfg: { hostname: "test" },
                 propsToStore: ["host"],

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -74,7 +74,7 @@ export class ConfigAutoStore {
      * @returns Auth handler class or undefined if none was found
      */
     private static _findAuthHandlerForProfile(opts: IConfigAutoStoreFindAuthHandlerForProfileOpts): AbstractAuthHandler | undefined {
-        const config = ImperativeConfig.instance.config;
+        const config = opts.config || ImperativeConfig.instance.config;
         const profileType = lodash.get(config.properties, `${opts.profilePath}.type`);
         const profile = config.api.profiles.get(opts.profilePath.replace(/profiles\./g, ""), false);
 
@@ -128,7 +128,7 @@ export class ConfigAutoStore {
      * @param opts Set of options required to store session config properties
      */
     public static async _storeSessCfgProps(opts: IConfigAutoStoreStoreSessCfgPropsOpts): Promise<void> {
-        const config = ImperativeConfig.instance.config;
+        const config = opts.config || ImperativeConfig.instance.config;
         // TODO Which autoStore value should take priority if it conflicts between layers
         if (opts.propsToStore.length == 0 || !config?.exists || !config.properties.autoStore) {
             return;

--- a/packages/config/src/ProfileCredentials.ts
+++ b/packages/config/src/ProfileCredentials.ts
@@ -40,7 +40,7 @@ export class ProfileCredentials {
      * is not possible to reinitialize.
      */
     public async loadManager(): Promise<void> {
-        if (!this.mSecured) {
+        if (!(this.mSecured ?? this.isSecured)) {
             throw new ImperativeError({ msg: "Secure credential storage is not enabled" });
         }
 

--- a/packages/config/src/ProfileCredentials.ts
+++ b/packages/config/src/ProfileCredentials.ts
@@ -29,9 +29,7 @@ export class ProfileCredentials {
      * in the Imperative settings.json file.
      */
     public get isSecured(): boolean {
-        if (this.mSecured == null) {
-            this.mSecured = this.isTeamConfigSecure() || this.isCredentialManagerInAppSettings();
-        }
+        this.mSecured = this.isTeamConfigSecure() || this.isCredentialManagerInAppSettings();
         return this.mSecured;
     }
 
@@ -42,7 +40,7 @@ export class ProfileCredentials {
      * is not possible to reinitialize.
      */
     public async loadManager(): Promise<void> {
-        if (!this.isSecured) {
+        if (!this.mSecured) {
             throw new ImperativeError({ msg: "Secure credential storage is not enabled" });
         }
 

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -884,7 +884,8 @@ export class ProfileInfo {
             this.mOldSchoolProfileDefaults = {};
             // Try to get profiles and types
             this.mOldSchoolProfileRootDir = path.join(ImperativeConfig.instance.cliHome, "profiles");
-            const profTypes = ProfileIO.getAllProfileDirectories(this.mOldSchoolProfileRootDir);
+            const profTypes = fs.existsSync(this.mOldSchoolProfileRootDir) ?
+                ProfileIO.getAllProfileDirectories(this.mOldSchoolProfileRootDir) : [];
             // Iterate over the types
             for (const profType of profTypes) {
                 // Set up the profile manager and list of profile names

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -218,6 +218,7 @@ export class ProfileInfo {
                 }
 
                 await ConfigAutoStore._storeSessCfgProps({
+                    config: this.mLoadedConfig,
                     defaultBaseProfileName: this.mLoadedConfig?.properties.defaults.base,
                     sessCfg: {
                         [options.property === "host" ? "hostname" : options.property]: options.value
@@ -863,7 +864,6 @@ export class ProfileInfo {
      */
     public async readProfilesFromDisk(teamCfgOpts?: IConfigOpts) {
         this.mLoadedConfig = await Config.load(this.mAppName, { homeDir: ImperativeConfig.instance.cliHome, ...teamCfgOpts });
-        if (ImperativeConfig.instance.config == null) { ImperativeConfig.instance.config = this.mLoadedConfig; }
         this.mUsingTeamConfig = this.mLoadedConfig.exists;
 
         try {

--- a/packages/config/src/doc/IConfigAutoStoreOpts.ts
+++ b/packages/config/src/doc/IConfigAutoStoreOpts.ts
@@ -11,6 +11,7 @@
 
 import { ICommandArguments } from "../../../cmd/src/doc/args/ICommandArguments";
 import { IHandlerParameters } from "../../../cmd/src/doc/handler/IHandlerParameters";
+import { Config } from "../Config";
 
 /**
  * Defines the options used by the ConfigAutoStore._findActiveProfile function
@@ -59,6 +60,12 @@ export interface IConfigAutoStoreFindAuthHandlerForProfileOpts extends IConfigAu
      * Used if cmdArguments == null
      */
     defaultBaseProfileName?: string;
+
+    /**
+     * Team configuration properties
+     * Overrides `ImperativeConfig.instance.config`
+     */
+    config?: Config;
 }
 
 /**


### PR DESCRIPTION
Fixes a few bugs identified in the ProfileInfo API when using it in a VS Code extension.

It should be possible to call `ProfileInfo.readProfilesFromDisk` repeatedly in a VSCE with the following results:
* In an environment where no team config files exist and the `~/.zowe/profiles` directory does not exist, it should not fail.
* If team config files did not exist before, but another application created them, the config layers should be repopulated.
* If secure properties did not exist in team config before, but another application created them, they should be loaded.