### PR TITLE
Optimize slow regexes detected by SonarCloud

### DIFF
--- a/packages/cmd/src/help/WebHelpGenerator.ts
+++ b/packages/cmd/src/help/WebHelpGenerator.ts
@@ -327,7 +327,7 @@ export class WebHelpGenerator {
         htmlContent += this.renderMarkdown(markdownContent);
 
         // Add Copy buttons after command line examples
-        htmlContent = htmlContent.replace(/<code>\$\s*(.*?)<\/code>/g,
+        htmlContent = htmlContent.replace(/<code>\$\s*([^<]+)<\/code>/g,
             `<code>$1</code> <button class="btn-copy no-print" data-balloon-pos="right" data-clipboard-text="$1">Copy</button>`);
 
         // Sanitize references to user's home directory

--- a/packages/imperative/src/config/cmd/report-env/EnvQuery.ts
+++ b/packages/imperative/src/config/cmd/report-env/EnvQuery.ts
@@ -481,16 +481,9 @@ export class EnvQuery {
         npmProgress.statusMessage = "Retrieving NPM registry info";
         npmProgress.percentComplete += percentIncr;
         await EnvQuery.updateProgressBar(doesProgBarExist);
-        getResult.itemValMsg += os.EOL + os.EOL + EnvQuery.getCmdOutput("npm", ["config", "list"])
-            .split(EnvQuery.allEolRegex)
-            .reduce((lines, line) => {
-                const match = /.*registry =|"project"|node bin location =|cwd =|HOME =/.exec(line);
-                if (match) {
-                    lines.push(line.slice(match.index));
-                }
-                return lines;
-            }, [])
-            .join(os.EOL);
+        getResult.itemValMsg += os.EOL + os.EOL + EnvQuery.getCmdOutput("npm", ["config", "list"]).match(
+            /((@[^:]+:)?registry =|"project"|node bin location =|cwd =|HOME =).*$/gm
+        ).join(os.EOL);
 
         // add indent to each line
         getResult.itemValMsg = EnvQuery.divider + "NPM information:" + os.EOL + EnvQuery.indent +

--- a/packages/imperative/src/config/cmd/report-env/EnvQuery.ts
+++ b/packages/imperative/src/config/cmd/report-env/EnvQuery.ts
@@ -481,12 +481,19 @@ export class EnvQuery {
         npmProgress.statusMessage = "Retrieving NPM registry info";
         npmProgress.percentComplete += percentIncr;
         await EnvQuery.updateProgressBar(doesProgBarExist);
-        getResult.itemValMsg += os.EOL + os.EOL + EnvQuery.getCmdOutput("npm", ["config", "list"]).match(
-            /.*registry =.*\n|"project.*\n|node bin location.*\n|cwd.*\n|HOME.*\n/g
-        ).join("");
+        getResult.itemValMsg += os.EOL + os.EOL + EnvQuery.getCmdOutput("npm", ["config", "list"])
+            .split(EnvQuery.allEolRegex)
+            .reduce((lines, line) => {
+                const match = /.*registry =|"project"|node bin location =|cwd =|HOME =/.exec(line);
+                if (match) {
+                    lines.push(line.slice(match.index));
+                }
+                return lines;
+            }, [])
+            .join(os.EOL);
 
         // add indent to each line
-        getResult.itemValMsg  = EnvQuery.divider + "NPM information:" + os.EOL+ EnvQuery.indent +
+        getResult.itemValMsg = EnvQuery.divider + "NPM information:" + os.EOL + EnvQuery.indent +
             getResult.itemValMsg.replace(EnvQuery.allEolRegex, "$1" + EnvQuery.indent);
 
         npmProgress.statusMessage = "Complete";


### PR DESCRIPTION
When reviewing, please verify that the updated regexes should behave the same as the old ones 🙂 
* WebHelpGenerator - searches for code blocks formatted like this: `<code>$ zowe ...</code>`
* EnvQuery: searches for lines of interest in the output of `npm config list`

These changes make SonarCloud happy (fixes [S5852](https://sonarcloud.io/organizations/zowe/rules?open=typescript%3AS5852&rule_key=typescript%3AS5852)), but are not user-facing so should not require a changelog.