### PR TITLE
fix: added web-diff template directory in files section of package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Web-diff template directory included in files section of package.json file.
+
 ## `5.4.1`
 
 - BugFix: Changed the default log level of `Console` class from "debug" to "warn". In Zowe v2 the `Logger` class was changed to have a default log level of "warn" but we missed updating the `Console` class to make it behave consistently. If you want a different log level, you can change it after initializing the console like this: `console.level = "info";` [zowe/zowe-cli#511](https://github.com/zowe/zowe-cli/issues/511)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "files": [
     "lib",
-    "web-help/dist"
+    "web-help/dist",
+    "web-diff"
   ],
   "publishConfig": {
     "registry": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"


### PR DESCRIPTION
Added web-diff template dir to the files sections of package.json to include the files in the registry package. in order to fix the error defined here: https://github.com/zowe/zowe-cli/pull/1460#issuecomment-1215161336


Signed-off-by: sarthakjdev <jsarthak448@gmail.com>