### PR TITLE
Improve performance of ProfileInfo API to load large team config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Improved performance of ProfileInfo API to load large team config files. [zowe/vscode-extension-for-zowe#1911](https://github.com/zowe/vscode-extension-for-zowe/issues/1911)
+
 ## `5.4.1`
 
 - BugFix: Changed the default log level of `Console` class from "debug" to "warn". In Zowe v2 the `Logger` class was changed to have a default log level of "warn" but we missed updating the `Console` class to make it behave consistently. If you want a different log level, you can change it after initializing the console like this: `console.level = "info";` [zowe/zowe-cli#511](https://github.com/zowe/zowe-cli/issues/511)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "@zowe/perf-timing": "1.0.7",
         "chalk": "2.4.2",
         "cli-table3": "0.6.2",
-        "comment-json": "4.1.0",
+        "comment-json": "4.1.1",
         "dataobject-parser": "1.2.1",
         "deepmerge": "4.2.2",
-        "diff": "^5.1.0",
-        "diff2html": "^3.4.17",
+        "diff": "5.1.0",
+        "diff2html": "3.4.17",
         "fast-glob": "3.2.7",
         "fastest-levenshtein": "1.0.12",
         "find-up": "4.1.0",
@@ -47,6 +47,7 @@
         "yargs": "15.3.1"
       },
       "devDependencies": {
+        "@types/comment-json": "^2.4.2",
         "@types/diff": "^5.0.2",
         "@types/find-up": "^2.1.1",
         "@types/fs-extra": "^8.0.1",
@@ -2820,6 +2821,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/comment-json": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/comment-json/-/comment-json-2.4.2.tgz",
+      "integrity": "sha512-El8na9x7/3M4KxXvOL34fbXbQtBgETELT89HNL8qK2RTlFpBOjlOSbXp1boODiocSnxWXXLW2WeH3DGazyKkVA==",
+      "deprecated": "This is a stub types definition. comment-json provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "comment-json": "*"
+      }
+    },
     "node_modules/@types/dateformat": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
@@ -5110,7 +5121,7 @@
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -5246,9 +5257,9 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.0.tgz",
-      "integrity": "sha512-WEghmVYaNq9NlWbrkzQTSsya9ycLyxJxpTQfZEan6a5Jomnjw18zS3Podf8q1Zf9BvonvQd/+Z7Z39L7KKzzdQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
+      "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
       "dependencies": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.2",
@@ -22489,6 +22500,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/comment-json": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/comment-json/-/comment-json-2.4.2.tgz",
+      "integrity": "sha512-El8na9x7/3M4KxXvOL34fbXbQtBgETELT89HNL8qK2RTlFpBOjlOSbXp1boODiocSnxWXXLW2WeH3DGazyKkVA==",
+      "dev": true,
+      "requires": {
+        "comment-json": "*"
+      }
+    },
     "@types/dateformat": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
@@ -24297,7 +24317,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "dev": true
     },
     "clone-buffer": {
@@ -24402,9 +24422,9 @@
       "dev": true
     },
     "comment-json": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.0.tgz",
