### PR TITLE
Be more specific about NPM execution

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: lts/*
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   changelog:
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'no-changelog') != true }}
     runs-on: ubuntu-latest
 
     steps:
@@ -16,8 +17,6 @@ jobs:
         fetch-depth: 0
 
     - name: Check Changelog Updated
-      id: checkchangelogupdated
-      if: ${{ contains( github.event.pull_request.labels.*.name, 'no-changelog') != true }}
       uses: awharn/check_changelog_action@v0.0.2
       with:
         header: '## Recent Changes'

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Configure Sonar Scan
       id: sonar-config
-      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x' }}
+      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' && matrix.node-version == '18.x' }}
       uses: zowe-actions/octorelease-script@master
       with:
         script: sonarConfig
@@ -101,7 +101,7 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
 
   release:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref_protected
     needs: test
     runs-on: ubuntu-latest
 
@@ -114,7 +114,7 @@ jobs:
         ref: ${{ github.ref }}
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: 'lts/*'
 

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, '[ci skip]')
     runs-on: ${{ matrix.os }}
+    outputs:
+      npm-resolutions: ${{ steps.npm-update.outputs.result }}
 
     strategy:
       fail-fast: false
@@ -38,11 +40,17 @@ jobs:
         node-version: ${{ matrix.node-version }}
         check-latest: true
 
+    - name: Disable Lint Annotations
+      run: |
+        echo "::remove-matcher owner=eslint-compact::"
+        echo "::remove-matcher owner=eslint-stylish::"
+
     - name: Install Dependencies
       run: npm ci
 
     - name: Update Dependencies
-      uses: octorelease/run-script@master
+      id: npm-update
+      uses: zowe-actions/octorelease-script@master
       with:
         script: npmUpdate
 
@@ -78,21 +86,19 @@ jobs:
       with:
         env_vars: OS,NODE
 
-    - name: Get Sonar Scan Args
-      id: sonar-scan-args
-      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
-      uses: octorelease/run-script@master
+    - name: Configure Sonar Scan
+      id: sonar-config
+      if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' && matrix.node-version == '16.x' }}
+      uses: zowe-actions/octorelease-script@master
       with:
-        script: getSonarScanArgs
+        script: sonarConfig
 
     - name: SonarCloud Scan
-      if: ${{ always() && steps.build.outcome == 'success' && steps.sonar-scan-args.outputs.result != '' }}
+      if: ${{ always() && steps.sonar-config.outcome == 'success' }}
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-      with:
-        args: ${{ steps.sonar-scan-args.outputs.result }}
 
   release:
     if: github.event_name == 'push'
@@ -116,17 +122,18 @@ jobs:
       run: npm ci
 
     - name: Update Dependencies
-      uses: octorelease/run-script@master
+      uses: zowe-actions/octorelease-script@master
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
+        NPM_RESOLUTIONS: ${{ needs.test.outputs.npm-resolutions }}
       with:
         script: npmUpdate
 
     - name: Build Source
       run: npm run build
 
-    - uses: octorelease/octorelease@master
+    - uses: zowe-actions/octorelease@master
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,15 +11,15 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, '[ci skip]')
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: lts/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Clean up uses of execSync in Imperative where it makes sense to do so.
+
 ## `4.18.9`
 
 - BugFix: Fixed dot-separated words incorrectly rendered as links in the web help. [#869](https://github.com/zowe/imperative/issues/869)

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "readline-sync": "1.4.10",
         "semver": "5.7.0",
         "stack-trace": "0.0.10",
+        "which": "3.0.0",
         "wrap-ansi": "7.0.0",
         "yamljs": "0.3.0",
         "yargs": "15.3.1"
@@ -53,6 +54,7 @@
         "@types/pacote": "^11.1.0",
         "@types/progress": "^2.0.3",
         "@types/stack-trace": "^0.0.29",
+        "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
         "ansi-colors": "^4.1.1",
@@ -3118,6 +3120,12 @@
         "@types/vinyl": "*"
       }
     },
+    "node_modules/@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "13.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
@@ -5230,6 +5238,18 @@
       },
       "engines": {
         "node": ">=4.8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/cssom": {
@@ -8127,6 +8147,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/globals": {
@@ -14403,6 +14435,18 @@
         "which": "^1.3.0"
       }
     },
+    "node_modules/node-notifier/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/node-pty": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.10.1.tgz",
@@ -19372,15 +19416,17 @@
       }
     },
     "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "which": "bin/which"
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/which-boxed-primitive": {
@@ -22030,6 +22076,12 @@
         "@types/vinyl": "*"
       }
     },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "13.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
@@ -23649,6 +23701,17 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "cssom": {
@@ -25935,6 +25998,17 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "globals": {
@@ -30848,6 +30922,17 @@
         "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "node-pty": {
@@ -34789,10 +34874,9 @@
       }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-nla//68K9NU6yRiwDY/Q8aU6siKlSs64aEC7+IV56QoAuyQT2ovsJcgGYGyqMOmI/CGN1BOR6mM5EN0FBO+zyQ==",
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "readline-sync": "1.4.10",
     "semver": "5.7.0",
     "stack-trace": "0.0.10",
+    "which": "3.0.0",
     "wrap-ansi": "7.0.0",
     "yamljs": "0.3.0",
     "yargs": "15.3.1"
@@ -93,6 +94,7 @@
     "@types/pacote": "^11.1.0",
     "@types/progress": "^2.0.3",
     "@types/stack-trace": "^0.0.29",
+    "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",
     "ansi-colors": "^4.1.1",

--- a/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
@@ -91,7 +91,7 @@ describe("Plugin Management Facility install handler", () => {
     });
 
     afterAll(() => {
-        jest.resetAllMocks();
+        jest.restoreAllMocks();
     });
 
     /**

--- a/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
@@ -34,7 +34,7 @@ jest.doMock("path", () => {
                 return originalPath.resolve(...path);
             }
         }
-    }
+    };
 });
 
 import { CommandResponse, IHandlerParameters } from "../../../../../cmd";
@@ -92,7 +92,7 @@ describe("Plugin Management Facility install handler", () => {
 
     afterAll(() => {
         jest.resetAllMocks();
-    })
+    });
 
     /**
    *  Create object to be passed to process function

--- a/packages/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.test.ts
@@ -56,6 +56,8 @@ describe("Plugin Management Facility uninstall handler", () => {
 
         // This needs to be mocked before running process function of uninstall handler
         (Logger.getImperativeLogger as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()));
+        mocks.execSync.mockReturnValue(packageRegistry);
+        mocks.readFileSync.mockReturnValue({});
     });
 
     /**
@@ -73,9 +75,8 @@ describe("Plugin Management Facility uninstall handler", () => {
         return x as IHandlerParameters;
     };
 
-    beforeEach(() => {
-        mocks.execSync.mockReturnValue(packageRegistry);
-        mocks.readFileSync.mockReturnValue({});
+    afterAll(() => {
+        jest.restoreAllMocks();
     });
 
     /**

--- a/packages/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/uninstall/uninstall.handler.test.ts
@@ -14,7 +14,6 @@ import Mock = jest.Mock;
 
 jest.mock("child_process");
 jest.mock("jsonfile");
-jest.mock("path");
 jest.mock("../../../../src/plugins/utilities/npm-interface/uninstall");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
 jest.mock("../../../../../cmd/src/response/CommandResponse");
@@ -28,7 +27,6 @@ import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { ImperativeError } from "../../../../../error";
 import { Logger } from "../../../../../logger";
 import { readFileSync, writeFileSync } from "jsonfile";
-import { resolve } from "path";
 import { TextUtils } from "../../../../../utilities";
 import { uninstall } from "../../../../src/plugins/utilities/npm-interface";
 import UninstallHandler from "../../../../src/plugins/cmd/uninstall/uninstall.handler";
@@ -40,8 +38,7 @@ describe("Plugin Management Facility uninstall handler", () => {
         execSync: execSync as Mock<typeof execSync>,
         readFileSync: readFileSync as Mock<typeof readFileSync>,
         writeFileSync: writeFileSync as Mock<typeof writeFileSync>,
-        uninstall: uninstall as Mock<typeof uninstall>,
-        resolve: resolve as Mock<typeof resolve>
+        uninstall: uninstall as Mock<typeof uninstall>
     };
 
     // two plugin set of values

--- a/packages/imperative/__tests__/plugins/cmd/update/update.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/update/update.handler.test.ts
@@ -61,6 +61,9 @@ describe("Plugin Management Facility update handler", () => {
 
         // This needs to be mocked before running process function of update handler
         (Logger.getImperativeLogger as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()));
+        mocks.execSync.mockReturnValue(packageRegistry);
+        mocks.readFileSync.mockReturnValue({});
+        npmLogin(packageRegistry);
     });
 
     /**
@@ -78,10 +81,8 @@ describe("Plugin Management Facility update handler", () => {
         return x as IHandlerParameters;
     };
 
-    beforeEach(() => {
-        mocks.execSync.mockReturnValue(packageRegistry);
-        mocks.readFileSync.mockReturnValue({});
-        npmLogin(packageRegistry);
+    afterAll(() => {
+        jest.restoreAllMocks();
     });
 
     /**

--- a/packages/imperative/__tests__/plugins/cmd/update/update.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/update/update.handler.test.ts
@@ -13,7 +13,6 @@ import Mock = jest.Mock;
 
 jest.mock("child_process");
 jest.mock("jsonfile");
-jest.mock("path");
 jest.mock("../../../../src/plugins/utilities/npm-interface/update");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
 jest.mock("../../../../../cmd/src/doc/handler/IHandlerParameters");
@@ -28,7 +27,6 @@ import { readFileSync, writeFileSync } from "jsonfile";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
-import { resolve } from "path";
 import { update } from "../../../../src/plugins/utilities/npm-interface";
 import UpdateHandler from "../../../../src/plugins/cmd/update/update.handler";
 import { npmLogin } from "../../../../src/plugins/utilities/NpmFunctions";
@@ -43,8 +41,7 @@ describe("Plugin Management Facility update handler", () => {
         execSync: execSync as Mock<typeof execSync>,
         readFileSync: readFileSync as Mock<typeof readFileSync>,
         writeFileSync: writeFileSync as Mock<typeof writeFileSync>,
-        update: update as Mock<typeof update>,
-        resolve: resolve as Mock<typeof resolve>
+        update: update as Mock<typeof update>
     };
 
     // two plugin set of values
@@ -153,8 +150,6 @@ describe("Plugin Management Facility update handler", () => {
         mocks.readFileSync.mockReturnValueOnce(fileJson);
 
         const handler = new UpdateHandler();
-
-        mocks.resolve.mockReturnValue(resolveVal);
 
         const params = getIHandlerParametersObject();
         params.arguments.plugin = pluginName;

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/install.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/install.test.ts
@@ -33,7 +33,7 @@ jest.doMock("path", () => {
                 return originalPath.resolve(...path);
             }
         }
-    }
+    };
 });
 
 import { Console } from "../../../../../console";
@@ -87,7 +87,7 @@ describe("PMF: Install Interface", () => {
 
     afterAll(() => {
         jest.resetAllMocks();
-    })
+    });
 
     /**
    * Validates that an npm install call was valid based on the parameters passed.

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/install.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/install.test.ts
@@ -11,44 +11,55 @@
 
 /* eslint-disable jest/expect-expect */
 import Mock = jest.Mock;
