### PR TITLE
Revert Node lockdown in workflows

### DIFF
--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 0
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -13,9 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Temporary workaround for regression in npm@8.11 and newer
-        # node-version: [14.x, 16.x, 18.x]
-        node-version: [14.x, 16.15.0, 18.2.0]
+        node-version: [14.x, 16.x, 18.x]
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     env:

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -33,9 +33,10 @@ jobs:
         fetch-depth: 0
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
+        check-latest: true
 
     - name: Install Dependencies
       run: npm ci

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -1165,8 +1165,8 @@ describe("TeamConfig ProfileInfo tests", () => {
 
     it("should load 256 profiles in under 15 seconds", async () => {
         const profInfo = createNewProfInfo(largeTeamProjDir);
-        const startTime = Date.now();
         await profInfo.readProfilesFromDisk();
+        const startTime = Date.now();
         const zosmfProfiles = profInfo.getAllProfiles("zosmf", { excludeHomeDir: true });
         expect(zosmfProfiles.length).toBe(256);
         for (const profAttrs of zosmfProfiles) {


### PR DESCRIPTION
⚠️ Do not merge until all builds pass. It seems that Ubuntu runners are still using Node 16.16 which doesn't include the fix.

Revert Node.js version lockdown now that the npm@8.11 bug has been fixed.

Also don't time the reading of profiles from disk in unit test. Since I/O performance may vary across GHA runners, this test was occasionally failing.