### PR TITLE
Change the command from adduser to login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Updated plugins `--login` command option to behave as expected when running in an NPM 9 environment
+
 ## `4.18.10`
 
-- BugFix: Clean up uses of execSync in Imperative where it makes sense to do so.
+- BugFix: Cleaned up uses of execSync in Imperative where it makes sense to do so.
 
 ## `4.18.9`
 

--- a/packages/imperative/src/plugins/cmd/install/install.definition.ts
+++ b/packages/imperative/src/plugins/cmd/install/install.definition.ts
@@ -57,7 +57,7 @@ const loginDescription =
     "If you used this flag once for specific registry, you don't have to use it again, it uses credentials from .npmrc file.\n" +
     "\n" +
     "For more information about npm registries, see: \n" +
-    "https://docs.npmjs.com/cli/login for NPM > 9\n" +
+    "https://docs.npmjs.com/cli/login for NPM >= 9\n" +
     "https://docs.npmjs.com/cli/adduser for NPM < 9";
 
 /**

--- a/packages/imperative/src/plugins/cmd/install/install.definition.ts
+++ b/packages/imperative/src/plugins/cmd/install/install.definition.ts
@@ -53,11 +53,12 @@ const fileDescription =
 
 const loginDescription =
     "The flag to add a registry user account to install from secure registry. It saves credentials " +
-    "to the .npmrc file using `npm adduser`. When this value is omitted, credentials from .npmrc file is used. " +
+    "to the .npmrc file using `npm login`. When this value is omitted, credentials from .npmrc file is used. " +
     "If you used this flag once for specific registry, you don't have to use it again, it uses credentials from .npmrc file.\n" +
     "\n" +
-    "For more information about npm registries, see: " +
-    "https://docs.npmjs.com/cli/adduser";
+    "For more information about npm registries, see: \n" +
+    "https://docs.npmjs.com/cli/login for NPM > 9\n" +
+    "https://docs.npmjs.com/cli/adduser for NPM < 9";
 
 /**
  * Definition of the install command.

--- a/packages/imperative/src/plugins/cmd/update/update.definition.ts
+++ b/packages/imperative/src/plugins/cmd/update/update.definition.ts
@@ -29,7 +29,7 @@ const loginDescription =
     "If you used this flag once for specific registry, you don't have to use it again, it uses credentials from .npmrc file.\n" +
     "\n" +
     "For more information about npm registries, see: \n" +
-    "https://docs.npmjs.com/cli/login for NPM > 9\n" +
+    "https://docs.npmjs.com/cli/login for NPM >= 9\n" +
     "https://docs.npmjs.com/cli/adduser for NPM < 9";
 
 /**

--- a/packages/imperative/src/plugins/cmd/update/update.definition.ts
+++ b/packages/imperative/src/plugins/cmd/update/update.definition.ts
@@ -25,11 +25,12 @@ const registryDescription =
 
 const loginDescription =
     "The flag to add a registry user account to install from secure registry. It saves credentials " +
-    "to the .npmrc file using `npm adduser`. When this value is omitted, credentials from .npmrc file is used. " +
+    "to the .npmrc file using `npm login`. When this value is omitted, credentials from .npmrc file is used. " +
     "If you used this flag once for specific registry, you don't have to use it again, it uses credentials from .npmrc file.\n" +
     "\n" +
-    "For more information about npm registries, see: " +
-    "https://docs.npmjs.com/cli/adduser";
+    "For more information about npm registries, see: \n" +
+    "https://docs.npmjs.com/cli/login for NPM > 9\n" +
+    "https://docs.npmjs.com/cli/adduser for NPM < 9";
 
 /**
  * Definition of the update command.

--- a/packages/imperative/src/plugins/utilities/NpmFunctions.ts
+++ b/packages/imperative/src/plugins/utilities/NpmFunctions.ts
@@ -84,7 +84,7 @@ export function npmLogin(registry: string) {
     try {
         spawnSync(npmCmd,
             [
-                "adduser",
+                "login",
                 "--registry", registry,
                 "--always-auth",
                 "--auth-type=legacy"


### PR DESCRIPTION
Prepare for breaking change in NPM 9 where `npm adduser` does not login to registries anymore (replaced with `npm login`)
Note that users will need to run a separate NPM command if they are using NPM 9 to create a user on their registry.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>