### PR TITLE
Fix DefaultHelpGenerator requiring a dev dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `DefaultHelpGenerator` unable to find module "ansi-colors" when Imperative is imported.
+
 ## `5.3.4`
 
 - BugFix: Added ANSI escape codes trimming for the Web Help. [#704](https://github.com/zowe/imperative/issues/704)

--- a/packages/cmd/__tests__/help/DefaultHelpGenerator.test.ts
+++ b/packages/cmd/__tests__/help/DefaultHelpGenerator.test.ts
@@ -566,6 +566,17 @@ describe("Default Help Generator", () => {
                 { commandDefinition: COMMAND_WITH_MARKDOWN_SPECIAL_CHRACTERS, fullCommandTree: fakeParent });
             expect(helpGen.buildDescriptionSection()).toMatchSnapshot();
         });
+
+        it("should remove ANSI escape codes from the help text", async () => {
+            const result = (DefaultHelpGenerator.prototype as any).escapeMarkdown(
+                `Specifies whether to verify that the objects to be created do not exist\
+ on the Db2 subsystem and that the related objects that are required for successful creation\
+ of the objects exist on the Db2 subsystem or in the input DDL.
+ \n \u001b[90m Default value: no \u001b[0m`
+            );
+
+            expect(result).toMatchSnapshot();
+        });
     });
 
     describe("deprecated commands", () => {
@@ -596,17 +607,6 @@ describe("Default Help Generator", () => {
 
             // jest's weird way of testing that a string does not contain a specific string
             expect(summary).toEqual(expect.not.stringContaining("not-deprecated-command | ndc Our non-deprecated command. (deprecated)"));
-        });
-
-        it("should removing ANSI escape codes from the help text", async () => {
-            const result = (DefaultHelpGenerator.prototype as any).escapeMarkdown(
-                `Specifies whether to verify that the objects to be created do not exist\
- on the Db2 subsystem and that the related objects that are required for successful creation\
- of the objects exist on the Db2 subsystem or in the input DDL.
- \n \u001b[90m Default value: no \u001b[0m`
-            );
-
-            expect(result).toMatchSnapshot();
         });
     });
 });

--- a/packages/cmd/__tests__/help/__snapshots__/DefaultHelpGenerator.test.ts.snap
+++ b/packages/cmd/__tests__/help/__snapshots__/DefaultHelpGenerator.test.ts.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Default Help Generator deprecated commands should removing ANSI escape codes from the help text 1`] = `
-"Specifies whether to verify that the objects to be created do not exist on the Db2 subsystem and that the related objects that are required for successful creation of the objects exist on the Db2 subsystem or in the input DDL\\\\.
- 
-  Default value: no "
-`;
-
 exports[`Default Help Generator error handling should detect an invalid command definition type 1`] = `"Help Generator Error: Unknown command definition type specified: \\"fake\\""`;
 
 exports[`Default Help Generator help text builder buildCommandAndAliases test 1`] = `"hello"`;
@@ -427,4 +421,10 @@ exports[`Default Help Generator help text builder should getCommandHelpText with
  --------------
 
 "
