### PR TITLE
Fix error when installing plugin that does not define profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed error when installing plug-ins that do not define profiles. [#859](https://github.com/zowe/imperative/issues/859)
+
 ## `5.3.6`
 
 - BugFix: Removed some extraneous dependencies. [#477](https://github.com/zowe/imperative/issues/477)

--- a/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
+++ b/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
@@ -1706,6 +1706,7 @@ describe("Plugin Management Facility", () => {
             PMF.currPluginName = "PluginWithConfigModule";
 
             const moduleContent = PMF.requirePluginModuleCallback(PMF.currPluginName)(modulePath);
+            expect(moduleContent).toEqual({});
             const issue = pluginIssues.getIssueListForPlugin(PMF.currPluginName)[0];
             expect(issue.issueSev).toBe(IssueSeverity.CMD_ERROR);
             expect(issue.issueText).toContain(

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -364,7 +364,7 @@ export class PluginManagementFacility {
                     pluginName + "' :\n" + pluginModuleRuntimePath + "\n" +
                     "Reason = " + requireError.message
                 );
-                return "{}";
+                return {};
             }
         };
     }

--- a/packages/imperative/src/plugins/utilities/npm-interface/install.ts
+++ b/packages/imperative/src/plugins/utilities/npm-interface/install.ts
@@ -134,9 +134,11 @@ export async function install(packageLocation: string, registry: string, install
             // Update the Imperative Configuration to add the profiles introduced by the recently installed plugin
             // This might be needed outside of PLUGIN_USING_CONFIG scenarios, but we haven't had issues with other APIs before
             const requirerFunction = PluginManagementFacility.instance.requirePluginModuleCallback(packageInfo.name);
-            UpdateImpConfig.addProfiles(ConfigurationLoader.load(null, packageInfo, requirerFunction).profiles);
-
-            ConfigSchema.updateSchema({ layer: "global" });
+            const pluginImpConfig = ConfigurationLoader.load(null, packageInfo, requirerFunction);
+            if (Array.isArray(pluginImpConfig.profiles)) {
+                UpdateImpConfig.addProfiles(pluginImpConfig.profiles);
+                ConfigSchema.updateSchema({ layer: "global" });
+            }
         }
 
         iConsole.info("Plugin '" + packageName + "' successfully installed.");


### PR DESCRIPTION
Fixes #859 which prevented users from installing plug-ins like `@zowe/zos-make-for-zowe-cli` and `@zowe/tasks-for-zowe-cli` which do not define new profile types in their configuration.

Also fixes an error where if global config exists and a plug-in is installed with an Imperative config that fails to load, install failed  with a cryptic error (`Cannot create property 'name' on string '{}'`) instead of reporting plug-in validation errors.