### PR TITLE
Remove validation tests that require a pluginHealthCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Remove validation of the deprecated pluginHealthCheck property. [#980](https://github.com/zowe/imperative/issues/980)
+
 ## `5.13.0`
 
 - Enhancement: Alters TextUtils behavior slightly to enable daemon color support without TTY

--- a/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
+++ b/__tests__/src/packages/imperative/plugins/suites/ValidatePlugin.ts
@@ -247,6 +247,7 @@ describe("Validate plugin", () => {
                 expect(result.status).toEqual(1);
             });
 
+            // TODO: remove this test in V3, when pluginHealthCheck is removed
             it("missing pluginHealthCheck property", () => {
                 const testPlugin = "missing_pluginHealthCheck";
                 const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
@@ -259,12 +260,14 @@ describe("Validate plugin", () => {
                 result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
                 result.stderr = removeNewline(result.stderr);
                 expect(result.stdout).toContain(testPlugin);
-                expect(result.stdout).toContain("Warning");
-                expect(result.stdout).toContain("The plugin's configuration does not contain an 'imperative.pluginHealthCheck' property.");
+                expect(result.stdout).toContain("This plugin was successfully validated. Enjoy the plugin.");
+                expect(result.stdout).not.toContain("Warning");
+                expect(result.stdout).not.toContain("The plugin's configuration does not contain an 'imperative.pluginHealthCheck' property.");
                 expect(result.stderr).not.toContain("Problems detected during plugin validation.");
                 expect(result.status).toEqual(0);
             });
 
+            // TODO: remove this test in V3, when pluginHealthCheck is removed
             it("missing pluginHealthCheck property - warning", () => {
                 const testPlugin = "missing_pluginHealthCheck";
                 const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
@@ -277,12 +280,14 @@ describe("Validate plugin", () => {
                 result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
                 result.stderr = removeNewline(result.stderr);
                 expect(result.stdout).toContain(testPlugin);
-                expect(result.stdout).toContain("Warning");
-                expect(result.stdout).toContain("The plugin's configuration does not contain an 'imperative.pluginHealthCheck' property.");
-                expect(result.stderr).toContain("Problems detected during plugin validation.");
-                expect(result.status).toEqual(1);
+                expect(result.stdout).toContain("This plugin was successfully validated. Enjoy the plugin.");
+                expect(result.stdout).not.toContain("Warning");
+                expect(result.stdout).not.toContain("The plugin's configuration does not contain an 'imperative.pluginHealthCheck' property.");
+                expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(0);
             });
 
+            // TODO: remove this test in V3, when pluginHealthCheck is removed
             it("missing pluginHealthCheck handler", () => {
                 const testPlugin = "missing_healthcheck_handler";
                 const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
@@ -295,13 +300,15 @@ describe("Validate plugin", () => {
                 result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
                 result.stderr = removeNewline(result.stderr);
                 expect(result.stdout).toContain(testPlugin);
-                expect(result.stdout).toContain("Error");
-                expect(result.stdout).toContain(`The program for the 'imperative.pluginHealthCheck' property does not exist:`);
-                expect(result.stdout).toContain("This plugin has configuration errors. No component of the plugin will be available");
+                expect(result.stdout).toContain("This plugin was successfully validated. Enjoy the plugin.");
+                expect(result.stdout).not.toContain("Error");
+                expect(result.stdout).not.toContain(`The program for the 'imperative.pluginHealthCheck' property does not exist:`);
+                expect(result.stdout).not.toContain("This plugin has configuration errors. No component of the plugin will be available");
                 expect(result.stderr).not.toContain("Problems detected during plugin validation.");
-                expect(result.status).not.toEqual(1);
+                expect(result.status).toEqual(0);
             });
 
+            // TODO: remove this test in V3, when pluginHealthCheck is removed
             it("missing pluginHealthCheck handler - error", () => {
                 const testPlugin = "missing_healthcheck_handler";
                 const fullPluginPath = join(testPluginDir, "error_plugins", testPlugin);
@@ -314,11 +321,12 @@ describe("Validate plugin", () => {
                 result = T.executeTestCLICommand(cliBin, this, cmd.split(" "));
                 result.stderr = removeNewline(result.stderr);
                 expect(result.stdout).toContain(testPlugin);
-                expect(result.stdout).toContain("Error");
-                expect(result.stdout).toContain(`The program for the 'imperative.pluginHealthCheck' property does not exist:`);
-                expect(result.stdout).toContain("This plugin has configuration errors. No component of the plugin will be available");
-                expect(result.stderr).toContain("Problems detected during plugin validation.");
-                expect(result.status).toEqual(1);
+                expect(result.stdout).toContain("This plugin was successfully validated. Enjoy the plugin.");
+                expect(result.stdout).not.toContain("Error");
+                expect(result.stdout).not.toContain(`The program for the 'imperative.pluginHealthCheck' property does not exist:`);
+                expect(result.stdout).not.toContain("This plugin has configuration errors. No component of the plugin will be available");
+                expect(result.stderr).not.toContain("Problems detected during plugin validation.");
+                expect(result.status).toEqual(0);
             });
 
             it("missing peerDependencies properties", () => {

--- a/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
+++ b/packages/imperative/__tests__/plugins/PluginManagementFacility.test.ts
@@ -87,7 +87,7 @@ describe("Plugin Management Facility", () => {
         pluginAliases: goodPluginAliases,
         pluginSummary: goodPluginSummary,
         rootCommandDescription: "imperative sample plugin",
-        pluginHealthCheck: "./lib/sample-plugin/healthCheck.handler",
+        pluginHealthCheck: "./lib/sample-plugin/healthCheck.handler",   // TODO: remove in V3, when pluginHealthCheck is removed
         definitions: [
             {
                 name: "foo",
@@ -732,7 +732,8 @@ describe("Plugin Management Facility", () => {
                     "The plugin defines no commands and overrides no framework components.");
             });
 
-            it("should record warning if plugin healthCheck property does not exist", () => {
+            // TODO: remove this test in V3, when pluginHealthCheck is removed
+            it("should not record warning if pluginHealthCheck property does not exist", () => {
                 // remove pluginHealthCheck property from config
                 badPluginConfig = JSON.parse(JSON.stringify(basePluginConfig));
                 delete badPluginConfig.pluginHealthCheck;
@@ -748,13 +749,12 @@ describe("Plugin Management Facility", () => {
                 // missing healthCheck is just a warning, so we succeed
                 expect(isValid).toBe(true);
 
-                const issue = pluginIssues.getIssueListForPlugin(pluginName)[0];
-                expect(issue.issueSev).toBe(IssueSeverity.WARNING);
-                expect(issue.issueText).toContain(
-                    "The plugin's configuration does not contain an 'imperative.pluginHealthCheck' property.");
+                // we no longer report any error about missing pluginHealthCheck property
+                expect(pluginIssues.getIssueListForPlugin(pluginName).length).toBe(0);
             });
 
-            it("should record error if plugin healthCheck file does not exist", () => {
+            // TODO: remove this test in V3, when pluginHealthCheck is removed
+            it("should not record error if pluginHealthCheck file does not exist", () => {
                 // set pluginHealthCheck property to a bogus file
                 badPluginConfig = JSON.parse(JSON.stringify(basePluginConfig));
                 badPluginConfig.pluginHealthCheck = "./This/File/Does/Not/Exist";
@@ -766,13 +766,10 @@ describe("Plugin Management Facility", () => {
                 mockAreVersionsCompatible.mockReturnValueOnce(true);
 
                 isValid = PMF.validatePlugin(badPluginCfgProps, basePluginCmdDef);
-                expect(isValid).toBe(false);
+                expect(isValid).toBe(true);
 
-                const issue = pluginIssues.getIssueListForPlugin(pluginName)[0];
-                expect(issue.issueSev).toBe(IssueSeverity.CFG_ERROR);
-                expect(issue.issueText).toContain(
-                    "The program for the 'imperative.pluginHealthCheck' property does not exist: " +
-                    join(PMFConstants.instance.PLUGIN_HOME_LOCATION, pluginName, "This/File/Does/Not/Exist.js"));
+                // we no longer report any error about missing pluginHealthCheck file
+                expect(pluginIssues.getIssueListForPlugin(pluginName).length).toBe(0);
             });
 
             it("should record error when ConfigurationValidator throws an exception", () => {

--- a/packages/imperative/__tests__/plugins/cmd/firststeps/showfirststeps.handler.test.ts
+++ b/packages/imperative/__tests__/plugins/cmd/firststeps/showfirststeps.handler.test.ts
@@ -46,7 +46,6 @@ describe("Plugin first steps command handler", () => {
         pluginAliases: goodPluginAliases,
         pluginSummary: goodPluginSummary,
         rootCommandDescription: "imperative sample plugin",
-        pluginHealthCheck: "./lib/sample-plugin/healthCheck.handler",
         definitions: [
             {
                 name: "foo",
@@ -89,7 +88,6 @@ describe("Plugin first steps command handler", () => {
         pluginAliases: goodPluginAliases,
         pluginSummary: goodPluginSummary,
         rootCommandDescription: "imperative sample plugin fs",
-        pluginHealthCheck: "./lib/sample-plugin/healthCheck.handler",
         definitions: [
             {
                 name: "foo",

--- a/packages/imperative/src/doc/IImperativeConfig.ts
+++ b/packages/imperative/src/doc/IImperativeConfig.ts
@@ -239,17 +239,12 @@ export interface IImperativeConfig {
      * The implementor of a plugin determines what actions
      * can confirm that the plugin is in an operational state.
      *
-     * This property is recommended for a plugin. The existence of this property
-     * and the existence of the specified file will be verified when the plugin
-     * is validated by the Imperative framework. Their absence will generate warnings.
-     *
      * The health check should return true if all plugin health checks pass.
      * It should return false otherwise.
      *
      * This property is unused for a base CLI.
      *
-     * TODO: While the pluginHealthCheck property is validated, no Imperative command
-     * currently calls the health check function.
+     * No Zowe CLI command currently calls the health check function.
      *
      * @deprecated
      *      This property is deprecated. Plugins that want to perform a health check can

--- a/packages/imperative/src/plugins/PluginManagementFacility.ts
+++ b/packages/imperative/src/plugins/PluginManagementFacility.ts
@@ -1101,25 +1101,6 @@ export class PluginManagementFacility {
          */
         this.validatePeerDepVersions(pluginCfgProps);
 
-        // check if the plugin has a healthCheck() function
-        if (!Object.prototype.hasOwnProperty.call(pluginCfgProps.impConfig, "pluginHealthCheck")) {
-            this.pluginIssues.recordIssue(pluginCfgProps.pluginName, IssueSeverity.WARNING,
-                "The plugin's configuration does not contain an '" +
-                this.impConfigPropNm + ".pluginHealthCheck' property.");
-        } else {
-            const healthChkModulePath =
-                this.formPluginRuntimePath(pluginCfgProps.pluginName, pluginCfgProps.impConfig.pluginHealthCheck);
-            const healthChkFilePath = healthChkModulePath + ".js";
-            if (existsSync(healthChkFilePath)) {
-                // replace relative path with absolute path in the healthCheck property
-                pluginCfgProps.impConfig.pluginHealthCheck = healthChkModulePath;
-            } else {
-                this.pluginIssues.recordIssue(pluginCfgProps.pluginName, IssueSeverity.CFG_ERROR,
-                    "The program for the '" + this.impConfigPropNm +
-                    ".pluginHealthCheck' property does not exist: " + healthChkFilePath);
-            }
-        }
-
         /* If a plugin does neither of the following actions, we reject it:
          *   - define commands
          *   - override an infrastructure component


### PR DESCRIPTION

**What It Does**

<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

PluginHealthCheck is deprecated, so plugin validation will no longer require pluginHealthCheck to be supplied by a plugin.

**How to Test**

<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Install (or validate) a plugin that does not have the pluginHealthCheck property (or has the property but the related file does not exist). No warning about the pluginHealthCheck should be displayed.

**Review Checklist**

I certify that I have:

- [x] tested my changes

- [x] added/updated automated tests

- [x] updated the changelog

- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**

<!-- Anything else noteworthy about this pull request. This section is optional. -->

Closes #980