+`;
+
+exports[`Default Help Generator help text builder should remove ANSI escape codes from the help text 1`] = `
+"Specifies whether to verify that the objects to be created do not exist on the Db2 subsystem and that the related objects that are required for successful creation of the objects exist on the Db2 subsystem or in the input DDL\\\\.
+ 
+  Default value: no "
 `;

--- a/packages/cmd/src/help/DefaultHelpGenerator.ts
+++ b/packages/cmd/src/help/DefaultHelpGenerator.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { format, isNullOrUndefined } from "util";
+import { format } from "util";
 import { AbstractHelpGenerator } from "./abstract/AbstractHelpGenerator";
 import { TextUtils } from "../../../utilities";
 import { Constants } from "../../../constants";
@@ -18,7 +18,7 @@ import { ImperativeError } from "../../../error";
 import { IHelpGeneratorParms } from "./doc/IHelpGeneratorParms";
 import { IHelpGeneratorFactoryParms } from "./doc/IHelpGeneratorFactoryParms";
 import { compareCommands, ICommandDefinition } from "../../src/doc/ICommandDefinition";
-import { ansiRegex } from "ansi-colors";
+import stripAnsi = require("strip-ansi");
 
 /**
  * Imperative default help generator. Accepts the command definitions and constructs
@@ -130,7 +130,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         let helpText = "";
 
         // Construct the command name section.
-        if (!this.mProduceMarkdown && !isNullOrUndefined(this.mCommandDefinition.name) &&
+        if (!this.mProduceMarkdown && this.mCommandDefinition.name != null &&
             this.mCommandDefinition.name.length > 0) {
             helpText += "\n" + this.buildHeader("COMMAND NAME");
             helpText += (DefaultHelpGenerator.HELP_INDENT + this.mCommandDefinition.name);
@@ -153,7 +153,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         helpText += this.buildUsageSection();
 
         // Add positional arguments to the help text
-        if (!isNullOrUndefined(this.mCommandDefinition.positionals) &&
+        if (this.mCommandDefinition.positionals != null &&
             this.mCommandDefinition.positionals.length > 0) {
             helpText += this.buildPositionalArgumentsSection();
         }
@@ -268,7 +268,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         // For a command, build the usage diagram with positional and options.
         if (this.mCommandDefinition.type === "command") {
             // Place the positional parameters.
-            if (!isNullOrUndefined(this.mCommandDefinition.positionals)) {
+            if (this.mCommandDefinition.positionals != null) {
                 for (const positional of this.mCommandDefinition.positionals) {
                     usage += " " + ((positional.required) ? "<" + positional.name + ">" : "[" + positional.name + "]");
                 }
@@ -278,7 +278,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
         } else if (this.mCommandDefinition.type === "group") {
             // Determine what command section we are currently at and append the correct usages.
             usage = usage.trim();
-            if (!isNullOrUndefined(this.mCommandDefinition.children) && this.mCommandDefinition.children.length > 0) {
+            if (this.mCommandDefinition.children != null && this.mCommandDefinition.children.length > 0) {
                 // Get all the possible command types. (E.G <group>, <command>, <command|group>, ETC)
                 let nextType = "<";
 
@@ -332,7 +332,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
      */
     public buildGlobalOptionsSection(): string {
         let result = this.buildHeader(Constants.GLOBAL_GROUP);
-        if (!isNullOrUndefined(this.groupToOption[Constants.GLOBAL_GROUP])) {
+        if (this.groupToOption[Constants.GLOBAL_GROUP] != null) {
             for (const globalOption of this.groupToOption[Constants.GLOBAL_GROUP]) {
                 result += this.buildOptionText(globalOption, this.optionToDescription[globalOption]);
             }
@@ -385,7 +385,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
      * @memberof DefaultHelpGenerator
      */
     public buildPositionalArgumentsSection(): string {
-        if (!isNullOrUndefined(this.mCommandDefinition.positionals) && this.mCommandDefinition.positionals.length > 0) {
+        if (this.mCommandDefinition.positionals != null && this.mCommandDefinition.positionals.length > 0) {
             let positionalsHelpText: string = this.buildHeader("Positional Arguments");
             for (const positional of this.mCommandDefinition.positionals) {
                 const positionalString = "{{codeBegin}}" +
@@ -497,7 +497,7 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
      */
     public buildExamplesSection(): string {
         let examplesText = "";
-        if (!isNullOrUndefined(this.mCommandDefinition.examples)) {
+        if (this.mCommandDefinition.examples != null) {
             examplesText = this.mCommandDefinition.examples.map((example) => {
                 const prefix = example.prefix != null ? example.prefix + "{{space}} " : "";
                 const exampleHyphen = this.mProduceMarkdown ? "" : "-";
@@ -553,7 +553,6 @@ export class DefaultHelpGenerator extends AbstractHelpGenerator {
      * @return {string} - The escaped string
      */
     private escapeMarkdown(text: string): string {
-        text = text.replace(ansiRegex, "");
-        return text.replace(/([*#\-`_[\]+.!\\])/g, "\\$1");
+        return stripAnsi(text).replace(/([*#\-`_[\]+.!\\])/g, "\\$1");
     }
 }


### PR DESCRIPTION
Fixes a bug introduced in #836, which requires a dev dep (`ansi-colors`) in the DefaultHelpGenerator.

Tests passed locally and in CI because the dev dep was present in `node_modules`, but it is missing when only prod deps are installed.

This PR resolves the issue by replacing the use of `ansi-colors` with `strip-ansi`, which is already a prod dep and should have the same behavior.