+let expectedVal;
+let returnedVal;
 
 jest.mock("child_process");
 jest.mock("jsonfile");
-jest.mock("path");
-jest.mock("fs");
 jest.mock("find-up");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
 jest.mock("../../../../../logger");
 jest.mock("../../../../../cmd/src/response/CommandResponse");
 jest.mock("../../../../../cmd/src/response/HandlerResponse");
 jest.mock("../../../../src/plugins/utilities/NpmFunctions");
+jest.doMock("path", () => {
+    const originalPath = jest.requireActual("path");
+    return {
+        ...originalPath,
+        resolve: (...path: string[]) => {
+            if (path[0] == expectedVal) {
+                return returnedVal ? returnedVal : expectedVal;
+            } else {
+                return originalPath.resolve(...path);
+            }
+        }
+    }
+});
 
 import { Console } from "../../../../../console";
-import { existsSync, lstatSync } from "fs";
 import { ImperativeError } from "../../../../../error";
 import { install } from "../../../../src/plugins/utilities/npm-interface";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { IPluginJsonObject } from "../../../../src/plugins/doc/IPluginJsonObject";
-import { dirname, isAbsolute, join, resolve, normalize } from "path";
 import { Logger } from "../../../../../logger";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
 import { readFileSync, writeFileSync } from "jsonfile";
 import { sync } from "find-up";
 import { getPackageInfo, installPackages } from "../../../../src/plugins/utilities/NpmFunctions";
