### PR TITLE
Add SonarCloud scan to GHA for Ubuntu + Node LTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
-## Recent Changes
+## `5.3.5`
 
 - BugFix: Fixed `DefaultHelpGenerator` unable to find module "ansi-colors" when Imperative is imported.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zowe/imperative",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zowe/imperative",
-      "version": "5.3.4",
+      "version": "5.3.5",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/lodash-deep": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/imperative",
-  "version": "5.3.4",
+  "version": "5.3.5",
   "description": "framework for building configurable CLIs",
   "author": "Zowe",
   "license": "EPL-2.0",


### PR DESCRIPTION
Run the SonarCloud scan manually in our workflow, instead of having it automatically triggered by webhooks, so that the scan includes coverage information.