### PR TITLE
Update workflow to use new Octorelease versions

### DIFF
--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, '[ci skip]')
     runs-on: ${{ matrix.os }}
+    outputs:
+      npm-resolutions: ${{ steps.npm-update.outputs.result }}
 
     strategy:
       fail-fast: false
@@ -39,11 +41,17 @@ jobs:
         node-version: ${{ matrix.node-version }}
         check-latest: true
 
+    - name: Disable Lint Annotations
+      run: |
+        echo "::remove-matcher owner=eslint-compact::"
+        echo "::remove-matcher owner=eslint-stylish::"
+
     - name: Install Dependencies
       run: npm ci
 
     - name: Update Dependencies
-      uses: octorelease/run-script@master
+      id: npm-update
+      uses: zowe-actions/octorelease-script@master
       with:
         script: npmUpdate
 
@@ -76,21 +84,19 @@ jobs:
       with:
         env_vars: OS,NODE
 
-    - name: Get Sonar Scan Args
-      id: sonar-scan-args
-      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
-      uses: octorelease/run-script@master
+    - name: Configure Sonar Scan
+      id: sonar-config
+      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x' }}
+      uses: zowe-actions/octorelease-script@master
       with:
-        script: getSonarScanArgs
+        script: sonarConfig
 
     - name: SonarCloud Scan
-      if: ${{ always() && steps.build.outcome == 'success' && steps.sonar-scan-args.outputs.result != '' }}
+      if: ${{ always() && steps.sonar-config.outcome == 'success' }}
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-      with:
-        args: ${{ steps.sonar-scan-args.outputs.result }}
 
   release:
     if: github.event_name == 'push'
@@ -114,17 +120,18 @@ jobs:
       run: npm ci
 
     - name: Update Dependencies
-      uses: octorelease/run-script@master
+      uses: zowe-actions/octorelease-script@master
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
+        NPM_RESOLUTIONS: ${{ needs.test.outputs.npm-resolutions }}
       with:
         script: npmUpdate
 
     - name: Build Source
       run: npm run build
 
-    - uses: octorelease/octorelease@master
+    - uses: zowe-actions/octorelease@master
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8520,28 +8520,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/glob-stream/node_modules/glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      }
-    },
-    "node_modules/glob-stream/node_modules/is-glob": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/glob-watcher": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
@@ -16220,12 +16198,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -26239,7 +26211,7 @@
       "requires": {
         "extend": "^3.0.0",
         "glob": "^7.1.1",
-        "glob-parent": "^3.1.0",
+        "glob-parent": "~5.1.2",
         "is-negated-glob": "^1.0.0",
         "ordered-read-streams": "^1.0.0",
         "pumpify": "^1.3.5",
@@ -26247,27 +26219,6 @@
         "remove-trailing-separator": "^1.0.1",
         "to-absolute-glob": "^2.0.0",
         "unique-stream": "^2.0.2"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
       }
     },
     "glob-watcher": {
@@ -26346,7 +26297,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "~5.1.2",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",
@@ -32099,12 +32050,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
       "dev": true
     },
     "path-exists": {


### PR DESCRIPTION
Updates the Imperative CI workflow to use latest versions of Octorelease actions to match Zowe CLI (https://github.com/zowe/zowe-cli/pull/1527).

Also updated the package lock file, which should fix #892.