### PR TITLE
Make changes to support color in daemon mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Alters TextUtils behavior slightly to enable daemon color support without TTY
+
 ## `5.12.0`
 
 - Enhancement: Added `--prune` option to `zowe config secure` command to delete unused properties. [#547](https://github.com/zowe/imperative/issues/547)

--- a/packages/cmd/__tests__/response/CommandResponse.test.ts
+++ b/packages/cmd/__tests__/response/CommandResponse.test.ts
@@ -20,6 +20,8 @@ import { IO } from "../../../io";
 import { OUTPUT_FORMAT } from "../..";
 import { CliUtils, IDaemonResponse } from "../../../utilities";
 
+const beforeForceColor = process.env.FORCE_COLOR;
+
 const EXAMPLE_LIST = [
     "banana",
     "strawberry",
@@ -88,7 +90,7 @@ const ORIGINAL_STDERR_WRITE = process.stderr.write;
 
 describe("Command Response", () => {
 
-    beforeAll(() => {
+    beforeEach(() => {
         // disable coloring
         process.env.FORCE_COLOR = "0";
     });
@@ -97,6 +99,7 @@ describe("Command Response", () => {
     afterEach(() => {
         process.stdout.write = ORIGINAL_STDOUT_WRITE;
         process.stderr.write = ORIGINAL_STDERR_WRITE;
+        process.env.FORCE_COLOR = beforeForceColor;
     });
 
     const testFile = __dirname + "/../../../__tests__/__results__/jest/progress_bar.txt";

--- a/packages/imperative/__tests__/handlers/DefaultRootCommandHandler.test.ts
+++ b/packages/imperative/__tests__/handlers/DefaultRootCommandHandler.test.ts
@@ -21,8 +21,8 @@ import { ImperativeConfig } from "../../../utilities/src/ImperativeConfig";
 import { MOCKED_COMMAND_TREE } from "../../../imperative/src/__mocks__/Imperative";
 
 (CommandResponse as any).spinnerChars = "-oO0)|(0Oo-";
-process.env.FORCE_COLOR = "0";
 const beforeForceColor = process.env.FORCE_COLOR;
+process.env.FORCE_COLOR = "0";
 
 const COMPLEX_COMMAND: ICommandDefinition = {
     name: "test-group",

--- a/packages/imperative/__tests__/handlers/DefaultRootCommandHandler.test.ts
+++ b/packages/imperative/__tests__/handlers/DefaultRootCommandHandler.test.ts
@@ -22,6 +22,7 @@ import { MOCKED_COMMAND_TREE } from "../../../imperative/src/__mocks__/Imperativ
 
 (CommandResponse as any).spinnerChars = "-oO0)|(0Oo-";
 process.env.FORCE_COLOR = "0";
+const beforeForceColor = process.env.FORCE_COLOR;
 
 const COMPLEX_COMMAND: ICommandDefinition = {
     name: "test-group",
@@ -90,12 +91,13 @@ const MULTIPLE_GROUPS: ICommandDefinition = {
 
 describe("Default Root Command Handler", () => {
 
-    afterAll(() => {
-        process.env.FORCE_COLOR = "1";
+    beforeEach(() => {
+        process.env.FORCE_COLOR = "0";
     });
 
     afterEach(() => {
         (ImperativeConfig as any).mInstance = null;
+        process.env.FORCE_COLOR = beforeForceColor;
     });
 
     it("should display the help if no options are specified", async () => {

--- a/packages/utilities/__tests__/TextUtils.test.ts
+++ b/packages/utilities/__tests__/TextUtils.test.ts
@@ -75,37 +75,31 @@ describe("TextUtils", () => {
 
     it("should set chalk level to 0 if FORCE_COLOR is 0", () => {
         process.env.FORCE_COLOR = "0";
-        const chalk = TextUtils.chalk;
-        expect(chalk.level).toEqual(0);
+        expect(TextUtils.chalk.level).toEqual(0);
     });
 
     it("should set chalk level to 1 if FORCE_COLOR is 1", () => {
         process.env.FORCE_COLOR = "1";
-        const chalk = TextUtils.chalk;
-        expect(chalk.level).toEqual(1);
+        expect(TextUtils.chalk.level).toEqual(1);
     });
 
     it("should set chalk level to 2 if FORCE_COLOR is 2", () => {
         process.env.FORCE_COLOR = "2";
-        const chalk = TextUtils.chalk;
-        expect(chalk.level).toEqual(2);
+        expect(TextUtils.chalk.level).toEqual(2);
     });
 
     it("should set chalk level to 3 if FORCE_COLOR is 3", () => {
         process.env.FORCE_COLOR = "3";
-        const chalk = TextUtils.chalk;
-        expect(chalk.level).toEqual(3);
+        expect(TextUtils.chalk.level).toEqual(3);
     });
 
     it("should not set chalk level to 4 if FORCE_COLOR is 4", () => {
         process.env.FORCE_COLOR = "4";
-        const chalk = TextUtils.chalk;
-        expect(chalk.level).not.toEqual(4);
+        expect(TextUtils.chalk.level).not.toEqual(4);
     });
 
     it("should not set chalk level to fake if FORCE_COLOR is fake", () => {
         process.env.FORCE_COLOR = "fake";
-        const chalk = TextUtils.chalk;
-        expect(chalk.level).not.toEqual("fake");
+        expect(TextUtils.chalk.level).not.toEqual("fake");
     });
 });

--- a/packages/utilities/__tests__/TextUtils.test.ts
+++ b/packages/utilities/__tests__/TextUtils.test.ts
@@ -24,7 +24,7 @@ describe("TextUtils", () => {
     beforeEach(() => {
         TextUtils.chalk.level = 0;
         process.env.FORCE_COLOR = "";
-});
+    });
 
     afterEach(() => {
         process.env.FORCE_COLOR = beforeForceColor;

--- a/packages/utilities/__tests__/TextUtils.test.ts
+++ b/packages/utilities/__tests__/TextUtils.test.ts
@@ -17,11 +17,21 @@ const tableObjects = [
 
 import { TextUtils } from "../src/TextUtils";
 
+const beforeForceColor = process.env.FORCE_COLOR;
+
 describe("TextUtils", () => {
 
+    beforeEach(() => {
+        TextUtils.chalk.level = 0;
+        process.env.FORCE_COLOR = "";
+});
+
+    afterEach(() => {
+        process.env.FORCE_COLOR = beforeForceColor;
+    });
+
     it("should be able to color text yellow", () => {
-        const chalk = TextUtils.chalk;
-        chalk.level = 1; // set basic color mode for OS independence
+        TextUtils.chalk.level = 1; // set basic color mode for OS independence
         const text = TextUtils.chalk.yellow("highlighting with chalk") + " hello";
         expect(text).toMatchSnapshot();
     });
@@ -61,5 +71,41 @@ describe("TextUtils", () => {
         const expected = "----testing\n----can be\n----interesting";
         const results = TextUtils.indentLines(text, "----");
         expect(results).toEqual(expected);
+    });
+
+    it("should set chalk level to 0 if FORCE_COLOR is 0", () => {
+        process.env.FORCE_COLOR = "0";
+        const chalk = TextUtils.chalk;
+        expect(chalk.level).toEqual(0);
+    });
+
+    it("should set chalk level to 1 if FORCE_COLOR is 1", () => {
+        process.env.FORCE_COLOR = "1";
+        const chalk = TextUtils.chalk;
+        expect(chalk.level).toEqual(1);
+    });
+
+    it("should set chalk level to 2 if FORCE_COLOR is 2", () => {
+        process.env.FORCE_COLOR = "2";
+        const chalk = TextUtils.chalk;
+        expect(chalk.level).toEqual(2);
+    });
+
+    it("should set chalk level to 3 if FORCE_COLOR is 3", () => {
+        process.env.FORCE_COLOR = "3";
+        const chalk = TextUtils.chalk;
+        expect(chalk.level).toEqual(3);
+    });
+
+    it("should not set chalk level to 4 if FORCE_COLOR is 4", () => {
+        process.env.FORCE_COLOR = "4";
+        const chalk = TextUtils.chalk;
+        expect(chalk.level).not.toEqual(4);
+    });
+
+    it("should not set chalk level to fake if FORCE_COLOR is fake", () => {
+        process.env.FORCE_COLOR = "fake";
+        const chalk = TextUtils.chalk;
+        expect(chalk.level).not.toEqual("fake");
     });
 });

--- a/packages/utilities/src/TextUtils.ts
+++ b/packages/utilities/src/TextUtils.ts
@@ -300,8 +300,16 @@ export class TextUtils {
         const mChalk = require("chalk");
         // chalk is supposed to handle this, but I think it only does so the first time it is loaded
         // so we need to check ourselves in case we've changed the environmental variables
-        mChalk.enabled = (process.env.FORCE_COLOR !== "0" && mChalk.supportsColor.hasBasic &&
-            isNullOrUndefined(process.env.MARKDOWN_GEN));
+        mChalk.enabled = (process.env.FORCE_COLOR !== "0" && process.env.MARKDOWN_GEN == null);
+        if (!mChalk.enabled) { mChalk.level = 0; }
+        else if (process.env.FORCE_COLOR != null) {
+            const parsedInt = parseInt(process.env.FORCE_COLOR);
+            // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+            if (!isNaN(parsedInt) && parsedInt >= 0 && parsedInt <= 3) {
+                mChalk.level = parsedInt;
+            }
+        }
+
         return mChalk;
     }
 

--- a/packages/utilities/src/TextUtils.ts
+++ b/packages/utilities/src/TextUtils.ts
@@ -300,7 +300,7 @@ export class TextUtils {
         const mChalk = require("chalk");
         // chalk is supposed to handle this, but I think it only does so the first time it is loaded
         // so we need to check ourselves in case we've changed the environmental variables
-        mChalk.enabled = (process.env.FORCE_COLOR !== "0" && process.env.MARKDOWN_GEN == null);
+        mChalk.enabled = process.env.FORCE_COLOR !== "0" && process.env.MARKDOWN_GEN == null;
         if (!mChalk.enabled) { mChalk.level = 0; }
         else if (process.env.FORCE_COLOR != null) {
             const parsedInt = parseInt(process.env.FORCE_COLOR);


### PR DESCRIPTION
Makes a small change to allow for color support in daemon mode by skipping the check for a TTY interface and enabling FORCE_COLOR to set the color level in `chalk`.