-      "integrity": "sha512-WEghmVYaNq9NlWbrkzQTSsya9ycLyxJxpTQfZEan6a5Jomnjw18zS3Podf8q1Zf9BvonvQd/+Z7Z39L7KKzzdQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.1.1.tgz",
+      "integrity": "sha512-v8gmtPvxhBlhdRBLwdHSjGy9BgA23t9H1FctdQKyUrErPjSrJcdDMqBq9B4Irtm7w3TNYLQJNH6ARKnpyag1sA==",
       "requires": {
         "array-timsort": "^1.0.3",
         "core-util-is": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@zowe/perf-timing": "1.0.7",
     "chalk": "2.4.2",
     "cli-table3": "0.6.2",
-    "comment-json": "4.1.0",
+    "comment-json": "4.1.1",
     "dataobject-parser": "1.2.1",
     "deepmerge": "4.2.2",
     "diff": "5.1.0",
@@ -89,6 +89,7 @@
     "yargs": "15.3.1"
   },
   "devDependencies": {
+    "@types/comment-json": "^2.4.2",
     "@types/diff": "^5.0.2",
     "@types/find-up": "^2.1.1",
     "@types/fs-extra": "^8.0.1",

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -46,6 +46,7 @@ describe("TeamConfig ProfileInfo tests", () => {
     const teamProjDir = path.join(testDir, testAppNm + "_team_config_proj");
     const userTeamProjDir = path.join(testDir, testAppNm + "_user_and_team_config_proj");
     const teamHomeProjDir = path.join(testDir, testAppNm + "_home_team_config_proj");
+    const largeTeamProjDir = path.join(testDir, testAppNm + "_large_team_config_proj");
     let origDir: string;
 
     const envHost = testEnvPrefix + "_OPT_HOST";
@@ -1045,7 +1046,7 @@ describe("TeamConfig ProfileInfo tests", () => {
             // Mock autoStore false
             jest.spyOn(profInfo, "getTeamConfig").mockReturnValueOnce({
                 ...profInfo.getTeamConfig(),
-                properties: { ...profInfo.getTeamConfig().layerMerge(false), autoStore: false }
+                mProperties: { ...profInfo.getTeamConfig().mProperties, autoStore: false }
             } as any);
             const ret = await profInfo.updateKnownProperty({ mergedArgs: prof, property: "host", value: "example.com" });
             const newHost = profInfo.getTeamConfig().api.layers.get().properties.profiles.LPAR4.properties.host;
@@ -1160,5 +1161,17 @@ describe("TeamConfig ProfileInfo tests", () => {
             expect(osLocInfo[1].path).toBe(path.join(teamHomeProjDir, testAppNm + ".config.json"));
             expect(osLocInfo[1].name).toBe(conflictingProfile);
         });
+    });
+
+    it("should load 256 profiles in under ten seconds", async () => {
+        const profInfo = createNewProfInfo(largeTeamProjDir);
+        const startTime = Date.now();
+        await profInfo.readProfilesFromDisk();
+        const zosmfProfiles = profInfo.getAllProfiles("zosmf", { excludeHomeDir: true });
+        expect(zosmfProfiles.length).toBe(256);
+        for (const profAttrs of zosmfProfiles) {
+            profInfo.mergeArgsForProfile(profAttrs);
+        }
+        expect(Date.now() - startTime).toBeLessThan(10000);
     });
 });

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -1163,7 +1163,7 @@ describe("TeamConfig ProfileInfo tests", () => {
         });
     });
 
