### PR TITLE
Fix plugin validation error for chained handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed a logic error where chained command handlers would cause plugin validation to fail [#320](https://github.com/zowe/imperative/issues/320)
+
 ## `5.7.5`
 
 - BugFix: Fixed ProfileInfo API failing to load schema for v1 profile when schema exists but no profiles of that type exist. [#645](https://github.com/zowe/imperative/issues/645)

--- a/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
@@ -93,6 +93,21 @@ describe("Validate plugin", () => {
             expect(result.stderr).not.toContain("Problems detected during plugin validation.");
             expect(result.status).not.toEqual(1);
         });
+
+        it("when imperative object in package.json does not contains a handler property but contains a chained handler", () => {
+            const pluginName = "chained-handler-plugin";
+            const testPlugin = join(testPluginDir, "chained_handler_plugin");
+            let cmd = `plugins install ${testPlugin}`;
+            let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+            expect(result.stdout).toContain(`Installed plugin name = '${pluginName}'`);
+
+            cmd = `plugins validate ${pluginName}`;
+            result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+            expect(result.stderr).toEqual("");
+            expect(result.stdout).toContain("successfully validated.");
+            expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+            expect(result.status).not.toEqual(1);
+        });
     });
 
     describe("should display proper error message", () => {
@@ -578,6 +593,7 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain(testPlugin);
                     expect(result.stdout).toContain("Error");
                     expect(result.stdout).toContain("has no 'handler' property");
+                    expect(result.stdout).not.toContain("has no 'handler' property in one of its chained handlers.");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
                     expect(result.stderr).not.toContain("Problems detected during plugin validation.");
                     expect(result.status).not.toEqual(1);
@@ -596,6 +612,117 @@ describe("Validate plugin", () => {
                     expect(result.stdout).toContain(testPlugin);
                     expect(result.stdout).toContain("Error");
                     expect(result.stdout).toContain("has no 'handler' property");
+                    expect(result.stdout).not.toContain("has no 'handler' property in one of its chained handlers.");
+                    expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
+                });
+
+                it("is defined with definition which does not contain handler in chained handler property", () => {
+                    const testPlugin = "definition_missing_chained_handler";
+                    const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                    let cmd = `plugins install ${fullPluginPath}`;
+                    let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                    cmd = `plugins validate ${testPlugin} --no-fail-on-error`;
+                    result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(testPlugin);
+                    expect(result.stdout).toContain("Error");
+                    expect(result.stdout).toContain("has no 'handler' property in one of its chained handlers.");
+                    expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+                    expect(result.status).not.toEqual(1);
+                });
+
+                it("is defined with definition which does not contain handler in chained handler property - error", () => {
+                    const testPlugin = "definition_missing_chained_handler";
+                    const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                    let cmd = `plugins install ${fullPluginPath}`;
+                    let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                    cmd = `plugins validate ${testPlugin}`;
+                    result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(testPlugin);
+                    expect(result.stdout).toContain("Error");
+                    expect(result.stdout).toContain("has no 'handler' property in one of its chained handlers.");
+                    expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
+                });
+
+                it("is defined with definition which does not contain anything in chained handler property", () => {
+                    const testPlugin = "definition_empty_chained_handler";
+                    const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                    let cmd = `plugins install ${fullPluginPath}`;
+                    let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                    cmd = `plugins validate ${testPlugin} --no-fail-on-error`;
+                    result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(testPlugin);
+                    expect(result.stdout).toContain("Error");
+                    expect(result.stdout).toContain("has defined 'chainedHandler' property but contains no handlers.");
+                    expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+                    expect(result.status).not.toEqual(1);
+                });
+
+                it("is defined with definition which does not contain anything in chained handler property - error", () => {
+                    const testPlugin = "definition_empty_chained_handler";
+                    const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                    let cmd = `plugins install ${fullPluginPath}`;
+                    let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                    cmd = `plugins validate ${testPlugin}`;
+                    result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(testPlugin);
+                    expect(result.stdout).toContain("Error");
+                    expect(result.stdout).toContain("has defined 'chainedHandler' property but contains no handlers.");
+                    expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).toContain("Problems detected during plugin validation.");
+                    expect(result.status).toEqual(1);
+                });
+
+                it("is defined with definition which has a bad handler path in chained handler property", () => {
+                    const testPlugin = "definition_bad_chained_handler";
+                    const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                    let cmd = `plugins install ${fullPluginPath}`;
+                    let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                    cmd = `plugins validate ${testPlugin} --no-fail-on-error`;
+                    result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(testPlugin);
+                    expect(result.stdout).toContain("Error");
+                    expect(result.stdout).toContain("A chained handler for command");
+                    expect(result.stdout).toContain("does not exist:");
+                    expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
+                    expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+                    expect(result.status).not.toEqual(1);
+                });
+
+                it("is defined with definition which has a bad handler path in chained handler property - error", () => {
+                    const testPlugin = "definition_bad_chained_handler";
+                    const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
+
+                    let cmd = `plugins install ${fullPluginPath}`;
+                    let result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(`Installed plugin name = '${testPlugin}'`);
+
+                    cmd = `plugins validate ${testPlugin}`;
+                    result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
+                    expect(result.stdout).toContain(testPlugin);
+                    expect(result.stdout).toContain("Error");
+                    expect(result.stdout).toContain("A chained handler for command");
+                    expect(result.stdout).toContain("does not exist:");
                     expect(result.stdout).toContain("This plugin has command errors. No plugin commands will be available");
                     expect(result.stderr).toContain("Problems detected during plugin validation.");
                     expect(result.status).toEqual(1);

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/index.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/index.d.ts
@@ -1,0 +1,12 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+export * from "./sample-plugin";

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/index.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/index.js
@@ -1,0 +1,7 @@
+"use strict";
+// import { SamplePlugin } from './sample-plugin';
+// import { IPluginMain, ICommandDefinition } from 'imperative';
+// import chalk from 'chalk';
+// import {join} from "path";
+Object.defineProperty(exports, "__esModule", { value: true });
+//# sourceMappingURL=index.js.map

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/index.js.map
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";AAAA,kDAAkD;AAClD,oEAAoE;AACpE,6BAA6B;AAC7B,6BAA6B"}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/bar/bar.handler.d.ts
@@ -1,0 +1,19 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
+
+/**
+ * Defining handler to be use for the 'bar' command.
+ */
+export default class BarHandler implements ICommandHandler {
+    public process(params: IHandlerParameters): Promise<void>;
+}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/bar/bar.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/bar/bar.handler.js
@@ -1,0 +1,22 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Defining handler to be use for the 'bar' command.
+ */
+class BarHandler {
+    process(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            params.response.console.log("@TODO Complete this command: bar");
+        });
+    }
+}
+exports.default = BarHandler;
+//# sourceMappingURL=bar.handler.js.map

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/bar/bar.handler.js.map
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/bar/bar.handler.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"bar.handler.js","sourceRoot":"","sources":["../../../../src/sample-plugin/cmd/bar/bar.handler.ts"],"names":[],"mappings":";;;;;;;;;;AAEA;;GAEG;AACH;IACe,OAAO,CAAC,MAA0B;;YAC7C,OAAO,CAAC,GAAG,CAAC,kCAAkC,CAAC,CAAC;YAGhD,+EAA+E;YAC/E,MAAM,CAAC,QAAQ,CAAC,KAAK,EAAE,CAAC;QAC1B,CAAC;KAAA;CACF;AARD,6BAQC"}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/foo/foo.handler.d.ts
@@ -1,0 +1,15 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
+export default class FooHandler implements ICommandHandler {
+    public process(params: IHandlerParameters): Promise<void>;
+}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/foo/foo.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/foo/foo.handler.js
@@ -1,0 +1,19 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+class FooHandler {
+    process(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            params.response.console.log("Invoked sample-plugin foo handler");
+        });
+    }
+}
+exports.default = FooHandler;
+//# sourceMappingURL=foo.handler.js.map

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/foo/foo.handler.js.map
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/cmd/foo/foo.handler.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"foo.handler.js","sourceRoot":"","sources":["../../../../src/sample-plugin/cmd/foo/foo.handler.ts"],"names":[],"mappings":";;;;;;;;;;AAEA;IACe,OAAO,CAAC,MAA0B;;YAC7C,OAAO,CAAC,GAAG,CAAC,mCAAmC,CAAC,CAAC;YAEjD,MAAM,CAAC,QAAQ,CAAC,KAAK,EAAE,CAAC;QAC1B,CAAC;KAAA;CACF;AAND,6BAMC"}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/healthCheck.handler.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/healthCheck.handler.d.ts
@@ -1,0 +1,16 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+import { ICommandHandler, IHandlerParameters } from "@zowe/imperative";
+
+export default class HealthCheckHandler implements ICommandHandler {
+    public process(params: IHandlerParameters): Promise<void>;
+}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/healthCheck.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/healthCheck.handler.js
@@ -1,0 +1,20 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+class HealthCheckHandler {
+    process(params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            console.log("Invoked health check handler");
+            params.response.build();
+        });
+    }
+}
+exports.default = HealthCheckHandler;
+//# sourceMappingURL=healthCheck.handler.js.map

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/healthCheck.handler.js.map
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/healthCheck.handler.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"healthCheck.handler.js","sourceRoot":"","sources":["../../src/sample-plugin/healthCheck.handler.ts"],"names":[],"mappings":";;;;;;;;;;AAEA;IACe,OAAO,CAAC,MAA0B;;YAC7C,OAAO,CAAC,GAAG,CAAC,8BAA8B,CAAC,CAAC;YAE5C,MAAM,CAAC,QAAQ,CAAC,KAAK,EAAE,CAAC;QAC1B,CAAC;KAAA;CACF;AAND,qCAMC"}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/index.d.ts
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/index.d.ts
@@ -1,0 +1,14 @@
+/*
+* This program and the accompanying materials are made available under the terms of the
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Copyright Contributors to the Zowe Project.
+*
+*/
+
+export * from "./healthCheck.handler";
+export * from "./cmd/foo/foo.handler";
+export * from "./cmd/bar/bar.handler";

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/index.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/index.js
@@ -1,0 +1,9 @@
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./healthCheck.handler"));
+__export(require("./cmd/foo/foo.handler"));
+__export(require("./cmd/bar/bar.handler"));
+//# sourceMappingURL=index.js.map

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/index.js.map
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/lib/sample-plugin/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../../src/sample-plugin/index.ts"],"names":[],"mappings":";;;;;AACA,2CAAsC;AACtC,2CAAsC;AACtC,2CAAsC"}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/chained_handler_plugin/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "chained-handler-plugin",
+  "version": "1.0.1",
+  "description": "Some description",
+  "main": "lib/index.js",
+  "files": [
+    "lib"
+  ],
+  "imperative": {
+    "name": "chained-handler-plugin",
+    "rootCommandDescription": "imperative working test plugin",
+    "pluginBaseCliVersion": "^1.0.0",
+    "pluginHealthCheck": "./lib/sample-plugin/healthCheck.handler",
+    "pluginAliases": [
+      "chp",
+      "chainedhandlerp"
+    ],
+    "pluginSummary": "This summary is completely different from the description!",
+    "definitions": [
+      {
+        "name": "foo",
+        "description": "dummy foo command",
+        "type": "command",
+        "chainedHandlers": [
+          {
+            "handler": "./lib/sample-plugin/cmd/foo/foo.handler"
+          },
+          {
+            "handler": "./lib/sample-plugin/cmd/bar/bar.handler"
+          }
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "type": "chained-handler-plugin",
+        "schema": {
+          "type": "object",
+          "title": "chained-handler-plugin Profile",
+          "description": "A chained-handler-plugin profile",
+          "properties": {
+            "cool": {
+              "type": "string",
+              "optionDefinition": {
+                "name": "cool",
+                "description": "A cool property",
+                "type": "string",
+                "required": false,
+                "defaultValue": "duck"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  "peerDependencies": {
+    "TestCLI": "1.0.2",
+    "@zowe/imperative": "1.0.0"
+  },
+  "typings": "lib/index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "EPL 2.0",
+  "private": false,
+  "publishConfig": {
+    "registry": "http://imperative-npm-registry:4873"
+  }
+}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_bad_chained_handler/dummy.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_bad_chained_handler/dummy.handler.js
@@ -1,0 +1,3 @@
+/**
+ * Dummy handler should not be called
+ */

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_bad_chained_handler/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_bad_chained_handler/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "definition_bad_chained_handler",
+  "version": "1.0.1",
+  "description": "Some description",
+  "main": "../lib/index.js",
+  "files": [
+    "lib"
+  ],
+  "imperative": {
+    "name": "definition_bad_chained_handler",
+    "rootCommandDescription": "definition bad chained handler",
+    "pluginBaseCliVersion": "^1.0.0",
+    "pluginHealthCheck": "./dummy.handler",
+    "definitions": [
+      {
+        "name": "foo",
+        "description": "dummy foo command",
+        "type": "command",
+        "chainedHandlers": [
+          {
+            "handler": "./bad.dummy.handler"
+          }, {
+            "handler": "./bad.dummy.handler"
+          }
+        ]
+      }
+    ]
+  },
+  "peerDependencies": {
+    "@zowe/imperative": "1.0.0"
+  },
+  "typings": "lib/index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "EPL 2.0",
+  "private": false,
+  "publishConfig": {
+    "registry": "http://imperative-npm-registry:4873"
+  }
+}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_empty_chained_handler/dummy.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_empty_chained_handler/dummy.handler.js
@@ -1,0 +1,3 @@
+/**
+ * Dummy handler should not be called
+ */

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_empty_chained_handler/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_empty_chained_handler/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "definition_empty_chained_handler",
+  "version": "1.0.1",
+  "description": "Some description",
+  "main": "../lib/index.js",
+  "files": [
+    "lib"
+  ],
+  "imperative": {
+    "name": "definition_empty_chained_handler",
+    "rootCommandDescription": "definition empty chained handler",
+    "pluginBaseCliVersion": "^1.0.0",
+    "pluginHealthCheck": "./dummy.handler",
+    "definitions": [
+      {
+        "name": "foo",
+        "description": "dummy foo command",
+        "type": "command",
+        "chainedHandlers": []
+      }
+    ]
+  },
+  "peerDependencies": {
+    "@zowe/imperative": "1.0.0"
+  },
+  "typings": "lib/index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "EPL 2.0",
+  "private": false,
+  "publishConfig": {
+    "registry": "http://imperative-npm-registry:4873"
+  }
+}

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_chained_handler/dummy.handler.js
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_chained_handler/dummy.handler.js
@@ -1,0 +1,3 @@
+/**
+ * Dummy handler should not be called
+ */

--- a/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_chained_handler/package.json
+++ b/__tests__/src/packages/imperative/plugins/test_plugins/error_plugins/definition_missing_chained_handler/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "definition_missing_chained_handler",
+  "version": "1.0.1",
+  "description": "Some description",
+  "main": "../lib/index.js",
+  "files": [
+    "lib"
+  ],
+  "imperative": {
+    "name": "definition_missing_chained_handler",
+    "rootCommandDescription": "definition missing chained handler",
+    "pluginBaseCliVersion": "^1.0.0",
+    "pluginHealthCheck": "./dummy.handler",
+    "definitions": [
+      {
+        "name": "foo",
+        "description": "dummy foo command",
+        "type": "command",
+        "chainedHandlers": [
+          {
+            "handler": "./dummy.handler"
+          },
+          {
+            
+          }
+        ]
+      }
+    ]
+  },
+  "peerDependencies": {
+    "@zowe/imperative": "1.0.0"
+  },
+  "typings": "lib/index.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "EPL 2.0",
+  "private": false,
+  "publishConfig": {
+    "registry": "http://imperative-npm-registry:4873"
+  }
+}

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -1132,51 +1132,54 @@ export class PluginManagementFacility {
             } else {
                 // is this entry a command?
                 if (pluginCmdDef.type.toLowerCase() === "command") {
-                    // a command might have chained handlers
-                    if (!Object.prototype.hasOwnProperty.call(pluginCmdDef, "chainedHandlers"))
-                        // if not, a command must have a handler
-                        if (!Object.prototype.hasOwnProperty.call(pluginCmdDef, "handler")) {
-                            this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
-                                "Command name = '" + pluginCmdName + "' has no 'handler' property");
-                        } else {
-                            // the handler file must exist
-                            const handlerModulePath =
-                                this.formPluginRuntimePath(pluginName, pluginCmdDef.handler);
-                            const handlerFilePath = handlerModulePath + ".js";
-                            if (existsSync(handlerFilePath)) {
-                                // replace relative path with absolute path in the handler property
-                                pluginCmdDef.handler = handlerModulePath;
-                            } else {
-                                this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
-                                    "The handler for command = '" + pluginCmdName +
-                                    "' does not exist: " + handlerFilePath);
-                            }
-                        }
-                    else {
-                        // if the command has chained handlers, verify they exist
-                        if (pluginCmdDef.chainedHandlers.length > 0) {
-                            for (const cmdHandler of pluginCmdDef.chainedHandlers) {
-                                if (!Object.prototype.hasOwnProperty.call(cmdHandler, "handler")) {
-                                    this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
-                                        "Command name = '" + pluginCmdName + "' has no 'handler' property in one of its chained handlers.");
-                                } else {
-                                    // the handler file must exist
-                                    const handlerModulePath =
-                                        this.formPluginRuntimePath(pluginName, cmdHandler.handler);
-                                    const handlerFilePath = handlerModulePath + ".js";
-                                    if (existsSync(handlerFilePath)) {
-                                        // replace relative path with absolute path in the handler property
-                                        cmdHandler.handler = handlerModulePath;
-                                    } else {
+                    // a command must have a handler or a chained handler
+                    if (!Object.prototype.hasOwnProperty.call(pluginCmdDef, "handler")) {
+                        // if it doesn't have a handler, does it have a chained handler
+                        if (Object.prototype.hasOwnProperty.call(pluginCmdDef, "chainedHandlers")) {
+                            // if the command has chained handlers, verify they exist
+                            if (pluginCmdDef.chainedHandlers.length > 0) {
+                                for (const cmdHandler of pluginCmdDef.chainedHandlers) {
+                                    if (!Object.prototype.hasOwnProperty.call(cmdHandler, "handler")) {
+                                        // the chained handler doesn't contain a handler
                                         this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
-                                            "A chained handler for command = '" + pluginCmdName +
-                                            "' does not exist: " + handlerFilePath);
+                                            "Command name = '" + pluginCmdName + "' has no 'handler' property in one of its chained handlers.");
+                                    } else {
+                                        // the handler file must exist
+                                        const handlerModulePath =
+                                            this.formPluginRuntimePath(pluginName, cmdHandler.handler);
+                                        const handlerFilePath = handlerModulePath + ".js";
+                                        if (existsSync(handlerFilePath)) {
+                                            // replace relative path with absolute path in the handler property
+                                            cmdHandler.handler = handlerModulePath;
+                                        } else {
+                                            this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
+                                                "A chained handler for command = '" + pluginCmdName +
+                                                "' does not exist: " + handlerFilePath);
+                                        }
                                     }
                                 }
+                            } else {
+                                // the chained handler list is empty
+                                this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
+                                    "Command name = '" + pluginCmdName + "' has defined 'chainedHandler' property but contains no handlers.");
                             }
                         } else {
+                            // there was not a handler or a chained handler
                             this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
-                                "Command name = '" + pluginCmdName + "' has defined 'chainedHandler' property but contains no handlers.");
+                                "Command name = '" + pluginCmdName + "' has no 'handler' property");
+                        }
+                    } else {
+                        // the handler file must exist
+                        const handlerModulePath =
+                            this.formPluginRuntimePath(pluginName, pluginCmdDef.handler);
+                        const handlerFilePath = handlerModulePath + ".js";
+                        if (existsSync(handlerFilePath)) {
+                            // replace relative path with absolute path in the handler property
+                            pluginCmdDef.handler = handlerModulePath;
+                        } else {
+                            this.pluginIssues.recordIssue(pluginName, IssueSeverity.CMD_ERROR,
+                                "The handler for command = '" + pluginCmdName +
+                                "' does not exist: " + handlerFilePath);
                         }
                     }
                 } else if (pluginCmdDef.type.toLowerCase() === "group") {


### PR DESCRIPTION
Fixes #320 

Updates plugin validation logic to fix a situation where plugin commands with chained command handlers would fail plugin validation.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>