### PR TITLE
Support for Kubernetes credential manager on ProfilesInfo API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5217,14 +5217,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -19969,9 +19975,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
       "dev": true
     },
     "caseless": {

--- a/packages/config/__tests__/ProfileCredentials.test.ts
+++ b/packages/config/__tests__/ProfileCredentials.test.ts
@@ -270,4 +270,27 @@ describe("ProfileCredentials tests", () => {
             expect(caughtError.message).toBe("Unable to read Imperative settings file");
         });
     });
+
+    describe("getCredentialManagerOverride", () => {
+        const sampleOverride = {
+            "overrides": {
+                "CredentialManager": {
+                    "plugin": "@zowe/cli",
+                    "type": "k8s"
+                }
+            }
+        };
+        it("retrieve the override settings if the file exists", () => {
+            const profCreds: any = new ProfileCredentials({
+                usingTeamConfig: false
+            } as any);
+            const expectedResult = {
+                "plugin": "@zowe/cli",
+                "type": "k8s"
+            };
+            jest.spyOn(fs, "existsSync").mockImplementation(() => true);
+            jest.spyOn(fs, "readFileSync").mockReturnValueOnce(Buffer.from(JSON.stringify(sampleOverride)));
+            expect(profCreds.getCredentialManagerOverride()).toEqual(expectedResult);
+        });
+    });
 });

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -214,16 +214,7 @@ describe("TeamConfig ProfileInfo tests", () => {
             jest.spyOn((profInfo as any).mCredentials, "loadManager").mockImplementationOnce(async () => {
                 throw new Error("bad credential manager");
             });
-            let caughtError;
-
-            try {
-                await profInfo.readProfilesFromDisk();
-            } catch (error) {
-                caughtError = error;
-            }
-
-            expect(caughtError).toBeDefined();
-            expect(caughtError.message).toBe("Failed to initialize secure credential manager");
+            await expect(profInfo.readProfilesFromDisk()).rejects.toThrowError();
         });
 
         const methodNames: (keyof ProfileInfo)[] = [

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -897,7 +897,7 @@ export class ProfileInfo {
         } catch (error) {
             throw new ProfInfoErr({
                 errorCode: ProfInfoErr.LOAD_CRED_MGR_FAILED,
-                msg: "Failed to initialize secure credential manager",
+                msg: "Failed to initialize secure credential manager\n" + error,
                 causeErrors: error
             });
         }

--- a/packages/utilities/src/__mocks__/ImperativeConfig.ts
+++ b/packages/utilities/src/__mocks__/ImperativeConfig.ts
@@ -12,6 +12,7 @@
 
 import { Config } from "../../../config/src/__mocks__/Config";
 import { IImperativeConfig } from "../../../imperative/src/doc/IImperativeConfig";
+import { ICredentialManager } from "../../../settings/src/doc/ISettingsFile";
 
 export class ImperativeConfig {
     private static mInstance: ImperativeConfig = null;
@@ -80,5 +81,9 @@ export class ImperativeConfig {
 
     public get envVariablePrefix(): string {
         return this.loadedConfig.envVariablePrefix == null ? this.loadedConfig.name : this.loadedConfig.envVariablePrefix;
+    }
+
+    public isCredentialManager(obj: any): obj is ICredentialManager {
+        return false;
     }
 }


### PR DESCRIPTION
Add support for newly added Kubernetes credential manager on Imperative's ProfilesInfo API used in Zowe Explorer. 

## How to test
1. Symlink Zowe Explorer to this cloned/packaged branch by adding the following line to [the branch related for the refactor work](https://github.com/zowe/vscode-extension-for-zowe/pull/2073) corresponding to this PR on it's package.json:
```JSON
"**/@zowe/imperative": "link:../imperative"
```

2. Open Zowe Explorer in debug extension host and go to the dropdown setting `zowe.security.credentialManager` and select `kubernetes` from the drop down options. 
3. Create a team config profile
4. perform a ds filter search on Zowe Explorer and enter credentials when prompted
5. After the filter search is performed successfully, verify in your Kubernetes cluster if the secrets were created as well and not on keytar.