### PR TITLE
Further optimization for EnvQuery regex

### DIFF
--- a/packages/imperative/src/config/cmd/report-env/EnvQuery.ts
+++ b/packages/imperative/src/config/cmd/report-env/EnvQuery.ts
@@ -481,9 +481,14 @@ export class EnvQuery {
         npmProgress.statusMessage = "Retrieving NPM registry info";
         npmProgress.percentComplete += percentIncr;
         await EnvQuery.updateProgressBar(doesProgBarExist);
-        getResult.itemValMsg += os.EOL + os.EOL + EnvQuery.getCmdOutput("npm", ["config", "list"]).match(
-            /((@[^:]+:)?registry =|"project"|node bin location =|cwd =|HOME =).*$/gm
-        ).join(os.EOL);
+
+        // Filter the output of "npm config list" command to only include lines we are interested in.
+        // Also remove "; " prefix from lines where it was added by npm and is not a user-added comment.
+        getResult.itemValMsg += os.EOL + os.EOL + EnvQuery.getCmdOutput("npm", ["config", "list"])
+            .split(EnvQuery.allEolRegex)
+            .filter(line => /registry =|"project"|node bin location =|cwd =|HOME =/.test(line))
+            .map(line => line.includes("registry =") ? line : line.replace(/^; /, ""))
+            .join(os.EOL);
 
         // add indent to each line
         getResult.itemValMsg = EnvQuery.divider + "NPM information:" + os.EOL + EnvQuery.indent +


### PR DESCRIPTION
Follow up to #909. After discussing with @gejohnston, it seemed the new regex had some undesirable change in behavior.

For example, if I had the following npm config:
```
; @zowe:registry=https://registry.npmjs.org
@zowe:registry=https://zowe.jfrog.io/zowe/api/npm/npm-local-release/
```

The "; " characters would have been stripped off in the output of `zowe config report-env`, making it unclear which line is uncommented and has priority.