### PR TITLE
Support credential manager override in ProfileInfo API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added `credMgrOverride` property to `IProfOpts` interface that can be used to override credential manager in the ProfileInfo API. [zowe-cli#1632](https://github.com/zowe/zowe-cli/issues/1632)
+- Deprecated: The `requireKeytar` property on the `IProfOpts` interface. Use the `credMgrOverride` property instead and pass the callback that requires Keytar to `ProfileCredentials.defaultCredMgrWithKeytar`.
+
 ## `5.9.3`
 
-- BugFix: Fix broken plugin install command for Windows when file has a space in the name
+- BugFix: Fixed broken plugin install command for Windows when file has a space in the name
 
 ## `5.9.2`
 

--- a/packages/config/__tests__/ProfileCredentials.test.ts
+++ b/packages/config/__tests__/ProfileCredentials.test.ts
@@ -11,11 +11,18 @@
 
 import * as fs from "fs";
 import { CredentialManagerFactory, DefaultCredentialManager, ICredentialManagerInit } from "../../security";
+import { ConfigSecure } from "../src/api/ConfigSecure";
 import { ProfileCredentials } from "../src/ProfileCredentials";
 
 jest.mock("../../security/src/CredentialManagerFactory");
 jest.mock("../../security/src/DefaultCredentialManager");
 jest.mock("../../utilities/src/ImperativeConfig");
+
+function mockConfigApi(secureApi: Partial<ConfigSecure>): any {
+    return {
+        api: { secure: secureApi }
+    };
+}
 
 describe("ProfileCredentials tests", () => {
     afterAll(() => {
@@ -26,7 +33,7 @@ describe("ProfileCredentials tests", () => {
         it("should be true if team config is not secure but CredentialManager is set", () => {
             const profCreds = new ProfileCredentials({
                 usingTeamConfig: true,
-                getTeamConfig: () => ({ api: { secure: { secureFields: () => [] } } })
+                getTeamConfig: () => mockConfigApi({ secureFields: () => [] })
             } as any);
             jest.spyOn(profCreds as any, "isCredentialManagerInAppSettings").mockReturnValueOnce(true);
             expect(profCreds.isSecured).toBe(true);
@@ -35,7 +42,7 @@ describe("ProfileCredentials tests", () => {
         it("should be true if team config is secure but CredentialManager is not set", () => {
             const profCreds = new ProfileCredentials({
                 usingTeamConfig: true,
-                getTeamConfig: () => ({ api: { secure: { secureFields: () => ["myAwesomeProperty"] } } })
+                getTeamConfig: () => mockConfigApi({ secureFields: () => ["myAwesomeProperty"] })
             } as any);
             jest.spyOn(profCreds as any, "isCredentialManagerInAppSettings").mockReturnValueOnce(false);
             expect(profCreds.isSecured).toBe(true);
@@ -44,7 +51,7 @@ describe("ProfileCredentials tests", () => {
         it("should be false if team config is not secure and CredentialManager is not set", () => {
             const profCreds = new ProfileCredentials({
                 usingTeamConfig: true,
-                getTeamConfig: () => ({ api: { secure: { secureFields: () => [] } } })
+                getTeamConfig: () => mockConfigApi({ secureFields: () => [] })
             } as any);
             jest.spyOn(profCreds as any, "isCredentialManagerInAppSettings").mockReturnValueOnce(false);
             expect(profCreds.isSecured).toBe(false);
@@ -277,13 +284,7 @@ describe("ProfileCredentials tests", () => {
         it("should call Config secure load API when team config enabled", async () => {
             const mockSecureLoad = jest.fn();
             const profCreds = new ProfileCredentials({
-                getTeamConfig: () => ({
-                    api: {
-                        secure: {
-                            load: mockSecureLoad
-                        }
-                    }
-                }),
+                getTeamConfig: () => mockConfigApi({ load: mockSecureLoad }),
                 usingTeamConfig: true
             } as any);
             jest.spyOn(profCreds, "isSecured", "get").mockReturnValue(true);

--- a/packages/config/__tests__/ProfileCredentials.test.ts
+++ b/packages/config/__tests__/ProfileCredentials.test.ts
@@ -26,7 +26,7 @@ describe("ProfileCredentials tests", () => {
         it("should be true if team config is not secure but CredentialManager is set", () => {
             const profCreds = new ProfileCredentials({
                 usingTeamConfig: true,
-                getTeamConfig: () => ({ api: { secure: { secureFields: () => [] as any } } })
+                getTeamConfig: () => ({ api: { secure: { secureFields: () => [] } } })
             } as any);
             jest.spyOn(profCreds as any, "isCredentialManagerInAppSettings").mockReturnValueOnce(true);
             expect(profCreds.isSecured).toBe(true);
@@ -35,7 +35,7 @@ describe("ProfileCredentials tests", () => {
         it("should be true if team config is secure but CredentialManager is not set", () => {
             const profCreds = new ProfileCredentials({
                 usingTeamConfig: true,
-                getTeamConfig: () => ({ api: { secure: { secureFields: () => ["myAwesomeProperty"] as any } } })
+                getTeamConfig: () => ({ api: { secure: { secureFields: () => ["myAwesomeProperty"] } } })
             } as any);
             jest.spyOn(profCreds as any, "isCredentialManagerInAppSettings").mockReturnValueOnce(false);
             expect(profCreds.isSecured).toBe(true);
@@ -44,7 +44,7 @@ describe("ProfileCredentials tests", () => {
         it("should be false if team config is not secure and CredentialManager is not set", () => {
             const profCreds = new ProfileCredentials({
                 usingTeamConfig: true,
-                getTeamConfig: () => ({ api: { secure: { secureFields: () => [] as any } } })
+                getTeamConfig: () => ({ api: { secure: { secureFields: () => [] } } })
             } as any);
             jest.spyOn(profCreds as any, "isCredentialManagerInAppSettings").mockReturnValueOnce(false);
             expect(profCreds.isSecured).toBe(false);
@@ -148,6 +148,11 @@ describe("ProfileCredentials tests", () => {
                 service: "@zowe/cli",
                 displayName: "Zowe CLI",
                 Manager: class extends DefaultCredentialManager {
+                    constructor(service: string, displayName?: string) {
+                        super(service, displayName);
+                        expect(service).toBe(credMgrOverride.service);
+                        expect(displayName).toBe(credMgrOverride.displayName);
+                    }
                     public initialize = mockCredMgrInitialize;
                 }
             };
@@ -156,7 +161,7 @@ describe("ProfileCredentials tests", () => {
             } as any, { credMgrOverride });
             jest.spyOn(profCreds, "isSecured", "get").mockReturnValue(true);
             jest.spyOn(CredentialManagerFactory, "initialize").mockImplementation(async (params: ICredentialManagerInit) => {
-                await new (params.Manager as any)(null).initialize();
+                await new (params.Manager as typeof DefaultCredentialManager)(params.service, params.displayName).initialize();
             });
             let caughtError;
 
@@ -180,7 +185,7 @@ describe("ProfileCredentials tests", () => {
             });
             jest.spyOn(profCreds, "isSecured", "get").mockReturnValue(true);
             jest.spyOn(CredentialManagerFactory, "initialize").mockImplementation(async (params: ICredentialManagerInit) => {
-                await new (params.Manager as any)(null).initialize();
+                await new (params.Manager as typeof DefaultCredentialManager)(params.service, params.displayName).initialize();
             });
             let caughtError;
 
@@ -206,7 +211,7 @@ describe("ProfileCredentials tests", () => {
             });
             jest.spyOn(profCreds, "isSecured", "get").mockReturnValue(true);
             jest.spyOn(CredentialManagerFactory, "initialize").mockImplementation(async (params: ICredentialManagerInit) => {
-                await new (params.Manager as any)(null).initialize();
+                await new (params.Manager as typeof DefaultCredentialManager)(params.service, params.displayName).initialize();
             });
             let caughtError;
 

--- a/packages/config/src/ProfileCredentials.ts
+++ b/packages/config/src/ProfileCredentials.ts
@@ -26,6 +26,14 @@ export class ProfileCredentials {
         this.mCredMgrOverride = (typeof opts === "function") ? ProfileCredentials.defaultCredMgrWithKeytar(opts) : opts?.credMgrOverride;
     }
 
+    /**
+     * Given a custom method to require Keytar, return an object that defines
+     * credential manager settings to replace the default credential manager.
+     * If the credential manager is not overridden, the default implementation
+     * is to `require("keytar")` from the caller app's node_modules folder.
+     * @param requireKeytar Callback to require Keytar module for managing secure credentials
+     * @returns Credential manager settings with Keytar module overridden
+     */
     public static defaultCredMgrWithKeytar(requireKeytar: () => NodeModule): ICredentialManagerInit {
         return {
             service: null,

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -179,7 +179,7 @@ export class ProfileInfo {
             this.mOverrideWithEnv = profInfoOpts.overrideWithEnv;
         }
 
-        this.mCredentials = new ProfileCredentials(this, profInfoOpts?.requireKeytar);
+        this.mCredentials = new ProfileCredentials(this, profInfoOpts?.requireKeytar ?? profInfoOpts);
 
         // do enough Imperative stuff to let imperative utilities work
         this.initImpUtils();

--- a/packages/config/src/doc/IProfOpts.ts
+++ b/packages/config/src/doc/IProfOpts.ts
@@ -9,6 +9,8 @@
 *
 */
 
+import { ICredentialManagerConstructor } from "../../../security";
+
 /**
  * Options that will affect the behavior of the ProfileInfo class.
  * They are supplied on the ProfileInfo constructor.
@@ -30,6 +32,15 @@ export interface IProfOpts {
      * Implements a custom method to require Keytar module which manages
      * secure credentials. If undefined, the default implementation is to
      * `require("keytar")` from the caller app's node_modules folder.
+     * @deprecated
      */
     requireKeytar?: () => NodeModule;
+
+    /**
+     * Overrides the credential manager class used to load and store secure
+     * properties. If undefined, the default implementation is to use the
+     * Imperative {@link KeytarCredentialManager} which will `require("keytar")`
+     * from the caller app's node_modules folder.
+     */
+    credMgrOverride?: ICredentialManagerConstructor;
 }

--- a/packages/config/src/doc/IProfOpts.ts
+++ b/packages/config/src/doc/IProfOpts.ts
@@ -9,7 +9,7 @@
 *
 */
 
-import { ICredentialManagerConstructor } from "../../../security";
+import { ICredentialManagerInit } from "../../../security";
 
 /**
  * Options that will affect the behavior of the ProfileInfo class.
@@ -42,5 +42,5 @@ export interface IProfOpts {
      * Imperative {@link KeytarCredentialManager} which will `require("keytar")`
      * from the caller app's node_modules folder.
      */
-    credMgrOverride?: ICredentialManagerConstructor;
+    credMgrOverride?: ICredentialManagerInit;
 }

--- a/packages/security/index.ts
+++ b/packages/security/index.ts
@@ -13,4 +13,5 @@ export * from "./src/CredentialManagerFactory";
 export * from "./src/DefaultCredentialManager";
 export * from "./src/abstract/AbstractCredentialManager";
 export * from "./src/doc/ICredentialManagerConstructor";
+export * from "./src/doc/ICredentialManagerInit";
 export * from "./src/errors/BadCredentialManagerError";


### PR DESCRIPTION
Resolves https://github.com/zowe/zowe-cli/issues/1632

The `credMgrOverride` property enables consumers of the ProfileInfo API like Zowe Explorer to override just Keytar:
```
const profInfo = new imperative.ProfileInfo("zowe", {
    credMgrOverride: ProfileCredentials.defaultCredMgrWithKeytar(() => __webpack_require__("keytar")),
});
```

Or the entire credential manager (pending https://github.com/zowe/zowe-cli-secrets-for-kubernetes/issues/8):
```
import { K8sCredentialManager } from "@zowe/secrets-for-kubernetes-for-zowe-cli";
const profInfo = new imperative.ProfileInfo("zowe", {
    credMgrOverride: {
        service: "Secrets for Kubernetes",
        Manager: K8sCredentialManager
    },
});
```

See [this ZE branch](https://github.com/zowe/vscode-extension-for-zowe/compare/test/k8s-credmgr-override) for an example of overriding the credential manager. Note that the ZE branch is only a PoC for testing purposes, not an actual implementation as that should use the K8s VSCE and would depend on #937.