-    it("should load 256 profiles in under ten seconds", async () => {
+    it("should load 256 profiles in under 15 seconds", async () => {
         const profInfo = createNewProfInfo(largeTeamProjDir);
         const startTime = Date.now();
         await profInfo.readProfilesFromDisk();
@@ -1172,6 +1172,6 @@ describe("TeamConfig ProfileInfo tests", () => {
         for (const profAttrs of zosmfProfiles) {
             profInfo.mergeArgsForProfile(profAttrs);
         }
-        expect(Date.now() - startTime).toBeLessThan(10000);
+        expect(Date.now() - startTime).toBeLessThan(15000);
     });
 });

--- a/packages/config/__tests__/__resources__/ProfInfoApp_large_team_config_proj/ProfInfoApp.config.json
+++ b/packages/config/__tests__/__resources__/ProfInfoApp_large_team_config_proj/ProfInfoApp.config.json
@@ -1,0 +1,1557 @@
+{
+    "$schema": "../ProfInfoApp_team_config_proj/ProfInfoApp.schema.json",
+    "profiles": {
+        "base": {
+            "type": "base",
+            "properties": {
+                "host": "example.com",
+                "rejectUnauthorized": true
+            },
+            "secure": [
+                "user",
+                "password"
+            ]
+        },
+        "zosmf_000": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1000
+            }
+        },
+        "zosmf_001": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1001
+            }
+        },
+        "zosmf_002": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1002
+            }
+        },
+        "zosmf_003": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1003
+            }
+        },
+        "zosmf_004": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1004
+            }
+        },
+        "zosmf_005": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1005
+            }
+        },
+        "zosmf_006": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1006
+            }
+        },
+        "zosmf_007": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1007
+            }
+        },
+        "zosmf_008": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1008
+            }
+        },
+        "zosmf_009": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1009
+            }
+        },
+        "zosmf_010": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1010
+            }
+        },
+        "zosmf_011": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1011
+            }
+        },
+        "zosmf_012": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1012
+            }
+        },
+        "zosmf_013": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1013
+            }
+        },
+        "zosmf_014": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1014
+            }
+        },
+        "zosmf_015": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1015
+            }
+        },
+        "zosmf_016": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1016
+            }
+        },
+        "zosmf_017": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1017
+            }
+        },
+        "zosmf_018": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1018
+            }
+        },
+        "zosmf_019": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1019
+            }
+        },
+        "zosmf_020": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1020
+            }
+        },
+        "zosmf_021": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1021
+            }
+        },
+        "zosmf_022": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1022
+            }
+        },
+        "zosmf_023": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1023
+            }
+        },
+        "zosmf_024": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1024
+            }
+        },
+        "zosmf_025": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1025
+            }
+        },
+        "zosmf_026": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1026
+            }
+        },
+        "zosmf_027": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1027
+            }
+        },
+        "zosmf_028": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1028
+            }
+        },
+        "zosmf_029": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1029
+            }
+        },
+        "zosmf_030": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1030
+            }
+        },
+        "zosmf_031": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1031
+            }
+        },
+        "zosmf_032": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1032
+            }
+        },
+        "zosmf_033": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1033
+            }
+        },
+        "zosmf_034": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1034
+            }
+        },
+        "zosmf_035": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1035
+            }
+        },
+        "zosmf_036": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1036
+            }
+        },
+        "zosmf_037": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1037
+            }
+        },
+        "zosmf_038": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1038
+            }
+        },
+        "zosmf_039": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1039
+            }
+        },
+        "zosmf_040": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1040
+            }
+        },
+        "zosmf_041": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1041
+            }
+        },
+        "zosmf_042": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1042
+            }
+        },
+        "zosmf_043": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1043
+            }
+        },
+        "zosmf_044": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1044
+            }
+        },
+        "zosmf_045": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1045
+            }
+        },
+        "zosmf_046": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1046
+            }
+        },
+        "zosmf_047": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1047
+            }
+        },
+        "zosmf_048": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1048
+            }
+        },
+        "zosmf_049": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1049
+            }
+        },
+        "zosmf_050": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1050
+            }
+        },
+        "zosmf_051": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1051
+            }
+        },
+        "zosmf_052": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1052
+            }
+        },
+        "zosmf_053": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1053
+            }
+        },
+        "zosmf_054": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1054
+            }
+        },
+        "zosmf_055": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1055
+            }
+        },
+        "zosmf_056": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1056
+            }
+        },
+        "zosmf_057": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1057
+            }
+        },
+        "zosmf_058": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1058
+            }
+        },
+        "zosmf_059": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1059
+            }
+        },
+        "zosmf_060": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1060
+            }
+        },
+        "zosmf_061": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1061
+            }
+        },
+        "zosmf_062": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1062
+            }
+        },
+        "zosmf_063": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1063
+            }
+        },
+        "zosmf_064": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1064
+            }
+        },
+        "zosmf_065": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1065
+            }
+        },
+        "zosmf_066": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1066
+            }
+        },
+        "zosmf_067": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1067
+            }
+        },
+        "zosmf_068": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1068
+            }
+        },
+        "zosmf_069": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1069
+            }
+        },
+        "zosmf_070": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1070
+            }
+        },
+        "zosmf_071": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1071
+            }
+        },
+        "zosmf_072": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1072
+            }
+        },
+        "zosmf_073": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1073
+            }
+        },
+        "zosmf_074": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1074
+            }
+        },
+        "zosmf_075": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1075
+            }
+        },
+        "zosmf_076": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1076
+            }
+        },
+        "zosmf_077": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1077
+            }
+        },
+        "zosmf_078": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1078
+            }
+        },
+        "zosmf_079": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1079
+            }
+        },
+        "zosmf_080": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1080
+            }
+        },
+        "zosmf_081": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1081
+            }
+        },
+        "zosmf_082": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1082
+            }
+        },
+        "zosmf_083": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1083
+            }
+        },
+        "zosmf_084": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1084
+            }
+        },
+        "zosmf_085": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1085
+            }
+        },
+        "zosmf_086": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1086
+            }
+        },
+        "zosmf_087": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1087
+            }
+        },
+        "zosmf_088": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1088
+            }
+        },
+        "zosmf_089": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1089
+            }
+        },
+        "zosmf_090": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1090
+            }
+        },
+        "zosmf_091": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1091
+            }
+        },
+        "zosmf_092": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1092
+            }
+        },
+        "zosmf_093": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1093
+            }
+        },
+        "zosmf_094": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1094
+            }
+        },
+        "zosmf_095": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1095
+            }
+        },
+        "zosmf_096": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1096
+            }
+        },
+        "zosmf_097": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1097
+            }
+        },
+        "zosmf_098": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1098
+            }
+        },
+        "zosmf_099": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1099
+            }
+        },
+        "zosmf_100": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1100
+            }
+        },
+        "zosmf_101": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1101
+            }
+        },
+        "zosmf_102": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1102
+            }
+        },
+        "zosmf_103": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1103
+            }
+        },
+        "zosmf_104": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1104
+            }
+        },
+        "zosmf_105": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1105
+            }
+        },
+        "zosmf_106": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1106
+            }
+        },
+        "zosmf_107": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1107
+            }
+        },
+        "zosmf_108": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1108
+            }
+        },
+        "zosmf_109": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1109
+            }
+        },
+        "zosmf_110": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1110
+            }
+        },
+        "zosmf_111": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1111
+            }
+        },
+        "zosmf_112": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1112
+            }
+        },
+        "zosmf_113": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1113
+            }
+        },
+        "zosmf_114": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1114
+            }
+        },
+        "zosmf_115": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1115
+            }
+        },
+        "zosmf_116": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1116
+            }
+        },
+        "zosmf_117": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1117
+            }
+        },
+        "zosmf_118": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1118
+            }
+        },
+        "zosmf_119": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1119
+            }
+        },
+        "zosmf_120": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1120
+            }
+        },
+        "zosmf_121": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1121
+            }
+        },
+        "zosmf_122": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1122
+            }
+        },
+        "zosmf_123": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1123
+            }
+        },
+        "zosmf_124": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1124
+            }
+        },
+        "zosmf_125": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1125
+            }
+        },
+        "zosmf_126": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1126
+            }
+        },
+        "zosmf_127": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1127
+            }
+        },
+        "zosmf_128": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1128
+            }
+        },
+        "zosmf_129": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1129
+            }
+        },
+        "zosmf_130": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1130
+            }
+        },
+        "zosmf_131": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1131
+            }
+        },
+        "zosmf_132": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1132
+            }
+        },
+        "zosmf_133": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1133
+            }
+        },
+        "zosmf_134": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1134
+            }
+        },
+        "zosmf_135": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1135
+            }
+        },
+        "zosmf_136": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1136
+            }
+        },
+        "zosmf_137": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1137
+            }
+        },
+        "zosmf_138": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1138
+            }
+        },
+        "zosmf_139": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1139
+            }
+        },
+        "zosmf_140": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1140
+            }
+        },
+        "zosmf_141": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1141
+            }
+        },
+        "zosmf_142": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1142
+            }
+        },
+        "zosmf_143": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1143
+            }
+        },
+        "zosmf_144": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1144
+            }
+        },
+        "zosmf_145": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1145
+            }
+        },
+        "zosmf_146": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1146
+            }
+        },
+        "zosmf_147": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1147
+            }
+        },
+        "zosmf_148": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1148
+            }
+        },
+        "zosmf_149": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1149
+            }
+        },
+        "zosmf_150": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1150
+            }
+        },
+        "zosmf_151": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1151
+            }
+        },
+        "zosmf_152": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1152
+            }
+        },
+        "zosmf_153": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1153
+            }
+        },
+        "zosmf_154": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1154
+            }
+        },
+        "zosmf_155": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1155
+            }
+        },
+        "zosmf_156": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1156
+            }
+        },
+        "zosmf_157": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1157
+            }
+        },
+        "zosmf_158": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1158
+            }
+        },
+        "zosmf_159": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1159
+            }
+        },
+        "zosmf_160": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1160
+            }
+        },
+        "zosmf_161": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1161
+            }
+        },
+        "zosmf_162": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1162
+            }
+        },
+        "zosmf_163": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1163
+            }
+        },
+        "zosmf_164": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1164
+            }
+        },
+        "zosmf_165": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1165
+            }
+        },
+        "zosmf_166": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1166
+            }
+        },
+        "zosmf_167": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1167
+            }
+        },
+        "zosmf_168": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1168
+            }
+        },
+        "zosmf_169": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1169
+            }
+        },
+        "zosmf_170": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1170
+            }
+        },
+        "zosmf_171": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1171
+            }
+        },
+        "zosmf_172": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1172
+            }
+        },
+        "zosmf_173": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1173
+            }
+        },
+        "zosmf_174": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1174
+            }
+        },
+        "zosmf_175": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1175
+            }
+        },
+        "zosmf_176": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1176
+            }
+        },
+        "zosmf_177": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1177
+            }
+        },
+        "zosmf_178": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1178
+            }
+        },
+        "zosmf_179": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1179
+            }
+        },
+        "zosmf_180": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1180
+            }
+        },
+        "zosmf_181": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1181
+            }
+        },
+        "zosmf_182": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1182
+            }
+        },
+        "zosmf_183": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1183
+            }
+        },
+        "zosmf_184": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1184
+            }
+        },
+        "zosmf_185": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1185
+            }
+        },
+        "zosmf_186": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1186
+            }
+        },
+        "zosmf_187": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1187
+            }
+        },
+        "zosmf_188": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1188
+            }
+        },
+        "zosmf_189": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1189
+            }
+        },
+        "zosmf_190": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1190
+            }
+        },
+        "zosmf_191": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1191
+            }
+        },
+        "zosmf_192": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1192
+            }
+        },
+        "zosmf_193": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1193
+            }
+        },
+        "zosmf_194": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1194
+            }
+        },
+        "zosmf_195": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1195
+            }
+        },
+        "zosmf_196": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1196
+            }
+        },
+        "zosmf_197": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1197
+            }
+        },
+        "zosmf_198": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1198
+            }
+        },
+        "zosmf_199": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1199
+            }
+        },
+        "zosmf_200": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1200
+            }
+        },
+        "zosmf_201": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1201
+            }
+        },
+        "zosmf_202": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1202
+            }
+        },
+        "zosmf_203": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1203
+            }
+        },
+        "zosmf_204": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1204
+            }
+        },
+        "zosmf_205": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1205
+            }
+        },
+        "zosmf_206": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1206
+            }
+        },
+        "zosmf_207": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1207
+            }
+        },
+        "zosmf_208": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1208
+            }
+        },
+        "zosmf_209": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1209
+            }
+        },
+        "zosmf_210": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1210
+            }
+        },
+        "zosmf_211": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1211
+            }
+        },
+        "zosmf_212": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1212
+            }
+        },
+        "zosmf_213": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1213
+            }
+        },
+        "zosmf_214": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1214
+            }
+        },
+        "zosmf_215": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1215
+            }
+        },
+        "zosmf_216": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1216
+            }
+        },
+        "zosmf_217": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1217
+            }
+        },
+        "zosmf_218": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1218
+            }
+        },
+        "zosmf_219": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1219
+            }
+        },
+        "zosmf_220": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1220
+            }
+        },
+        "zosmf_221": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1221
+            }
+        },
+        "zosmf_222": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1222
+            }
+        },
+        "zosmf_223": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1223
+            }
+        },
+        "zosmf_224": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1224
+            }
+        },
+        "zosmf_225": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1225
+            }
+        },
+        "zosmf_226": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1226
+            }
+        },
+        "zosmf_227": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1227
+            }
+        },
+        "zosmf_228": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1228
+            }
+        },
+        "zosmf_229": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1229
+            }
+        },
+        "zosmf_230": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1230
+            }
+        },
+        "zosmf_231": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1231
+            }
+        },
+        "zosmf_232": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1232
+            }
+        },
+        "zosmf_233": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1233
+            }
+        },
+        "zosmf_234": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1234
+            }
+        },
+        "zosmf_235": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1235
+            }
+        },
+        "zosmf_236": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1236
+            }
+        },
+        "zosmf_237": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1237
+            }
+        },
+        "zosmf_238": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1238
+            }
+        },
+        "zosmf_239": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1239
+            }
+        },
+        "zosmf_240": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1240
+            }
+        },
+        "zosmf_241": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1241
+            }
+        },
+        "zosmf_242": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1242
+            }
+        },
+        "zosmf_243": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1243
+            }
+        },
+        "zosmf_244": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1244
+            }
+        },
+        "zosmf_245": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1245
+            }
+        },
+        "zosmf_246": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1246
+            }
+        },
+        "zosmf_247": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1247
+            }
+        },
+        "zosmf_248": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1248
+            }
+        },
+        "zosmf_249": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1249
+            }
+        },
+        "zosmf_250": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1250
+            }
+        },
+        "zosmf_251": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1251
+            }
+        },
+        "zosmf_252": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1252
+            }
+        },
+        "zosmf_253": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1253
+            }
+        },
+        "zosmf_254": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1254
+            }
+        },
+        "zosmf_255": {
+            "type": "zosmf",
+            "properties": {
+                "port": 1255
+            }
+        }
+    },
+    "defaults": {
+        "base": "base",
+        "zosmf": "zosmf_000"
+    },
+    "autoStore": true
+}

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -219,7 +219,7 @@ export class ProfileInfo {
 
                 await ConfigAutoStore._storeSessCfgProps({
                     config: this.mLoadedConfig,
-                    defaultBaseProfileName: this.mLoadedConfig?.properties.defaults.base,
+                    defaultBaseProfileName: this.mLoadedConfig?.mProperties.defaults.base,
                     sessCfg: {
                         [options.property === "host" ? "hostname" : options.property]: options.value
                     },
@@ -250,7 +250,7 @@ export class ProfileInfo {
         const toUpdate = options.mergedArgs.knownArgs.find((v => v.argName === options.property)) ||
             options.mergedArgs.missingArgs.find((v => v.argName === options.property));
 
-        if (toUpdate == null || (toUpdate.argLoc.locType === ProfLocType.TEAM_CONFIG && !this.getTeamConfig().properties.autoStore)) {
+        if (toUpdate == null || (toUpdate.argLoc.locType === ProfLocType.TEAM_CONFIG && !this.getTeamConfig().mProperties.autoStore)) {
             return false;
         }
 
@@ -329,7 +329,7 @@ export class ProfileInfo {
 
         // Do we have team config profiles?
         if (this.mUsingTeamConfig) {
-            const teamConfigProfs = this.mLoadedConfig.layerMerge(true, options?.excludeHomeDir).profiles;
+            const teamConfigProfs = this.mLoadedConfig.layerMerge({ maskSecure: true, excludeGlobalLayer: options?.excludeHomeDir }).profiles;
             // Iterate over them
             for (const prof in teamConfigProfs) {
                 // Check if the profile has a type
@@ -404,7 +404,8 @@ export class ProfileInfo {
 
         if (this.usingTeamConfig) {
             // get default profile name from the team config
-            if (!Object.prototype.hasOwnProperty.call(this.mLoadedConfig.maskedProperties.defaults, profileType)) {
+            const configProperties = this.mLoadedConfig.mProperties;
+            if (!Object.prototype.hasOwnProperty.call(configProperties.defaults, profileType)) {
                 // no default exists for the requested type
                 this.mImpLogger.warn("Found no profile of type '" +
                     profileType + "' in team config."
@@ -413,7 +414,7 @@ export class ProfileInfo {
             }
 
             // extract info from the underlying team config
-            const foundProfNm = this.mLoadedConfig.maskedProperties.defaults[profileType];
+            const foundProfNm = configProperties.defaults[profileType];
 
             // for a team config, we use the last node of the jsonLoc as the name
             const foundJson = this.mLoadedConfig.api.profiles.expandPath(foundProfNm);
@@ -572,14 +573,16 @@ export class ProfileInfo {
             knownArgs: [],
             missingArgs: []
         };
+        let configProperties: IConfig;
 
         const osLocInfo = this.getOsLocInfo(profile)?.[0];
         if (profile.profLoc.locType === ProfLocType.TEAM_CONFIG) {
+            configProperties = this.mLoadedConfig.mProperties;
             if (profile.profName != null) {
                 // Load args from service profile if one exists
                 const serviceProfile = this.mLoadedConfig.api.profiles.get(profile.profName, false);
                 for (const [propName, propVal] of Object.entries(serviceProfile)) {
-                    const [argLoc, secure] = this.argTeamConfigLoc({ profileName: profile.profName, propName, osLocInfo });
+                    const [argLoc, secure] = this.argTeamConfigLoc({ profileName: profile.profName, propName, osLocInfo, configProperties });
                     mergedArgs.knownArgs.push({
                         argName: CliUtils.getOptionFormat(propName).camelCase,
                         dataType: this.argDataType(typeof propVal),  // TODO Is using `typeof` bad for "null" values that may be int or bool?
@@ -602,13 +605,13 @@ export class ProfileInfo {
             }
             if (baseProfile != null) {
                 // Load args from default base profile if one exists
-                const baseProfileName = realBaseProfileName ?? this.mLoadedConfig.properties.defaults.base;
+                const baseProfileName = realBaseProfileName ?? configProperties.defaults.base;
                 for (const [propName, propVal] of Object.entries(baseProfile)) {
                     const argName = CliUtils.getOptionFormat(propName).camelCase;
                     // Skip properties already loaded from service profile
                     if (!mergedArgs.knownArgs.find((arg) => arg.argName === argName)) {
                         const [argLoc, secure] = this.argTeamConfigLoc({
-                            profileName: baseProfileName, propName, osLocInfo, configProperties: layerProperties
+                            profileName: baseProfileName, propName, osLocInfo, configProperties: layerProperties ?? configProperties
                         });
                         mergedArgs.knownArgs.push({
                             argName,
@@ -684,13 +687,16 @@ export class ProfileInfo {
                     if (profile.profLoc.locType === ProfLocType.TEAM_CONFIG) {
                         let [argLoc, foundInSecureArray]: [IProfLoc, boolean] = [null, false];
                         try {
-                            [argLoc, foundInSecureArray] = this.argTeamConfigLoc({ profileName: profile.profName, propName, osLocInfo });
+                            [argLoc, foundInSecureArray] = this.argTeamConfigLoc({
+                                profileName: profile.profName,
+                                propName, osLocInfo, configProperties
+                            });
                             argFound = true;
                         } catch (_argNotFoundInServiceProfile) {
-                            if (this.mLoadedConfig.api.profiles.defaultGet("base")) {
+                            if (configProperties.defaults.base != null) {
                                 try {
                                     [argLoc, foundInSecureArray] = this.argTeamConfigLoc({
-                                        profileName: this.mLoadedConfig.properties.defaults.base, propName, osLocInfo
+                                        profileName: configProperties.defaults.base, propName, osLocInfo, configProperties
                                     });
                                     argFound = true;
                                 } catch (_argNotFoundInBaseProfile) {
@@ -947,7 +953,7 @@ export class ProfileInfo {
         if (profile.profLoc.locType === ProfLocType.TEAM_CONFIG) {
             const ret: IProfLocOsLoc[] = [];
             for (const loc of osLoc) {
-                for (const layer of this.mLoadedConfig.layers) {
+                for (const layer of this.mLoadedConfig.mLayers) {
                     if (layer.path === loc) {
                         // we found the config layer matching osLoc
                         ret.push({ name: profile.profName, path: loc, user: layer.user, global: layer.global });
@@ -969,7 +975,7 @@ export class ProfileInfo {
         switch (arg.argLoc.locType) {
             case ProfLocType.TEAM_CONFIG:
                 if (arg.argLoc.osLoc?.length > 0 && arg.argLoc.jsonLoc != null) {
-                    for (const layer of this.mLoadedConfig.layers) {
+                    for (const layer of this.mLoadedConfig.mLayers) {
                         if (layer.path === arg.argLoc.osLoc[0]) {
                             // we found the config layer matching arg.osLoc
                             argValue = lodash.get(layer.properties, arg.argLoc.jsonLoc);
@@ -1109,7 +1115,7 @@ export class ProfileInfo {
         if (this.mUsingTeamConfig) {
             // Load profile schemas for all layers
             let lastSchema: { path: string, json: any } = { path: null, json: null };
-            for (const layer of this.getTeamConfig().layers) {
+            for (const layer of this.getTeamConfig().mLayers) {
                 if (layer.properties.$schema == null) continue;
                 const schemaUri = new url.URL(layer.properties.$schema, url.pathToFileURL(layer.path));
                 if (schemaUri.protocol !== "file:") {
@@ -1225,16 +1231,17 @@ export class ProfileInfo {
      *          and a boolean false if the profile is not a default profile
      */
     private isDefaultTeamProfile(path: string, profileType?: string): boolean {
+        const configProperties = this.mLoadedConfig.mProperties;
 
         // Is it defined for a particular profile type?
         if (profileType) {
-            if (this.mLoadedConfig.maskedProperties.defaults[profileType] === path) return true;
+            if (configProperties.defaults[profileType] === path) return true;
             else return false;
         }
 
         // Iterate over defaults to see if it's a default profile
-        for (const def in this.mLoadedConfig.maskedProperties.defaults) {
-            if (this.mLoadedConfig.maskedProperties.defaults[def] === path) {
+        for (const def in configProperties.defaults) {
+            if (configProperties.defaults[def] === path) {
                 return true;
             }
         }
@@ -1250,7 +1257,7 @@ export class ProfileInfo {
      */
     private findTeamOsLocation(jsonPath: string, excludeHomeDir?: boolean): string[] {
         const files: string[] = [];
-        const layers = this.mLoadedConfig.layers;
+        const layers = this.mLoadedConfig.mLayers;
         for (const layer of layers) {
             if (excludeHomeDir && layer.global) continue;
             if (lodash.get(layer.properties, jsonPath) !== undefined && !files.includes(layer.path)) {
@@ -1291,7 +1298,7 @@ export class ProfileInfo {
         const secFields = this.getTeamConfig().api.secure.secureFields(osLocInfo);
         const buildPath = (ps: string[], p: string) => `${ps.join(".profiles.")}.properties.${p}`;
         while (segments.length > 0 &&
-            lodash.get(opts.configProperties ?? this.mLoadedConfig.properties, buildPath(segments, opts.propName)) === undefined &&
+            lodash.get(opts.configProperties ?? this.mLoadedConfig.mProperties, buildPath(segments, opts.propName)) === undefined &&
             secFields.indexOf(buildPath(segments, opts.propName)) === -1) {
             // Drop segment from end of path if property not found
             segments.pop();
@@ -1314,7 +1321,7 @@ export class ProfileInfo {
         if (_isPropInLayer(opts.configProperties) && opts.osLocInfo) {
             filePath = opts.osLocInfo.path;
         } else {
-            for (const layer of this.mLoadedConfig.layers) {
+            for (const layer of this.mLoadedConfig.mLayers) {
                 // Find the first layer that includes the JSON path
                 if (_isPropInLayer(layer.properties)) {
                     filePath = layer.path;
@@ -1367,7 +1374,7 @@ export class ProfileInfo {
                 schemaMapKey = `${profile.profLoc.osLoc[0]}:${profile.profType}`;
             } else {
                 // no profile exists, so loop through layers and use the first schema found
-                for (const layer of this.mLoadedConfig.layers) {
+                for (const layer of this.mLoadedConfig.mLayers) {
                     const tempKey = `${layer.path}:${profile.profType}`;
                     if (this.mProfileSchemaCache.has(tempKey)) {
                         schemaMapKey = tempKey;

--- a/packages/config/src/api/ConfigProfiles.ts
+++ b/packages/config/src/api/ConfigProfiles.ts
@@ -55,7 +55,7 @@ export class ConfigProfiles extends ConfigApi {
     public get(path: string, mustExist?: boolean): { [key: string]: string } {
         if (mustExist !== false && !this.exists(path))
             return null;
-        return this.buildProfile(path, JSONC.parse(JSONC.stringify(this.mConfig.properties.profiles, null, ConfigConstants.INDENT)));
+        return JSONC.parse(JSONC.stringify(this.buildProfile(path, this.mConfig.mProperties.profiles), null, ConfigConstants.INDENT));
     }
 
     // _______________________________________________________________________
@@ -67,7 +67,7 @@ export class ConfigProfiles extends ConfigApi {
      * @returns True if a profile exists. False otherwise.
      */
     public exists(path: string): boolean {
-        return (this.findProfile(path, this.mConfig.properties.profiles) != null);
+        return (this.findProfile(path, this.mConfig.mProperties.profiles) != null);
     }
 
     // _______________________________________________________________________
@@ -93,7 +93,7 @@ export class ConfigProfiles extends ConfigApi {
      *          for example {"host": "lpar.your.domain.net", port: 1234}
      */
     public defaultGet(profileType: string): { [key: string]: string } {
-        const dflt = this.mConfig.properties.defaults[profileType];
+        const dflt = this.mConfig.mProperties.defaults[profileType];
         return dflt != null ? this.get(dflt) : null;
     }
 

--- a/packages/config/src/doc/IConfigMergeOpts.ts
+++ b/packages/config/src/doc/IConfigMergeOpts.ts
@@ -1,0 +1,31 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+export interface IConfigMergeOpts {
+    /**
+     * Indicates whether we should mask off secure properties.
+     * @defaultValue `false`
+     */
+    maskSecure?: boolean;
+
+    /**
+     * Indicates whether we should exclude global layers.
+     * @defaultValue `false`
+     */
+    excludeGlobalLayer?: boolean;
+
+    /**
+     * Indicates whether we should clone layers to prevent accidental edits.
+     * If maskSecure is true, then it is implied that cloneLayers is true.
+     * @defaultValue `true`
+     */
+    cloneLayers?: boolean;
+}


### PR DESCRIPTION
Related to zowe/vscode-extension-for-zowe#1911

**Performance Comparison**
| ProfileInfo method | Time Before (ms) | Time After (ms) |
| --- | --- | --- |
| readProfilesFromDisk | 61.0 | 44.2 |
| getDefaultProfile | 49.9 | 4.8 |
| mergeArgsForProfile | 203.4 | 12.8 |

The most significant improvement is in `mergeArgsForProfile`, since some apps like Zowe Explorer call it for every profile in the team config. The time to merge args for 100 z/OSMF profiles used to be around 20s and has been reduced by over 10x.

**Summary of Changes**
* Refactors the Config and ProfileInfo APIs so that they clone JSONC objects as little as possible. I discovered that cloning a JSONC object with `JSONC.parse(JSONC.stringify(obj))` is very slow, so it should be done sparingly except when needed to prevent accidental edits to the original object.
* Changes the parameters on some internal methods. I don't believe this is a breaking change any more than it would be for private methods, since we compile with the `stripInternal` flag. This means internal methods are only accessible by other Imperative modules and are hidden from the type definitions we publish.
* Updates the `comment-json` dependency to include a fix I made over a year ago related to comments getting lost when stringifying arrays: https://github.com/kaelzhang/node-comment-json/pull/31. The PR was merged quickly but we forgot to update to the version with the fix.
* Adds a unit test to ensure the ProfileInfo API stays reasonably performant in the future. The test fails if it takes longer than 15s to load 256 profiles. It takes under 10s on my local machine and around 12s on some GitHub Actions runners. As long as this test passes, we should be able to load 1000 profiles per minute.