### PR TITLE
Prevent secure properties lookup on a global-layer base profile that doesn't exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Prevented base profile secure-property lookup on the global layer when there is not default base profile. [#881](https://github.com/zowe/imperative/issues/881)
+
 ## `5.5.0`
 
 - Enhancement: Added ZOWE_CLI_PLUGINS_DIR environment variable to override location where plugins are installed. [zowe/zowe-cli#1483](https://github.com/zowe/zowe-cli/issues/1483)

--- a/packages/config/__tests__/__resources__/ProfInfoApp_nested_team_config_proj/ProfInfoApp.config.json
+++ b/packages/config/__tests__/__resources__/ProfInfoApp_nested_team_config_proj/ProfInfoApp.config.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "./ProfInfoApp.schema.json",
+    "profiles": {
+        "TEST001": {
+            "properties": {
+                "host": "TEST001.your.domain.net",
+                "rejectUnauthorized": true
+            },
+            "secure": ["user", "password"],
+            "profiles": {
+                "first": {
+                    "type": "zosmf",
+                    "properties": {
+                        "port": 443
+                    }
+                }
+            }
+        }
+    },
+    "defaults": {
+        "zosmf": "TEST001.first"
+    },
+    "autoStore": true
+}

--- a/packages/config/__tests__/__resources__/ProfInfoApp_nested_team_config_proj/ProfInfoApp.schema.json
+++ b/packages/config/__tests__/__resources__/ProfInfoApp_nested_team_config_proj/ProfInfoApp.schema.json
@@ -1,0 +1,210 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$version": "1.0",
+    "type": "object",
+    "description": "Zowe configuration",
+    "properties": {
+        "profiles": {
+            "type": "object",
+            "description": "Mapping of profile names to profile configurations",
+            "patternProperties": {
+                "^\\S*$": {
+                    "type": "object",
+                    "description": "Profile configuration object",
+                    "properties": {
+                        "type": {
+                            "description": "Profile type",
+                            "type": "string",
+                            "enum": [
+                                "zosmf",
+                                "base"
+                            ]
+                        },
+                        "properties": {
+                            "description": "Profile properties object",
+                            "type": "object"
+                        },
+                        "profiles": {
+                            "description": "Optional subprofile configurations",
+                            "type": "object",
+                            "$ref": "#/properties/profiles"
+                        },
+                        "secure": {
+                            "description": "Secure property names",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "uniqueItems": true
+                        }
+                    },
+                    "allOf": [
+                        {
+                            "if": {
+                                "properties": {
+                                    "type": false
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "properties": {
+                                        "title": "Missing profile type"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "type": {
+                                        "const": "zosmf"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "properties": {
+                                        "type": "object",
+                                        "title": "z/OSMF Profile",
+                                        "description": "z/OSMF Profile",
+                                        "properties": {
+                                            "host": {
+                                                "type": "string",
+                                                "description": "The z/OSMF server host name."
+                                            },
+                                            "port": {
+                                                "type": "number",
+                                                "description": "The z/OSMF server port.",
+                                                "default": 443
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "Mainframe (z/OSMF) user name, which can be the same as your TSO login."
+                                            },
+                                            "password": {
+                                                "type": "string",
+                                                "description": "Mainframe (z/OSMF) password, which can be the same as your TSO password."
+                                            },
+                                            "rejectUnauthorized": {
+                                                "type": "boolean",
+                                                "description": "Reject self-signed certificates.",
+                                                "default": true
+                                            },
+                                            "basePath": {
+                                                "type": "string",
+                                                "description": "The base path for your API mediation layer instance. Specify this option to prepend the base path to all z/OSMF resources when making REST requests. Do not specify this option if you are not using an API mediation layer."
+                                            },
+                                            "protocol": {
+                                                "type": "string",
+                                                "description": "The protocol used (HTTP or HTTPS)",
+                                                "default": "https",
+                                                "enum": [
+                                                    "http",
+                                                    "https"
+                                                ]
+                                            },
+                                            "encoding": {
+                                                "type": "number",
+                                                "description": "The encoding for download and upload of z/OS data set and USS files. The default encoding if not specified is 1047."
+                                            },
+                                            "responseTimeout": {
+                                                "type": "number",
+                                                "description": "The maximum amount of time in seconds the z/OSMF Files TSO servlet should run before returning a response. Any request exceeding this amount of time will be terminated and return an error. Allowed values: 5 - 600"
+                                            }
+                                        },
+                                        "required": []
+                                    },
+                                    "secure": {
+                                        "items": {
+                                            "enum": [
+                                                "user",
+                                                "password"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "if": {
+                                "properties": {
+                                    "type": {
+                                        "const": "base"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "properties": {
+                                        "type": "object",
+                                        "title": "Base Profile",
+                                        "description": "Base profile that stores values shared by multiple service profiles",
+                                        "properties": {
+                                            "host": {
+                                                "type": "string",
+                                                "description": "Host name of service on the mainframe."
+                                            },
+                                            "port": {
+                                                "type": "number",
+                                                "description": "Port number of service on the mainframe."
+                                            },
+                                            "user": {
+                                                "type": "string",
+                                                "description": "User name to authenticate to service on the mainframe."
+                                            },
+                                            "password": {
+                                                "type": "string",
+                                                "description": "Password to authenticate to service on the mainframe."
+                                            },
+                                            "rejectUnauthorized": {
+                                                "type": "boolean",
+                                                "description": "Reject self-signed certificates.",
+                                                "default": true
+                                            },
+                                            "tokenType": {
+                                                "type": "string",
+                                                "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'."
+                                            },
+                                            "tokenValue": {
+                                                "type": "string",
+                                                "description": "The value of the token to pass to the API."
+                                            }
+                                        },
+                                        "required": []
+                                    },
+                                    "secure": {
+                                        "items": {
+                                            "enum": [
+                                                "user",
+                                                "password",
+                                                "tokenValue"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "defaults": {
+            "type": "object",
+            "description": "Mapping of profile types to default profile names",
+            "properties": {
+                "zosmf": {
+                    "description": "Default zosmf profile",
+                    "type": "string"
+                },
+                "base": {
+                    "description": "Default base profile",
+                    "type": "string"
+                }
+            }
+        },
+        "autoStore": {
+            "type": "boolean",
+            "description": "If true, values you enter when prompted are stored for future use"
+        }
+    }
+}

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -603,6 +603,7 @@ export class ProfileInfo {
                 layerProperties = this.mLoadedConfig.findLayer(osLoc.user, osLoc.global)?.properties;
                 realBaseProfileName = layerProperties?.defaults.base;
                 if (realBaseProfileName) baseProfile = this.mLoadedConfig.api.profiles.buildProfile(realBaseProfileName, layerProperties?.profiles);
+                else baseProfile = null;
             }
             if (baseProfile != null) {
                 // Load args from default base profile if one exists


### PR DESCRIPTION
- Fix #881 