### PR TITLE
fix: Update build/test scripts to be compatible with npm@9

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js LTS
       uses: actions/setup-node@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     - name: Check Changelog Updated
-      uses: awharn/check_changelog_action@v0.0.2
+      uses: awharn/check_changelog_action@v1
       with:
         header: '## Recent Changes'
         file: 'CHANGELOG.md'

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -65,10 +65,6 @@ jobs:
       if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
       uses: t1m0thyj/unlock-keyring@v1
 
-    - name: Fix NPM 9 Breaking Change
-      if: ${{ always() && steps.build.outcome == 'success' && ( matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && matrix.node-version == '18.x' }}
-      run: mkdir .npm-global && echo "{}" > ./.npm-global/package.json
-
     - name: Integration Tests
       if: ${{ always() && steps.build.outcome == 'success' }}
       run: npm run test:integration

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
@@ -71,7 +71,7 @@ jobs:
 
     - name: Archive Results
       if: ${{ always() && steps.build.outcome == 'success' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}-${{ matrix.node-version }}-results
         path: __tests__/__results__/
@@ -89,7 +89,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/imperative.yml
+++ b/.github/workflows/imperative.yml
@@ -65,6 +65,10 @@ jobs:
       if: ${{ always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
       uses: t1m0thyj/unlock-keyring@v1
 
+    - name: Fix NPM 9 Breaking Change
+      if: ${{ always() && steps.build.outcome == 'success' && ( matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') && matrix.node-version == '18.x' }}
+      run: mkdir .npm-global && echo "{}" > ./.npm-global/package.json
+
     - name: Integration Tests
       if: ${{ always() && steps.build.outcome == 'success' }}
       run: npm run test:integration

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js LTS
       uses: actions/setup-node@v3

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ github.event.workflow_run.head_repository.full_name }}
         ref: ${{ github.event.workflow_run.head_branch }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @zowe:registry=https://zowe.jfrog.io/zowe/api/npm/npm-release/
+install-links=false

--- a/__tests__/src/TestUtil.ts
+++ b/__tests__/src/TestUtil.ts
@@ -181,6 +181,7 @@ export function executeTestCLICommand(cliBinModule: string, testContext: any, ar
     }
     const childEnv = JSON.parse(JSON.stringify(env)); // copy current env
     childEnv.FORCE_COLOR = "0";
+    childEnv.npm_config_install_links = "false";
     const child = spawnSync(nodeCommand, args, {
         cwd: execDir,
         encoding: "utf8",

--- a/__tests__/src/TestUtil.ts
+++ b/__tests__/src/TestUtil.ts
@@ -419,7 +419,7 @@ export function runCliScript(scriptPath: string, cwd: string, args: any = [], en
         // Color can vary OS/terminal
         const childEnv = JSON.parse(JSON.stringify(process.env));
         childEnv.FORCE_COLOR = "0";
-
+        childEnv.npm_config_install_links = "false";
         // Add .npm-global folder where test CLIs are installed to front of PATH
         if (process.platform === "win32") {
             childEnv.Path = nodePath.join(__dirname, "..", "..", ".npm-global") + ";" + childEnv.Path;

--- a/scripts/sampleCliTool.js
+++ b/scripts/sampleCliTool.js
@@ -32,7 +32,7 @@ switch (process.argv[2]) {
         runAll((dir) => ({ command: "npm run build", cwd: dir }), true);
         break;
     case "install":
-        runAll((dir) => ({ command: `npm install -g . --prefix ${npmPrefix}`, cwd: dir }));
+        runAll((dir) => ({ command: `npm install -g . --prefix ${npmPrefix} --install-links=false`, cwd: dir }));
         break;
     case "uninstall":
         // Delete install folder since npm uninstall doesn't work as expected: https://github.com/npm/npm/issues/17905


### PR DESCRIPTION
ℹ️ Note:
- This branch was created from the `v5.7.7` tag.
- This should allow us to publish directly from this branch if we don't want to release any new enhancements for Zowe v2.6.1

---

Once we publish (if we decide to do so) we can rebase the branch with master instead of the v5.7.7 tag

---
UPDATE:
No need to publish a new version of imperative.

 **TODO**
 - [x] Rebase this PR with master
 - [x] remove any changelog updates
 - ~`[]`  label as release-current~
 - [x] fix tests?
 - [ ] release-patch since this PR didn't go out: https://github.com/zowe/imperative/pull/934