### PR TITLE
Add environment variable to override plugins dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
+- Enhancement: Added ZOWE_CLI_PLUGINS_DIR environment variable to override location where plugins are installed. [zowe/zowe-cli#1483](https://github.com/zowe/zowe-cli/issues/1483)
 - BugFix: Fixed exception when non-string passed to ImperativeExpect.toBeDefinedAndNonBlank(). [#856](https://github.com/zowe/imperative/issues/856)
 
 ## `5.4.3`

--- a/__tests__/__integration__/imperative/__tests__/__integration__/api/env/__snapshots__/EnvironmentalVariableSettings.integration.test.ts.snap
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/api/env/__snapshots__/EnvironmentalVariableSettings.integration.test.ts.snap
@@ -18,6 +18,10 @@ Object {
     "key": "IMP_INTEGRATION_TESTING_APP_MASK_OUTPUT",
     "value": "TRUE",
   },
+  "pluginsDir": Object {
+    "key": "IMP_INTEGRATION_TESTING_CLI_PLUGINS_DIR",
+    "value": undefined,
+  },
   "promptPhrase": Object {
     "key": "IMP_INTEGRATION_TESTING_PROMPT_PHRASE",
     "value": undefined,

--- a/packages/imperative/__tests__/env/EnvironmentalVariableSettings.test.ts
+++ b/packages/imperative/__tests__/env/EnvironmentalVariableSettings.test.ts
@@ -30,6 +30,7 @@ describe("EnvironmentalVariableSettings tests", () => {
             cliHome: getSetting(prefix + EnvironmentalVariableSettings.CLI_HOME_SUFFIX),
             promptPhrase: getSetting(prefix + EnvironmentalVariableSettings.PROMPT_PHRASE_SUFFIX),
             maskOutput: getSetting(prefix + EnvironmentalVariableSettings.APP_MASK_OUTPUT_SUFFIX, Constants.DEFAULT_MASK_OUTPUT),
+            pluginsDir: getSetting(prefix + EnvironmentalVariableSettings.CLI_PLUGINS_DIR_SUFFIX)
         };
     };
 
@@ -102,6 +103,7 @@ describe("EnvironmentalVariableSettings tests", () => {
             expect(envSettings.cliHome.value).toBeUndefined();
             expect(envSettings.promptPhrase.value).toBeUndefined();
             expect(envSettings.maskOutput.value).toEqual(Constants.DEFAULT_MASK_OUTPUT);
+            expect(envSettings.pluginsDir.value).toBeUndefined();
             expect(envSettings).toEqual(getEnvSettings(prefix));
         });
 
@@ -118,6 +120,7 @@ describe("EnvironmentalVariableSettings tests", () => {
             expect(envSettings.cliHome.value).toBeUndefined();
             expect(envSettings.promptPhrase.value).toBeUndefined();
             expect(envSettings.maskOutput.value).toEqual(maskLogLevel);
+            expect(envSettings.pluginsDir.value).toBeUndefined();
             expect(envSettings).toEqual(getEnvSettings(prefix));
         });
     });

--- a/packages/imperative/__tests__/plugins/utilities/PMFConstants.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/PMFConstants.test.ts
@@ -13,12 +13,12 @@ jest.mock("path");
 jest.mock("../../../../logger/src/Logger");
 jest.mock("../../../../utilities/src/ImperativeConfig");
 
-import { EnvironmentalVariableSettings } from "../../..";
 import Mock = jest.Mock;
 
 describe("PMFConstants", () => {
     let {PMFConstants} = require("../../../src/plugins/utilities/PMFConstants");
     let {ImperativeConfig} = require("../../../../utilities/src/ImperativeConfig");
+    let {EnvironmentalVariableSettings} = require("../../../src/env/EnvironmentalVariableSettings");
     let {join} = require("path");
 
     const cliInstallDir = "installed";
@@ -30,6 +30,7 @@ describe("PMFConstants", () => {
         jest.resetModules();
         ({PMFConstants} = await import("../../../src/plugins/utilities/PMFConstants"));
         ({ImperativeConfig} = await import("../../../../utilities/src/ImperativeConfig"));
+        ({EnvironmentalVariableSettings} = await import("../../../src/env/EnvironmentalVariableSettings"));
         ({join} = await import("path"));
 
         mocks.join = join;
@@ -39,7 +40,9 @@ describe("PMFConstants", () => {
         const pmfRoot = `${ImperativeConfig.instance.cliHome}/plugins`;
         const pluginJson = `${pmfRoot}/plugins.json`;
 
-        jest.spyOn(EnvironmentalVariableSettings, "read").mockReturnValueOnce({} as any);
+        jest.spyOn(EnvironmentalVariableSettings, "read").mockReturnValueOnce({
+            pluginsDir: {}
+        } as any);
         mocks.join.mockReturnValueOnce(pmfRoot)
             .mockReturnValueOnce(pluginJson)
             .mockReturnValueOnce(cliInstallDir);
@@ -54,15 +57,13 @@ describe("PMFConstants", () => {
     });
 
     it("should initialize properly with custom plugins dir", () => {
-        const pluginsDir = "/tmp/zowe";
-        const pmfRoot = `${pluginsDir}/plugins`;
+        const pmfRoot = "/tmp/zowe-plugins";
         const pluginJson = `${pmfRoot}/plugins.json`;
 
         jest.spyOn(EnvironmentalVariableSettings, "read").mockReturnValueOnce({
-            pluginsDir: { value: pluginsDir }
+            pluginsDir: { value: pmfRoot }
         } as any);
-        mocks.join.mockReturnValueOnce(pmfRoot)
-            .mockReturnValueOnce(pluginJson)
+        mocks.join.mockReturnValueOnce(pluginJson)
             .mockReturnValueOnce(cliInstallDir);
 
         const pmf = PMFConstants.instance;

--- a/packages/imperative/src/doc/IImperativeEnvironmentalVariableSettings.ts
+++ b/packages/imperative/src/doc/IImperativeEnvironmentalVariableSettings.ts
@@ -47,4 +47,10 @@ export interface IImperativeEnvironmentalVariableSettings {
      * @type {IImperativeEnvironmentalVariableSetting}
      */
     maskOutput?: IImperativeEnvironmentalVariableSetting;
+
+    /**
+     * The directory where CLI plugins are installed.
+     * Default is `${cliHome}/plugins`.
+     */
+    pluginsDir?: IImperativeEnvironmentalVariableSetting;
 }

--- a/packages/imperative/src/env/EnvironmentalVariableSettings.ts
+++ b/packages/imperative/src/env/EnvironmentalVariableSettings.ts
@@ -61,6 +61,14 @@ export class EnvironmentalVariableSettings {
      */
     public static readonly PROMPT_PHRASE_SUFFIX = "_PROMPT_PHRASE";
 
+    /**
+     * The end of the environmental variable for configuring the plugins directory for your CLI
+     * The prefix will be added to the beginning of this value to contruct the full key
+     * @type {string}
+     * @memberof EnvironmentalVariableSettings
+     */
+    public static readonly CLI_PLUGINS_DIR_SUFFIX = "_CLI_PLUGINS_DIR";
+
 
     /**
      * Read all environmental variable settings for a CLI
@@ -88,6 +96,8 @@ export class EnvironmentalVariableSettings {
                 getSetting(prefix + this.PROMPT_PHRASE_SUFFIX),
             maskOutput:
                 getSetting(prefix + this.APP_MASK_OUTPUT_SUFFIX, Constants.DEFAULT_MASK_OUTPUT),
+            pluginsDir:
+                getSetting(prefix + this.CLI_PLUGINS_DIR_SUFFIX)
         };
     }
 }

--- a/packages/imperative/src/plugins/utilities/PMFConstants.ts
+++ b/packages/imperative/src/plugins/utilities/PMFConstants.ts
@@ -12,6 +12,7 @@
 import { ImperativeConfig } from "../../../../utilities";
 import { dirname, join } from "path";
 import { Config } from "../../../../config";
+import { EnvironmentalVariableSettings } from "../../env/EnvironmentalVariableSettings";
 
 /**
  * Constants used by the PMF.
@@ -111,7 +112,8 @@ export class PMFConstants {
         this.NPM_NAMESPACE = "@zowe";
         this.CLI_CORE_PKG_NAME = ImperativeConfig.instance.hostPackageName;
         this.IMPERATIVE_PKG_NAME = ImperativeConfig.instance.imperativePackageName;
-        this.PMF_ROOT = join(ImperativeConfig.instance.cliHome, "plugins");
+        const envPluginsDir = EnvironmentalVariableSettings.read(ImperativeConfig.instance.envVariablePrefix).pluginsDir.value;
+        this.PMF_ROOT = envPluginsDir || join(ImperativeConfig.instance.cliHome, "plugins");
         this.PLUGIN_JSON = join(this.PMF_ROOT, "plugins.json");
         this.PLUGIN_USING_CONFIG = ImperativeConfig.instance.config?.exists;
         this.PLUGIN_INSTALL_LOCATION = join(this.PMF_ROOT, "installed");


### PR DESCRIPTION
This is the Imperative part of the enhancement requested in https://github.com/zowe/zowe-cli/issues/1483