### PR TITLE
Skip loading project config layers when project directory is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated `Config.search` API to skip loading project config layers when project directory is an empty string. [#883](https://github.com/zowe/imperative/issues/883)
+
 ## `5.5.1`
 
 - BugFix: Prevented base profile secure-property lookup on the global layer when there is not default base profile. [#881](https://github.com/zowe/imperative/issues/881)

--- a/packages/config/__tests__/Config.test.ts
+++ b/packages/config/__tests__/Config.test.ts
@@ -581,10 +581,17 @@ describe("Config tests", () => {
             expect(file).not.toBe(notExpectedPath);
             expect(file).toBe(path.resolve(expectedPath));
         });
+        it("should not search for a file when startDir is empty string", async () => {
+            const existsSpy = jest.spyOn(fs, "existsSync");
+            const file = Config.search(configFile, { startDir: "" });
+            expect(file).toBeNull();
+            expect(existsSpy).not.toHaveBeenCalled();
+        });
         it("should fail to find a file", async () => {
-            jest.spyOn(fs, "existsSync").mockReturnValue(false);
+            const existsSpy = jest.spyOn(fs, "existsSync").mockReturnValue(false);
             const file = Config.search(configFile, { startDir: configDir });
             expect(file).toBeNull();
+            expect(existsSpy).toHaveBeenCalledTimes(configDir.split(path.sep).length);
         });
 
         describe("without opts", () => {

--- a/packages/config/src/Config.ts
+++ b/packages/config/src/Config.ts
@@ -166,8 +166,8 @@ export class Config {
      */
     public async reload(opts?: IConfigOpts) {
         this.mLayers = [];
-        this.mHomeDir = opts?.homeDir || this.mHomeDir || path.join(os.homedir(), `.${this.mApp}`);
-        this.mProjectDir = opts?.projectDir || process.cwd();
+        this.mHomeDir = opts?.homeDir ?? this.mHomeDir ?? path.join(os.homedir(), `.${this.mApp}`);
+        this.mProjectDir = opts?.projectDir ?? process.cwd();
 
         // Populate configuration file layers
         for (const layer of [
@@ -399,6 +399,7 @@ export class Config {
      */
     public static search(file: string, opts?: { ignoreDirs?: string[]; startDir?: string }): string {
         opts = opts || {};
+        if (opts.startDir === "") { return null; }
         const p = findUp.sync((directory: string) => {
             if (opts.ignoreDirs?.includes(directory)) return;
             return fs.existsSync(path.join(directory, file)) && directory;


### PR DESCRIPTION
Resolves #883 

This allows Zowe Explorer to avoid loading project config profiles when there is no workspace open in VS Code:
`profileInfo.readProfilesFromDisk({ homeDir: "~/.zowe", projectDir: workspaceRoot ?? "" })`