+import * as fs from "fs";
+import * as path from "path";
+
+function setResolve(toResolve: string, resolveTo?: string) {
+    expectedVal = toResolve;
+    returnedVal = resolveTo;
+}
 
 describe("PMF: Install Interface", () => {
     // Objects created so types are correct.
     const mocks = {
-        dirname: dirname as Mock<typeof dirname>,
         installPackages: installPackages as Mock<typeof installPackages>,
-        existsSync: existsSync as Mock<typeof existsSync>,
-        isAbsolute: isAbsolute as Mock<typeof isAbsolute>,
-        join: join as Mock<typeof join>,
         readFileSync: readFileSync as Mock<typeof readFileSync>,
-        resolve: resolve as Mock<typeof resolve>,
         writeFileSync: writeFileSync as Mock<typeof writeFileSync>,
-        normalize: normalize as Mock<typeof normalize>,
-        lstatSync: lstatSync as Mock<typeof lstatSync>,
         sync: sync as Mock<typeof sync>,
         getPackageInfo: getPackageInfo as Mock<typeof getPackageInfo>
     };
@@ -59,7 +70,8 @@ describe("PMF: Install Interface", () => {
 
     beforeEach(() => {
     // Mocks need cleared after every test for clean test runs
-        jest.resetAllMocks();
+        expectedVal = undefined;
+        returnedVal = undefined;
 
         // This needs to be mocked before running install
         (Logger.getImperativeLogger as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()));
@@ -69,10 +81,13 @@ describe("PMF: Install Interface", () => {
      */
         mocks.readFileSync.mockReturnValue({});
         mocks.sync.mockReturnValue("fake_find-up_sync_result");
-        mocks.dirname.mockReturnValue("fake-dirname");
-        mocks.resolve.mockReturnValue(packageName);
-        mocks.join.mockReturnValue("/fake/join/path");
+        jest.spyOn(path, "dirname").mockReturnValue("fake-dirname");
+        jest.spyOn(path, "join").mockReturnValue("/fake/join/path");
     });
+
+    afterAll(() => {
+        jest.resetAllMocks();
+    })
 
     /**
    * Validates that an npm install call was valid based on the parameters passed.
@@ -113,14 +128,15 @@ describe("PMF: Install Interface", () => {
     describe("Basic install", () => {
         beforeEach(() => {
             mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: packageVersion });
-            mocks.existsSync.mockReturnValue(true);
-            mocks.normalize.mockReturnValue("testing");
-            mocks.lstatSync.mockReturnValue({
+            jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+            jest.spyOn(path, "normalize").mockReturnValue("testing");
+            jest.spyOn(fs, "lstatSync").mockReturnValue({
                 isSymbolicLink: jest.fn().mockReturnValue(true)
             });
         });
 
         it("should install from the npm registry", async () => {
+            setResolve(packageName);
             await install(packageName, packageRegistry);
 
             // Validate the install
@@ -135,8 +151,8 @@ describe("PMF: Install Interface", () => {
         it("should install an absolute file path", async () => {
             const rootFile = "/root/a";
 
-            mocks.isAbsolute.mockReturnValue(true);
-
+            jest.spyOn(path, "isAbsolute").mockReturnValueOnce(true);
+            setResolve(rootFile);
             await install(rootFile, packageRegistry);
 
             // Validate the install
@@ -154,15 +170,16 @@ describe("PMF: Install Interface", () => {
 
             // Mock these before each test here since they are common
             beforeEach(() => {
-                mocks.isAbsolute.mockReturnValue(false);
-                mocks.resolve.mockReturnValue(absolutePath);
+                jest.spyOn(path, "isAbsolute").mockReturnValueOnce(false);
+                jest.spyOn(path, "resolve").mockReturnValueOnce(absolutePath);
             });
 
             it("should install a relative file path", async () => {
                 // Setup mocks for install function
-                mocks.existsSync.mockReturnValue(true);
+                jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
 
                 // Call the install function
+                setResolve(relativePath, absolutePath);
                 await install(relativePath, packageRegistry);
 
                 // Validate results
@@ -177,7 +194,7 @@ describe("PMF: Install Interface", () => {
 
         it("should install from a url", async () => {
             const installUrl = "http://www.example.com";
-            mocks.resolve.mockReturnValue(installUrl);
+            setResolve(installUrl);
 
             // mocks.isUrl.mockReturnValue(true);
 
@@ -198,11 +215,11 @@ describe("PMF: Install Interface", () => {
             // are validated to have been called or not.
             const location = "/this/should/not/change";
 
-            mocks.isAbsolute.mockReturnValue(false);
-            mocks.existsSync.mockReturnValue(true);
+            jest.spyOn(path, "isAbsolute").mockReturnValueOnce(false);
+            jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
             mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: packageVersion });
-            mocks.normalize.mockReturnValue("testing");
-            mocks.lstatSync.mockReturnValue({
+            jest.spyOn(path, "normalize").mockReturnValue("testing");
+            jest.spyOn(fs, "lstatSync").mockReturnValue({
                 isSymbolicLink: jest.fn().mockReturnValue(true)
             });
 
@@ -216,20 +233,21 @@ describe("PMF: Install Interface", () => {
             const semverVersion = "^1.5.2";
             const semverPackage = `${packageName}@${semverVersion}`;
 
-            mocks.existsSync.mockReturnValue(true);
-            mocks.normalize.mockReturnValue("testing");
-            mocks.lstatSync.mockReturnValue({
+            jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+            jest.spyOn(path, "normalize").mockReturnValue("testing");
+            jest.spyOn(fs, "lstatSync").mockReturnValue({
                 isSymbolicLink: jest.fn().mockReturnValue(true)
             });
 
             // While this doesn't replicate the function, we are installing an npm package
             // so it is shorter to just skip the if condition in install.
-            mocks.isAbsolute.mockReturnValue(true);
+            jest.spyOn(path, "isAbsolute").mockReturnValueOnce(true);
 
             // This is valid under semver ^1.5.2
             mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: "1.5.16" });
 
             // Call the install
+            setResolve(semverPackage);
             await install(semverPackage, packageRegistry);
 
             // Test that shit happened
@@ -252,13 +270,14 @@ describe("PMF: Install Interface", () => {
             };
 
             mocks.getPackageInfo.mockResolvedValue({ name: packageName, version: packageVersion });
-            mocks.existsSync.mockReturnValue(true);
-            mocks.normalize.mockReturnValue("testing");
-            mocks.lstatSync.mockReturnValue({
+            jest.spyOn(fs, "existsSync").mockReturnValueOnce(true);
+            jest.spyOn(path, "normalize").mockReturnValue("testing");
+            jest.spyOn(fs, "lstatSync").mockReturnValue({
                 isSymbolicLink: jest.fn().mockReturnValue(true)
             });
             mocks.readFileSync.mockReturnValue(oneOldPlugin);
 
+            setResolve(packageName);
             await install(packageName, packageRegistry);
 
             wasNpmInstallCallValid(packageName, packageRegistry);

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/install.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/install.test.ts
@@ -61,7 +61,8 @@ describe("PMF: Install Interface", () => {
         readFileSync: readFileSync as Mock<typeof readFileSync>,
         writeFileSync: writeFileSync as Mock<typeof writeFileSync>,
         sync: sync as Mock<typeof sync>,
-        getPackageInfo: getPackageInfo as Mock<typeof getPackageInfo>
+        getPackageInfo: getPackageInfo as Mock<typeof getPackageInfo>,
+        path: path as Mock<typeof path>
     };
 
     const packageName = "a";
@@ -86,7 +87,7 @@ describe("PMF: Install Interface", () => {
     });
 
     afterAll(() => {
-        jest.resetAllMocks();
+        jest.restoreAllMocks();
     });
 
     /**

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
@@ -14,8 +14,6 @@ import Mock = jest.Mock;
 
 jest.mock("child_process");
 jest.mock("jsonfile");
-jest.mock("path");
-jest.mock("fs");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
 jest.mock("../../../../../logger");
 jest.mock("../../../../../cmd/src/response/CommandResponse");
@@ -23,7 +21,7 @@ jest.mock("../../../../../cmd/src/response/HandlerResponse");
 
 import * as fs from "fs";
 import { Console } from "../../../../../console";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import { ImperativeError } from "../../../../../error";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
@@ -36,7 +34,7 @@ import { uninstall } from "../../../../src/plugins/utilities/npm-interface";
 describe("PMF: Uninstall Interface", () => {
     // Objects created so types are correct.
     const mocks = {
-        execSync: execSync as Mock<typeof execSync>,
+        spawnSync: spawnSync as Mock<typeof spawnSync>,
         readFileSync: readFileSync as Mock<typeof readFileSync>,
         writeFileSync: writeFileSync as Mock<typeof writeFileSync>
     };
@@ -56,13 +54,12 @@ describe("PMF: Uninstall Interface", () => {
     });
 
     /**
-   * Validates that an execSync npm uninstall call was valid based on the parameters passed.
+   * Validates that an spawnSync npm uninstall call was valid based on the parameters passed.
    *
    * @param {string} expectedPackage The package that should be sent to npm uninstall
    */
-    const wasExecSyncCallValid = (expectedPackage: string) => {
-        expect(mocks.execSync).toHaveBeenCalledWith(
-            `${npmCmd} uninstall "${expectedPackage}" --prefix "${PMFConstants.instance.PLUGIN_INSTALL_LOCATION}" -g`,
+    const wasSpawnSyncCallValid = (expectedPackage: string) => {
+        expect(mocks.spawnSync).toHaveBeenCalledWith(npmCmd, ["uninstall", expectedPackage, "--prefix", PMFConstants.instance.PLUGIN_INSTALL_LOCATION, "-g"],
             {
                 cwd  : PMFConstants.instance.PMF_ROOT,
                 stdio: ["pipe", "pipe", process.stderr]
@@ -95,7 +92,7 @@ describe("PMF: Uninstall Interface", () => {
 
     describe("Basic uninstall", () => {
         beforeEach(() => {
-            mocks.execSync.mockReturnValue(`+ ${packageName}`);
+            mocks.spawnSync.mockReturnValue(`+ ${packageName}`);
         });
 
         it("should uninstall", () => {
@@ -118,7 +115,7 @@ describe("PMF: Uninstall Interface", () => {
             uninstall(packageName);
 
             // Validate the install
-            wasExecSyncCallValid(packageName);
+            wasSpawnSyncCallValid(packageName);
             wasWriteFileSyncCallValid();
         });
 
@@ -142,7 +139,7 @@ describe("PMF: Uninstall Interface", () => {
             uninstall(samplePackageName);
 
             // Validate the install
-            wasExecSyncCallValid(samplePackageName);
+            wasSpawnSyncCallValid(samplePackageName);
             wasWriteFileSyncCallValid();
         });
 
@@ -189,7 +186,7 @@ describe("PMF: Uninstall Interface", () => {
             }
 
             // Validate the install
-            wasExecSyncCallValid(packageName);
+            wasSpawnSyncCallValid(packageName);
             expect(caughtError.message).toContain("Failed to uninstall plugin, install folder still exists");
         });
     });

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
@@ -50,7 +50,10 @@ describe("PMF: Uninstall Interface", () => {
 
         // This needs to be mocked before running uninstall
         (Logger.getImperativeLogger as Mock<typeof Logger.getImperativeLogger>).mockReturnValue(new Logger(new Console()));
+    });
 
+    afterAll(() => {
+        jest.restoreAllMocks();
     });
 
     /**

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/uninstall.test.ts
@@ -59,8 +59,14 @@ describe("PMF: Uninstall Interface", () => {
    * @param {string} expectedPackage The package that should be sent to npm uninstall
    */
     const wasSpawnSyncCallValid = (expectedPackage: string) => {
-        expect(mocks.spawnSync).toHaveBeenCalledWith(npmCmd, ["uninstall", expectedPackage, "--prefix", PMFConstants.instance.PLUGIN_INSTALL_LOCATION, "-g"],
-            {
+        expect(mocks.spawnSync).toHaveBeenCalledWith(npmCmd,
+            [
+                "uninstall",
+                expectedPackage,
+                "--prefix",
+                PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
+                "-g"
+            ], {
                 cwd  : PMFConstants.instance.PMF_ROOT,
                 stdio: ["pipe", "pipe", process.stderr]
             }

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/update.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/update.test.ts
@@ -52,6 +52,10 @@ describe("PMF: update Interface", () => {
         mocks.readFileSync.mockReturnValue({});
     });
 
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
     /**
    * Validates that an spawnSync npm install call was valid based on the parameters passed.
    *

--- a/packages/imperative/__tests__/plugins/utilities/npm-interface/update.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/npm-interface/update.test.ts
@@ -13,8 +13,6 @@ import Mock = jest.Mock;
 
 jest.mock("child_process");
 jest.mock("jsonfile");
-jest.mock("path");
-jest.mock("fs");
 jest.mock("../../../../src/plugins/utilities/PMFConstants");
 jest.mock("../../../../../logger");
 jest.mock("../../../../../cmd/src/response/CommandResponse");
@@ -22,7 +20,6 @@ jest.mock("../../../../../cmd/src/response/HandlerResponse");
 jest.mock("../../../../src/plugins/utilities/NpmFunctions");
 
 import { Console } from "../../../../../console";
-import { existsSync } from "fs";
 import { IPluginJson } from "../../../../src/plugins/doc/IPluginJson";
 import { Logger } from "../../../../../logger";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
@@ -34,7 +31,6 @@ describe("PMF: update Interface", () => {
     // Objects created so types are correct.
     const mocks = {
         installPackages: installPackages as Mock<typeof installPackages>,
-        existsSync: existsSync as Mock<typeof existsSync>,
         readFileSync: readFileSync as Mock<typeof readFileSync>,
         getPackageInfo: getPackageInfo as Mock<typeof getPackageInfo>
     };
@@ -57,12 +53,12 @@ describe("PMF: update Interface", () => {
     });
 
     /**
-   * Validates that an execSync npm install call was valid based on the parameters passed.
+   * Validates that an spawnSync npm install call was valid based on the parameters passed.
    *
    * @param {string} expectedPackage The package that should be sent to npm update
    * @param {string} expectedRegistry The registry that should be sent to npm update
    * @param {boolean} [updateFromFile=false] was the update from a file. This affects
-   *                                          the pipe sent to execSync stdio option.
+   *                                          the pipe sent to spawnSync stdio option.
    */
     const wasNpmInstallCallValid = (expectedPackage: string, expectedRegistry: string) => {
         expect(mocks.installPackages).toHaveBeenCalledWith(PMFConstants.instance.PLUGIN_INSTALL_LOCATION,

--- a/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
@@ -25,7 +25,7 @@ const cmdOutputJson = {
     stderr: "The validate commands's standard error",
     data: {}
 };
-const spawnSyncOutput = { stdout: JSON.stringify(cmdOutputJson) }
+const spawnSyncOutput = { stdout: JSON.stringify(cmdOutputJson) };
 
 describe("runValidatePlugin", () => {
     const mainModule = process.mainModule;
@@ -38,7 +38,7 @@ describe("runValidatePlugin", () => {
 
     afterEach(() => {
         process.mainModule = mainModule;
-        mocks.spawnSync.mockReset()
+        mocks.spawnSync.mockReset();
     });
 
     const mocks = {

--- a/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
+++ b/packages/imperative/__tests__/plugins/utilities/runValidatePlugin.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { runValidatePlugin } from "../../../src/plugins/utilities/runValidatePlugin";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import { Imperative } from "../../..";
 import Mock = jest.Mock;
 
@@ -21,10 +21,11 @@ const pluginName = "fakePluginName";
 const cmdOutputJson = {
     success: true,
     message: "",
-    stdout: "",
-    stderr: "",
+    stdout: "The validate commands's standard output",
+    stderr: "The validate commands's standard error",
     data: {}
 };
+const spawnSyncOutput = { stdout: JSON.stringify(cmdOutputJson) }
 
 describe("runValidatePlugin", () => {
     const mainModule = process.mainModule;
@@ -37,17 +38,16 @@ describe("runValidatePlugin", () => {
 
     afterEach(() => {
         process.mainModule = mainModule;
+        mocks.spawnSync.mockReset()
     });
 
     const mocks = {
-        execSync: execSync as Mock<typeof execSync>
+        spawnSync: spawnSync as Mock<typeof spawnSync>
     };
 
     it("should display both the stdout and stderr of the validate command", () => {
         // mock the output of executing the validatePlugin command
-        cmdOutputJson.stdout = "The validate commands's standard output";
-        cmdOutputJson.stderr = "The validate commands's standard error";
-        mocks.execSync.mockReturnValue(JSON.stringify(cmdOutputJson));
+        mocks.spawnSync.mockReturnValue(spawnSyncOutput);
         (Imperative as any).mRootCommandName = "dummy";
         const resultMsg = runValidatePlugin(pluginName);
         expect(resultMsg).toContain(cmdOutputJson.stdout);

--- a/packages/imperative/src/plugins/utilities/npm-interface/uninstall.ts
+++ b/packages/imperative/src/plugins/utilities/npm-interface/uninstall.ts
@@ -17,7 +17,7 @@ import { IPluginJson } from "../../doc/IPluginJson";
 import { Logger } from "../../../../../logger";
 import { ImperativeError } from "../../../../../error";
 import { TextUtils } from "../../../../../utilities";
-import { execSync, StdioOptions } from "child_process";
+import { spawnSync, StdioOptions } from "child_process";
 import { cmdToRun } from "../NpmFunctions";
 const npmCmd = cmdToRun();
 
@@ -64,13 +64,20 @@ export function uninstall(packageName: string): void {
         // formatting or colors but at least I can get the output of stdout right. (comment from install handler)
         iConsole.info("Uninstalling package...this may take some time.");
 
-        execSync(`${npmCmd} uninstall "${npmPackage}" ` +
-            `--prefix "${PMFConstants.instance.PLUGIN_INSTALL_LOCATION}" -g`, {
-            cwd: PMFConstants.instance.PMF_ROOT,
-            // We need to capture stdout but apparently stderr also gives us a progress
-            // bar from the npm install.
-            stdio: pipe
-        });
+        spawnSync(npmCmd,
+            [
+                "uninstall",
+                npmPackage,
+                "--prefix",
+                PMFConstants.instance.PLUGIN_INSTALL_LOCATION,
+                "-g"
+            ], {
+                cwd: PMFConstants.instance.PMF_ROOT,
+                // We need to capture stdout but apparently stderr also gives us a progress
+                // bar from the npm install.
+                stdio: pipe
+            }
+        );
 
         const installFolder = path.join(PMFConstants.instance.PLUGIN_NODE_MODULE_LOCATION, npmPackage);
         if (fs.existsSync(installFolder)) {


### PR DESCRIPTION
Execute NPM directly in several Plugin interfaces.
Replace execSync with spawnSync.
Update tests to deal with this change.