### PR TITLE
Introduced examples for setting default profiles in Examples section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Introduced examples for setting default profiles in `zowe config set` Examples section. [#1428](https://github.com/zowe/zowe-cli/issues/1428)
+
 ## `5.3.6`
 
 - BugFix: Removed some extraneous dependencies. [#477](https://github.com/zowe/imperative/issues/477)

--- a/packages/imperative/src/config/cmd/set/set.definition.ts
+++ b/packages/imperative/src/config/cmd/set/set.definition.ts
@@ -75,6 +75,14 @@ export const setDefinition: ICommandDefinition = {
         {
             description: "Store the property value",
             options: `"profiles.host1.profiles.service1.properties.setting" "value" --secure`
+        },
+        {
+            description: "Set a default zosmf profile",
+            options: `"defaults.zosmf" "zosmfProfileName"`
+        },
+        {
+            description: "Set a default tso profile",
+            options: `"defaults.tso" "tsoProfileName"`
         }
     ]
 };

--- a/packages/imperative/src/config/cmd/set/set.definition.ts
+++ b/packages/imperative/src/config/cmd/set/set.definition.ts
@@ -22,7 +22,6 @@ export const setDefinition: ICommandDefinition = {
         {
             name: "property",
             description: "The property to set. You may specify a path using dot notation (e.g. profiles.host1.profiles.service1.properties.setting)",
-            required: true,
             type: "string"
         },
         {

--- a/packages/imperative/src/config/cmd/set/set.definition.ts
+++ b/packages/imperative/src/config/cmd/set/set.definition.ts
@@ -22,6 +22,7 @@ export const setDefinition: ICommandDefinition = {
         {
             name: "property",
             description: "The property to set. You may specify a path using dot notation (e.g. profiles.host1.profiles.service1.properties.setting)",
+            required: true,
             type: "string"
         },
         {


### PR DESCRIPTION
Included examples for setting default profiles in zowe config set.

Linked to [#1428](https://github.com/zowe/zowe-cli/issues/1428)