### PR TITLE
Fix IO.writeFileAsync method throwing errors badly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed `IO.writeFileAsync` method throwing uncatchable errors. [#896](https://github.com/zowe/imperative/issues/896)
+
 ## `5.7.6`
 
 - BugFix: Fixed a logic error where chained command handlers would cause plugin validation to fail [#320](https://github.com/zowe/imperative/issues/320)

--- a/packages/io/__tests__/IO.test.ts
+++ b/packages/io/__tests__/IO.test.ts
@@ -360,20 +360,20 @@ describe("IO tests", () => {
         expect(error.message).toMatchSnapshot();
     });
 
-    it("should get an error for no input on writeFileAsync", () => {
+    it("should get an error for no input on writeFileAsync", async () => {
         let error;
         try {
-            IO.writeFileAsync("   ", "   ");
+            await IO.writeFileAsync("   ", "   ");
         } catch (thrownError) {
             error = thrownError;
         }
         expect(error.message).toMatchSnapshot();
     });
 
-    it("should get an error for no input on writeFileAsync second parm", () => {
+    it("should get an error for no input on writeFileAsync second parm", async () => {
         let error;
         try {
-            IO.writeFileAsync("data", undefined);
+            await IO.writeFileAsync("data", undefined);
         } catch (thrownError) {
             error = thrownError;
         }

--- a/packages/io/__tests__/IO.test.ts
+++ b/packages/io/__tests__/IO.test.ts
@@ -384,7 +384,7 @@ describe("IO tests", () => {
 
         // mock fs.writeFile
         (fs.writeFile as any) = jest.fn((file: string, content: string, UTF8: string, callBack) => {
-            callBack();
+            process.nextTick(callBack);
         });
 
         let error;
@@ -402,7 +402,7 @@ describe("IO tests", () => {
         (fs.writeFile as any) = jest.fn((file: string, content: string, UTF8: string, callBack) => {
             const ioError = new Error();
             ioError.message = "Fake IO error";
-            callBack(ioError);
+            process.nextTick(() => callBack(ioError));
         });
 
         let error;

--- a/packages/io/src/IO.ts
+++ b/packages/io/src/IO.ts
@@ -12,7 +12,6 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { isNullOrUndefined } from "util";
 import { ImperativeReject } from "../../interfaces";
 import { ImperativeError } from "../../error";
 import { ImperativeExpect } from "../../expect";
@@ -86,7 +85,7 @@ export class IO {
     public static normalizeExtension(extension: string): string {
         ImperativeExpect.toNotBeNullOrUndefined(extension, "extension");
         extension = extension.trim();
-        if (!isNullOrUndefined(extension) && extension.length > 0 && extension[0] !== ".") {
+        if (extension != null && extension.length > 0 && extension[0] !== ".") {
             // add a '.' character to the extension if omitted
             // (if someone specifies just "bin", make the extension ".bin" )
             extension = "." + extension;
@@ -316,16 +315,12 @@ export class IO {
         ImperativeExpect.toBeDefinedAndNonBlank(file, "file");
         ImperativeExpect.toNotBeNullOrUndefined(content, "Content to write to the file must not be null or undefined");
         return new Promise<void>((resolve, reject: ImperativeReject) => {
-            try {
-                fs.writeFile(file, content, IO.UTF8, (err) => {
-                    if (!isNullOrUndefined(err)) {
-                        throw new ImperativeError({msg: err.message});
-                    }
-                    resolve();
-                });
-            } catch (error) {
-                throw new ImperativeError({msg: error.message});
-            }
+            fs.writeFile(file, content, IO.UTF8, (err) => {
+                if (err != null) {
+                    reject(new ImperativeError({msg: err.message}));
+                }
+                resolve();
+            });
         });
     }
 


### PR DESCRIPTION
Fixes the `console.error` call being skipped in this example due to uncatchable errors:
```
try {
  await IO.writeFileAsync("nonExistentFolder/newFile", "Hello world");
} catch (err) {
  console.error(`Caught exception: ${err}`);
}
```

Thanks to @zFernand0 for suggesting using `process.nextTick` in unit tests to verify the fix.