### PR TITLE
Fix line endings not always being normalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,8 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- BugFix: Added ANSI escape codes trimming for the Web Help. [#704](https://github.com/zowe/imperative/issues/704)
 - BugFix: Fixed `AbstractRestClient` not converting LF line endings to CRLF for every line when downloading large files on Windows. [zowe/zowe-cli#1458](https://github.com/zowe/zowe-cli/issues/1458)
-
-## `5.3.3`
-
-- Enhancement: Added ANSI escape codes trimming for the Web Help.
 
 ## `5.3.3`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `AbstractRestClient` not converting LF line endings to CRLF for every line when downloading large files on Windows. [zowe/zowe-cli#1458](https://github.com/zowe/zowe-cli/issues/1458)
+
 ## `5.3.3`
 
 - Expose the isSecured functionality from the ProfilesCredentials [#549](https://github.com/zowe/imperative/issues/549)

--- a/packages/io/__tests__/IO.test.ts
+++ b/packages/io/__tests__/IO.test.ts
@@ -278,6 +278,20 @@ describe("IO tests", () => {
         expect(fnFm).toHaveBeenCalledTimes(Math.ceil(willBeADir.length / 2));
     });
 
+    it("processNewLines should replace LF line endings with CRLF on Windows", () => {
+        jest.spyOn(os, "platform").mockReturnValueOnce(IO.OS_WIN32);
+        const original = "\nabc\ndef\n";
+        const processed = IO.processNewlines(original);
+        expect(processed).toBe(original.replace(/\n/g, "\r\n"));
+    });
+
+    it("processNewLines should not replace LF line ending when last byte is CR", () => {
+        jest.spyOn(os, "platform").mockReturnValueOnce(IO.OS_WIN32);
+        const original = "\nabc\ndef\n";
+        const processed = IO.processNewlines(original, "\r".charCodeAt(0));
+        expect(processed).toBe(original.replace(/\n/g, "\r\n").slice(1));
+    });
+
     it("should get an error for no input on mkdirp", () => {
         let error;
         try {

--- a/packages/io/src/IO.ts
+++ b/packages/io/src/IO.ts
@@ -259,16 +259,21 @@ export class IO {
      * (basically, if the user is on Windows, change  \n to \r\n)
      * @static
      * @param {string} original - original input
+     * @param {number} lastByte - last byte of previous input, if it is being processed in chunks
      * @returns {string} - input with removed newlines
      * @memberof IO
      */
-    public static processNewlines(original: string): string {
+    public static processNewlines(original: string, lastByte?: number): string {
         ImperativeExpect.toNotBeNullOrUndefined(original, "Required parameter 'original' must not be null or undefined");
         if (os.platform() !== IO.OS_WIN32) {
             return original;
         }
         // otherwise, we're on windows
-        return original.replace(/([^\r])\n/g, "$1\r\n");
+        const processed = original.replace(/([^\r])\n/g, "$1\r\n");
+        if (lastByte != null && lastByte !== "\r".charCodeAt(0) && original.startsWith("\n")) {
+            return "\r" + processed;
+        }
+        return processed;
     }
 
     /**

--- a/packages/io/src/IO.ts
+++ b/packages/io/src/IO.ts
@@ -270,7 +270,7 @@ export class IO {
         }
         // otherwise, we're on windows
         const processed = original.replace(/([^\r])\n/g, "$1\r\n");
-        if (lastByte != null && lastByte !== "\r".charCodeAt(0) && original.startsWith("\n")) {
+        if ((lastByte == null || lastByte !== "\r".charCodeAt(0)) && original.startsWith("\n")) {
             return "\r" + processed;
         }
         return processed;

--- a/packages/rest/src/client/AbstractRestClient.ts
+++ b/packages/rest/src/client/AbstractRestClient.ts
@@ -214,6 +214,14 @@ export abstract class AbstractRestClient {
     protected mDecode: boolean = true;
 
     /**
+     * Last byte received when response is being streamed
+     * @private
+     * @type {number}
+     * @memberof AbstractRestClient
+     */
+    protected lastByteReceived: number = 0;
+
+    /**
      * Creates an instance of AbstractRestClient.
      * @param {AbstractSession} mSession - representing connection to this api
      * @memberof AbstractRestClient
@@ -604,7 +612,7 @@ export abstract class AbstractRestClient {
             this.log.debug("Streaming data chunk of length " + respData.length + " to response stream");
             if (this.mNormalizeResponseNewlines && this.mContentEncoding == null) {
                 this.log.debug("Normalizing new lines in data chunk to operating system appropriate line endings");
-                respData = Buffer.from(IO.processNewlines(respData.toString()));
+                respData = Buffer.from(IO.processNewlines(respData.toString(), this.lastByteReceived));
             }
             if (this.mTask != null) {
                 // update the progress task if provided by the requester
@@ -625,6 +633,7 @@ export abstract class AbstractRestClient {
             }
             // write the chunk to the response stream if requested
             this.mResponseStream.write(respData);
+            this.lastByteReceived = respData[respData.byteLength - 1];
         }
     }
 

--- a/packages/rest/src/client/CompressionUtils.ts
+++ b/packages/rest/src/client/CompressionUtils.ts
@@ -62,13 +62,7 @@ export class CompressionUtils {
 
             // Second transform is optional and processes line endings
             if (normalizeNewLines) {
-                const transformSnd = new Transform({
-                    transform(chunk, _, callback) {
-                        this.push(Buffer.from(IO.processNewlines(chunk.toString())));
-                        callback();
-                    }
-                });
-                transforms.push(transformSnd);
+                transforms.push(this.newLinesTransform());
             }
 
             // Chain transforms and response stream together
@@ -98,6 +92,17 @@ export class CompressionUtils {
             msg: `Failed to decompress response ${source} with content encoding type ${encoding}`,
             additionalDetails: err.message,
             causeErrors: err
+        });
+    }
+
+    private static newLinesTransform(): Transform {
+        let lastByte: number = 0;
+        return new Transform({
+            transform(chunk, _, callback) {
+                this.push(Buffer.from(IO.processNewlines(chunk.toString(), lastByte)));
+                lastByte = chunk[chunk.byteLength - 1];
+                callback();
+            }
         });
     }
 

--- a/packages/rest/src/client/CompressionUtils.ts
+++ b/packages/rest/src/client/CompressionUtils.ts
@@ -95,12 +95,15 @@ export class CompressionUtils {
         });
     }
 
+    /**
+     * Return a transform to normalize line endings in response text.
+     */
     private static newLinesTransform(): Transform {
-        let lastByte: number = 0;
+        let lastByteReceived: number = 0;
         return new Transform({
             transform(chunk, _, callback) {
-                this.push(Buffer.from(IO.processNewlines(chunk.toString(), lastByte)));
-                lastByte = chunk[chunk.byteLength - 1];
+                this.push(Buffer.from(IO.processNewlines(chunk.toString(), lastByteReceived)));
+                lastByteReceived = chunk[chunk.byteLength - 1];
                 callback();
             }
         });


### PR DESCRIPTION
Fixes a bug in Imperative that caused zowe/zowe-cli#1458

This PR changes the default behavior of `IO.processNewlines` (when `lastByte` is null) to replace `\n` at the beginning of a string with `\r\n` on Windows. IMO this is a bug fix, not a breaking change.