### PR TITLE
Support object overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enchancement: Enabled use of Object type overrides for credential manager override.
+
 ## `5.8.3`
 
 - BugFix: Fixed `--help-examples` option failing on command groups. [zowe-cli#1617](https://github.com/zowe/zowe-cli/issues/1617)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 ## Recent Changes
 
-- Enchancement: Enabled use of Object type overrides for credential manager override.
+- Enhancement: Enabled use of Object type overrides for credential manager override.
 
 ## `5.8.3`
 

--- a/packages/imperative/__tests__/OverridesLoader.test.ts
+++ b/packages/imperative/__tests__/OverridesLoader.test.ts
@@ -113,6 +113,67 @@ describe("OverridesLoader", () => {
             });
         });
 
+        describe("determineDisplayName", () => {
+            const customSettings = {
+                overrides: {
+                    CredentialManager: {
+                        plugin: "@zowe/cli",
+                        type: "keytar"
+                    }
+                }
+            };
+            const defaultSettings = {
+                overrides: {
+                    CredentialManager: "@zowe/cli"
+                }
+            };
+            const config: IImperativeConfig = {
+                name: "@zowe/cli",
+                overrides: {
+                    CredentialManager: "@zowe/cli"
+                }
+            };
+            const packageJson = {
+                name: "@zowe/cli",
+                dependencies: {
+                    keytar: "1.0"
+                }
+            };
+            it("should return credential manager plugin string if override is an object of ICredentialManager", async () => {
+                const privateOverridesLoader: any = OverridesLoader;
+                jest.spyOn(AppSettings, "initialized", "get").mockReturnValue(true);
+                jest.spyOn(AppSettings, "instance", "get").mockReturnValue({
+                    getNamespace: () => ({ CredentialManager: "@zowe/cli" }),
+                    get: () => "@zowe/cli"
+                } as any);
+                await OverridesLoader.load(config, packageJson);
+                expect(privateOverridesLoader.determineDisplayName(customSettings.overrides, config)).toEqual("@zowe/cli");
+            });
+            it("should return credential manager string property if override is of type string", async () => {
+                const privateOverridesLoader: any = OverridesLoader;
+                jest.spyOn(AppSettings, "initialized", "get").mockReturnValue(true);
+                jest.spyOn(AppSettings, "instance", "get").mockReturnValue({
+                    getNamespace: () => ({ CredentialManager: "@zowe/cli" }),
+                    get: () => "@zowe/cli"
+                } as any);
+                await OverridesLoader.load(config, packageJson);
+                expect(privateOverridesLoader.determineDisplayName(defaultSettings.overrides, config)).toEqual("@zowe/cli");
+            });
+            it("should return the credential manager override from the appSettings instance", async () => {
+                const privateOverridesLoader: any = OverridesLoader;
+                jest.spyOn(AppSettings, "initialized", "get").mockReturnValue(true);
+                jest.spyOn(AppSettings, "instance", "get").mockReturnValue({
+                    getNamespace: () => ({ CredentialManager: "@zowe/cli" }),
+                    get: () => ({
+                        "plugin": "@zowe/cli",
+                        "type": "keytar"
+                    })
+                } as any);
+                await OverridesLoader.load(config, packageJson);
+                expect(privateOverridesLoader.determineDisplayName(defaultSettings.overrides, config)).toEqual("@zowe/cli");
+            });
+        });
+
         it("should load the default when override matches host package name and keytar is present in dependencies", async () => {
             const config: IImperativeConfig = {
                 name: "ABCD",

--- a/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
+++ b/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
@@ -152,6 +152,15 @@ describe("Plugin Management Facility", () => {
         }
     };
 
+    const customSettings: ISettingsFile = {
+        overrides: {
+            CredentialManager: {
+                plugin: "@zowe/cli",
+                type: "keytar"
+            }
+        }
+    };
+
     beforeEach(() => {
         jest.resetAllMocks();
         realAddCmdGrpToResolvedCliCmdTree = PMF.addCmdGrpToResolvedCliCmdTree;
@@ -447,6 +456,17 @@ describe("Plugin Management Facility", () => {
 
             // restore the real getInstalledPlugins function
             pluginIssues.getInstalledPlugins = getInstalledPluginsReal;
+        });
+
+        it("should set mPluginOverrides if object of ICredentialManager is passed in override", () => {
+            const expectedResult = {
+                "plugin": "@zowe/cli",
+                "type": "keytar"
+            };
+            AppSettings.initialize("test.json", customSettings);
+            ImperativeConfig.instance.callerPackageJson.name = "@zowe/cli";
+            PluginManagementFacility.instance.loadAllPluginCfgProps();
+            expect(PluginManagementFacility.instance.pluginOverrides.CredentialManager).toEqual(expectedResult);
         });
     }); // end loadAllPluginCfgProps
 

--- a/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
@@ -10,22 +10,8 @@
 */
 
 /* eslint-disable jest/expect-expect */
-import Mock = jest.Mock;
-
 let expectedVal;
 let returnedVal;
-
-jest.mock("child_process");
-jest.mock("jsonfile");
-jest.mock("../../../../src/plugins/utilities/npm-interface/install");
-jest.mock("../../../../src/plugins/utilities/runValidatePlugin");
-jest.mock("../../../../src/plugins/utilities/PMFConstants");
-jest.mock("../../../../../cmd/src/response/CommandResponse");
-jest.mock("../../../../../cmd/src/response/HandlerResponse");
-jest.mock("../../../../../cmd/src/doc/handler/IHandlerParameters");
-jest.mock("../../../../../logger");
-jest.mock("../../../../src/Imperative");
-jest.mock("../../../../src/plugins/utilities/NpmFunctions");
 jest.doMock("path", () => {
     const originalPath = jest.requireActual("path");
     return {
@@ -40,6 +26,7 @@ jest.doMock("path", () => {
     };
 });
 
+import Mock = jest.Mock;
 import { CommandResponse, IHandlerParameters } from "../../../../../cmd";
 import { Console } from "../../../../../console";
 import { ImperativeError } from "../../../../../error";
@@ -52,6 +39,18 @@ import { readFileSync, writeFileSync } from "jsonfile";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
 import { TextUtils } from "../../../../../utilities";
 import { getRegistry, npmLogin } from "../../../../src/plugins/utilities/NpmFunctions";
+
+jest.mock("child_process");
+jest.mock("jsonfile");
+jest.mock("../../../../src/plugins/utilities/npm-interface/install");
+jest.mock("../../../../src/plugins/utilities/runValidatePlugin");
+jest.mock("../../../../src/plugins/utilities/PMFConstants");
+jest.mock("../../../../../cmd/src/response/CommandResponse");
+jest.mock("../../../../../cmd/src/response/HandlerResponse");
+jest.mock("../../../../../cmd/src/doc/handler/IHandlerParameters");
+jest.mock("../../../../../logger");
+jest.mock("../../../../src/Imperative");
+jest.mock("../../../../src/plugins/utilities/NpmFunctions");
 
 describe("Plugin Management Facility install handler", () => {
 

--- a/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/install/install.handler.test.ts
@@ -12,6 +12,9 @@
 /* eslint-disable jest/expect-expect */
 import Mock = jest.Mock;
 
+let expectedVal;
+let returnedVal;
+
 jest.mock("child_process");
 jest.mock("jsonfile");
 jest.mock("../../../../src/plugins/utilities/npm-interface/install");
@@ -49,9 +52,6 @@ import { readFileSync, writeFileSync } from "jsonfile";
 import { PMFConstants } from "../../../../src/plugins/utilities/PMFConstants";
 import { TextUtils } from "../../../../../utilities";
 import { getRegistry, npmLogin } from "../../../../src/plugins/utilities/NpmFunctions";
-
-let expectedVal;
-let returnedVal;
 
 describe("Plugin Management Facility install handler", () => {
 

--- a/packages/imperative/src/doc/IImperativeOverrides.ts
+++ b/packages/imperative/src/doc/IImperativeOverrides.ts
@@ -34,6 +34,7 @@
 
 import { ICredentialManagerConstructor } from "../../../security";
 import { IConstructor } from "../../../interfaces";
+import { ICredentialManager } from "../../../settings";
 
 /**
  * Type of the {@link ImperativeOverrides} interface. This ensures that all
@@ -48,7 +49,7 @@ interface IOverridesRestriction {
  * and can be of either constructor or string type.
  */
 type ConstructorOrString<T extends IOverridesRestriction> = {
-    [K in keyof T] ?: T[K] | string | Object;
+    [K in keyof T] ?: T[K] | string | ICredentialManager;
 };
 
 /**

--- a/packages/imperative/src/doc/IImperativeOverrides.ts
+++ b/packages/imperative/src/doc/IImperativeOverrides.ts
@@ -48,7 +48,7 @@ interface IOverridesRestriction {
  * and can be of either constructor or string type.
  */
 type ConstructorOrString<T extends IOverridesRestriction> = {
-    [K in keyof T] ?: T[K] | string;
+    [K in keyof T] ?: T[K] | string | Object;
 };
 
 /**

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -261,7 +261,7 @@ export class PluginManagementFacility {
         // Loop through each overrides setting here. Setting is an override that we are modifying while
         // plugin is the pluginName from which to get the setting. This is probably the ugliest piece
         // of code that I have ever written :/
-         for (const [setting, plugin] of Object.entries(AppSettings.instance.getNamespace("overrides"))) {
+        for (const [setting, plugin] of Object.entries(AppSettings.instance.getNamespace("overrides"))) {
 
             const pluginName = this.getPluginName(plugin, setting);
             if (pluginName !== false && pluginName !== ImperativeConfig.instance.hostPackageName) {

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -25,7 +25,7 @@ import { ConfigurationValidator } from "../ConfigurationValidator";
 import { ConfigurationLoader } from "../ConfigurationLoader";
 import { DefinitionTreeResolver } from "../DefinitionTreeResolver";
 import { IImperativeOverrides } from "../doc/IImperativeOverrides";
-import { ICredentialManager } from "../../../settings/src/doc/ISettingsFile";
+import { ICredentialManager } from "../../../settings";
 import { AppSettings } from "../../../settings";
 import { IO } from "../../../io";
 
@@ -1266,7 +1266,7 @@ export class PluginManagementFacility {
 
     private getPluginName(plugin: string | false | ICredentialManager, setting: string): string | boolean {
         if(ImperativeConfig.instance.isCredentialManager(plugin)) {
-            const pluginName = plugin.plugin ? plugin.plugin : "@zowe/cli";
+            const pluginName = plugin.plugin ?? "@zowe/cli";
             (this.mPluginOverrides as any)[setting] = {
                 plugin: pluginName,
                 type: plugin.type

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -25,6 +25,7 @@ import { ConfigurationValidator } from "../ConfigurationValidator";
 import { ConfigurationLoader } from "../ConfigurationLoader";
 import { DefinitionTreeResolver } from "../DefinitionTreeResolver";
 import { IImperativeOverrides } from "../doc/IImperativeOverrides";
+import { ICredentialManager } from "../../../settings/src/doc/ISettingsFile";
 import { AppSettings } from "../../../settings";
 import { IO } from "../../../io";
 
@@ -260,7 +261,9 @@ export class PluginManagementFacility {
         // Loop through each overrides setting here. Setting is an override that we are modifying while
         // plugin is the pluginName from which to get the setting. This is probably the ugliest piece
         // of code that I have ever written :/
-        for (const [setting, pluginName] of Object.entries(AppSettings.instance.getNamespace("overrides"))) {
+         for (const [setting, plugin] of Object.entries(AppSettings.instance.getNamespace("overrides"))) {
+
+            const pluginName = this.getPluginName(plugin, setting);
             if (pluginName !== false && pluginName !== ImperativeConfig.instance.hostPackageName) {
                 Logger.getImperativeLogger().debug(
                     `PluginOverride: Attempting to overwrite "${setting}" with value provided by plugin "${pluginName}"`
@@ -1258,6 +1261,19 @@ export class PluginManagementFacility {
                     );
                 }
             }
+        }
+    }
+
+    private getPluginName(plugin: string | false | ICredentialManager, setting: string): string | boolean {
+        if(ImperativeConfig.instance.isCredentialManager(plugin)) {
+            const pluginName = plugin.plugin ? plugin.plugin : "@zowe/cli";
+            (this.mPluginOverrides as any)[setting] = {
+                plugin: pluginName,
+                type: plugin.type
+            };
+            return pluginName;
+        } else {
+            return plugin;
         }
     }
 } // end PluginManagementFacility

--- a/packages/security/__tests__/CredentialManagerFactory.test.ts
+++ b/packages/security/__tests__/CredentialManagerFactory.test.ts
@@ -174,6 +174,14 @@ describe("CredentialManagerFactory", () => {
             expect(() => CredentialManagerFactory.determineCredentialManagerType(sampleObject))
                 .toThrowError("Invalid CredentialManager of type notSupportedTypeExample passed in");
         });
+        it("should throw an error if an object override with a plugin not of '@zowe/cli' is installed", () => {
+            const sampleObject: ICredentialManager = {
+                plugin: "mySamplePlugin",
+                type: "keytar"
+            };
+            expect(() => CredentialManagerFactory.determineCredentialManagerType(sampleObject))
+                .toThrowError(`Object type credential manager overide is not supported for plugins outside of @zowe/cli`);
+        });
         it("should use the DefaultCredentialManager if keytar is passed as a type in manager override", () => {
             const sampleObject: ICredentialManager = {
                 plugin: "@zowe/cli",

--- a/packages/security/__tests__/CredentialManagerFactory.test.ts
+++ b/packages/security/__tests__/CredentialManagerFactory.test.ts
@@ -12,7 +12,7 @@
 import { UnitTestUtils } from "../../../__tests__/src/UnitTestUtils";
 import { resolve } from "path";
 import { generateRandomAlphaNumericString } from "../../../__tests__/src/TestUtil";
-import { ICredentialManager } from "../../settings/src/doc/ISettingsFile";
+import { ICredentialManager } from "../../settings";
 
 const ORIG_ERR = process.stderr.write;
 

--- a/packages/security/src/CredentialManagerFactory.ts
+++ b/packages/security/src/CredentialManagerFactory.ts
@@ -193,6 +193,11 @@ export class CredentialManagerFactory {
             *  e.g: case 'myCredentialManager'
             *           return MyCredentialManager;
             */
+            if(manager.plugin !== "@zowe/cli") {
+                throw new ImperativeError({
+                    msg: `Object type credential manager overide is not supported for plugins outside of @zowe/cli`
+                });
+            }
             switch(manager.type) {
                 case 'keytar':
                     return DefaultCredentialManager;

--- a/packages/security/src/CredentialManagerFactory.ts
+++ b/packages/security/src/CredentialManagerFactory.ts
@@ -14,6 +14,7 @@ import { ImperativeError } from "../../error";
 import { ICredentialManagerInit } from "./doc/ICredentialManagerInit";
 import { DefaultCredentialManager } from "./DefaultCredentialManager";
 import { ImperativeConfig } from "../../utilities";
+import { IImperativeOverrides } from "../../imperative/src/doc/IImperativeOverrides";
 
 /**
  * This is a wrapper class that controls access to the credential manager used within
@@ -187,7 +188,7 @@ export class CredentialManagerFactory {
      * @param manager the manager containing the type of CredentialManager to use or string
      * @returns an Object of AbstractCredentialManager with the CredentialManager to use
      */
-    private static determineCredentialManagerType(manager: any): any {
+    private static determineCredentialManagerType(manager: IImperativeOverrides["CredentialManager"]): any {
         if(ImperativeConfig.instance.isCredentialManager(manager)) {
             /* add other cases for future credential manager types
             *  e.g: case 'myCredentialManager'
@@ -206,7 +207,7 @@ export class CredentialManagerFactory {
             }
         }
         else {
-            return (manager == null) ? DefaultCredentialManager : manager;
+            return manager ?? DefaultCredentialManager;
         }
     }
 

--- a/packages/settings/index.ts
+++ b/packages/settings/index.ts
@@ -10,3 +10,8 @@
 */
 
 export * from "./src/AppSettings";
+
+export type ICredentialManager = {
+    plugin?: string,
+    type: string
+};

--- a/packages/settings/src/AppSettings.ts
+++ b/packages/settings/src/AppSettings.ts
@@ -11,12 +11,13 @@
 
 import * as DeepMerge from "deepmerge";
 import { existsSync } from "fs";
-import { ISettingsFile, ICredentialManager } from "./doc/ISettingsFile";
+import { ISettingsFile } from "./doc/ISettingsFile";
 import { Logger } from "../../logger";
 import { ISettingsFilePersistence } from "./persistance/ISettingsFilePersistence";
 import { JSONSettingsFilePersistence } from "./persistance/JSONSettingsFilePersistence";
 import { IO } from "../../io";
 import { ImperativeError } from "../../error";
+import { ICredentialManager } from "..";
 
 type SettingValue = false | string | ICredentialManager;
 

--- a/packages/settings/src/AppSettings.ts
+++ b/packages/settings/src/AppSettings.ts
@@ -11,14 +11,14 @@
 
 import * as DeepMerge from "deepmerge";
 import { existsSync } from "fs";
-import { ISettingsFile } from "./doc/ISettingsFile";
+import { ISettingsFile, ICredentialManager } from "./doc/ISettingsFile";
 import { Logger } from "../../logger";
 import { ISettingsFilePersistence } from "./persistance/ISettingsFilePersistence";
 import { JSONSettingsFilePersistence } from "./persistance/JSONSettingsFilePersistence";
 import { IO } from "../../io";
 import { ImperativeError } from "../../error";
 
-type SettingValue = false | string;
+type SettingValue = false | string | ICredentialManager;
 
 /**
  * This class represents settings for an Imperative CLI application that can be configured

--- a/packages/settings/src/doc/ISettingsFile.ts
+++ b/packages/settings/src/doc/ISettingsFile.ts
@@ -11,6 +11,11 @@
 
 import { IImperativeOverrides } from "../../../imperative/src/doc/IImperativeOverrides";
 
+export type ICredentialManager = {
+    plugin?: string,
+    type: string
+};
+
 /**
  * This interface defines the structure of the settings file.
  */
@@ -35,7 +40,12 @@ export interface ISettingsFile {
          *          the plugin. If the plugin doesn't provide the override, a warning
          *          will be logged to the console, the value will be left unchanged
          *          and we will act as if the key was null.
+         *
+         * { plugin?: string; type: string } - An object with two properties. The plugin property defines which
+         *                                     plugin should be used (default is @zowe/cli), and a property type
+         *                                     which defines which credential manager of imperative to use.
          */
-        [K in keyof IImperativeOverrides]-?: false | string; // All keys of IImperativeOverrides now become required
+        [K in keyof IImperativeOverrides]-?: false | string | ICredentialManager;
+        // All keys of IImperativeOverrides now become required
     };
 }

--- a/packages/settings/src/doc/ISettingsFile.ts
+++ b/packages/settings/src/doc/ISettingsFile.ts
@@ -10,11 +10,7 @@
 */
 
 import { IImperativeOverrides } from "../../../imperative/src/doc/IImperativeOverrides";
-
-export type ICredentialManager = {
-    plugin?: string,
-    type: string
-};
+import { ICredentialManager } from "../..";
 
 /**
  * This interface defines the structure of the settings file.

--- a/packages/utilities/__tests__/ImperativeConfig.test.ts
+++ b/packages/utilities/__tests__/ImperativeConfig.test.ts
@@ -10,7 +10,7 @@
 */
 
 import { Constants } from "../../constants";
-import { ICredentialManager } from "../../settings/src/doc/ISettingsFile";
+import { ICredentialManager } from "../../settings";
 
 describe("ImperativeConfig", () => {
     const {ImperativeConfig} = require("../../utilities/src/ImperativeConfig");

--- a/packages/utilities/__tests__/ImperativeConfig.test.ts
+++ b/packages/utilities/__tests__/ImperativeConfig.test.ts
@@ -10,6 +10,7 @@
 */
 
 import { Constants } from "../../constants";
+import { ICredentialManager } from "../../settings/src/doc/ISettingsFile";
 
 describe("ImperativeConfig", () => {
     const {ImperativeConfig} = require("../../utilities/src/ImperativeConfig");
@@ -94,6 +95,26 @@ describe("ImperativeConfig", () => {
             const pkgJson = ImperativeConfig.instance.callerPackageJson;
             expect(pkgJson.name).toBe("@zowe/imperative");
             expect(pkgJson.repository.url).toBe("https://github.com/zowe/imperative.git");
+        });
+
+        it("should return true if the object passed in from override fulfills the ICredentialManager interface", () => {
+            const sampleObject: ICredentialManager = {
+                "plugin": "@zowe/cli",
+                "type": "keytar"
+            };
+            expect(ImperativeConfig.instance.isCredentialManager(sampleObject)).toBe(true);
+        });
+
+        it("should throw an error if object passed in from override does not contain a type parameter", () => {
+            const sampleObject: Object = {
+                "plugin": "@zowe/cli"
+            };
+            expect(() => ImperativeConfig.instance.isCredentialManager(sampleObject)).toThrow();
+        });
+
+        it("should throw an error if object passed in from override is an empty object", () => {
+            const sampleObject: Object = {};
+            expect(() => ImperativeConfig.instance.isCredentialManager(sampleObject)).toThrow();
         });
     });
 

--- a/packages/utilities/src/ImperativeConfig.ts
+++ b/packages/utilities/src/ImperativeConfig.ts
@@ -17,7 +17,7 @@ import { EnvironmentalVariableSettings } from "../../imperative/src/env/Environm
 import { IDaemonContext } from "../../imperative/src/doc/IDaemonContext";
 import { ICommandProfileSchema } from "../../cmd";
 import { Config } from "../../config";
-import { ICredentialManager } from "../../settings/src/doc/ISettingsFile";
+import { ICredentialManager } from "../../settings";
 
 /**
  * This class is used to contain all configuration being set by Imperative.
@@ -309,7 +309,7 @@ export class ImperativeConfig {
      * @returns boolean representing whether it complies or not with the interface
      */
     public isCredentialManager(obj: any): obj is ICredentialManager {
-        if(typeof obj !== 'object' && obj !== null) {
+        if(!obj || typeof obj !== 'object') {
             return false;
         }
         if(!('type' in obj)) {

--- a/packages/utilities/src/ImperativeConfig.ts
+++ b/packages/utilities/src/ImperativeConfig.ts
@@ -17,6 +17,7 @@ import { EnvironmentalVariableSettings } from "../../imperative/src/env/Environm
 import { IDaemonContext } from "../../imperative/src/doc/IDaemonContext";
 import { ICommandProfileSchema } from "../../cmd";
 import { Config } from "../../config";
+import { ICredentialManager } from "../../settings/src/doc/ISettingsFile";
 
 /**
  * This class is used to contain all configuration being set by Imperative.
@@ -300,5 +301,22 @@ export class ImperativeConfig {
         if (ImperativeConfig.instance.loadedConfig.profiles != null)
             ImperativeConfig.instance.loadedConfig.profiles.forEach(profile => schemas[profile.type] = profile.schema);
         return schemas;
+    }
+
+    /**
+     * Checks if obj complies with the { @link ICredentialManager } interface
+     * @throws ImperativeError if object is of type ICredentialManager but does not have required 'type' property
+     * @returns boolean representing whether it complies or not with the interface
+     */
+    public isCredentialManager(obj: any): obj is ICredentialManager {
+        if(typeof obj !== 'object' && obj !== null) {
+            return false;
+        }
+        if(!('type' in obj)) {
+            throw new ImperativeError({
+                msg: "imperative.json setting for override on credential manager's property 'type' was not defined"
+            });
+        }
+        return true;
     }
 }


### PR DESCRIPTION
support for object type overrides in imperative.json's credential manager override property. 

to test:

go to `imperative.json` and change your credentialManager override to:
```JSON
{
  "overrides": {
    "CredentialManager": {
            "plugin": "@zowe/cli",
            "type:": "keytar"
    }
  }
}

```

__Note: the `plugin` property is not required if the override comes from imperative's core repo__