### PR TITLE
series of changes that coincide with a recent feature of zowe cli  

### DIFF
--- a/packages/cmd/src/doc/response/api/handler/IPromptOptions.ts
+++ b/packages/cmd/src/doc/response/api/handler/IPromptOptions.ts
@@ -36,4 +36,12 @@ export interface IPromptOptions {
      * @memberof IPromptOptions
      */
     maskChar?: string | null;
+
+    /**
+     * Text color to apply to your prompt
+     * ex: "yellow"
+     * @type {string}
+     * @memberof IPromptOptions
+     */
+    color?: string | null;
 }

--- a/packages/utilities/src/CliUtils.ts
+++ b/packages/utilities/src/CliUtils.ts
@@ -592,6 +592,10 @@ export class CliUtils {
             secToWait = maxSecToWait;
         }
 
+        if (opts.color){
+            message = TextUtils.chalk[opts.color](message);
+        }
+        
         return new Promise((resolve, reject) => {
             require("read")({
                 input: process.stdin,

--- a/packages/utilities/src/ProcessUtils.ts
+++ b/packages/utilities/src/ProcessUtils.ts
@@ -124,9 +124,9 @@ export class ProcessUtils {
      * the `{envVariablePrefix}_EDITOR` environment variable if specified.
      * @param filePath File path to edit
      */
-    public static async openInEditor(filePath: string) {
-        let editor;
-        if (ImperativeConfig.instance.loadedConfig.envVariablePrefix != null) {
+    public static async openInEditor(filePath: string, editorOpt?: string) {
+        let editor = editorOpt;
+        if (!editorOpt && ImperativeConfig.instance.loadedConfig.envVariablePrefix != null) {
             const editorEnvVar = `${ImperativeConfig.instance.loadedConfig.envVariablePrefix}_EDITOR`;
             if (process.env[editorEnvVar] != null) { editor = process.env[editorEnvVar]; }
         }


### PR DESCRIPTION
- enable command arguments to change `{$Prefix}_EDITOR`
- allow for terminal prompts to have text color