### PR TITLE
Fix logic error in config list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Imperative package will be documented in this file.
 ## Recent Changes
 
 - Enhancement: Added the function IO.giveAccessOnlyToOwner to restrict access to only the currently running user ID.
+- BugFix: Fixed a logic error in the `config list` command that caused unwanted behavior when a positional and `--locations` were both passed in.
 
 ## `5.13.2`
 

--- a/packages/imperative/__tests__/config/cmd/list/list.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/list/list.handler.test.ts
@@ -13,6 +13,7 @@ jest.mock("../../../../../utilities/src/ImperativeConfig");
 
 import { Config, ConfigConstants, IConfig, IConfigLayer } from "../../../../../config";
 import { ImperativeConfig } from "../../../../../utilities";
+import { cloneDeep } from "lodash";
 import ListHandler from "../../../../src/config/cmd/list/list.handler";
 
 let dataObj: any;
@@ -75,7 +76,7 @@ const configLayers: IConfigLayer[] = [
     { exists: false, properties: Config.empty() } as any
 ];
 
-const configMaskedProps: IConfig = configLayers[0].properties;
+const configMaskedProps: IConfig = cloneDeep(configLayers[0].properties); // Because otherwise it is modifying the original
 configMaskedProps.profiles.email.properties.user = ConfigConstants.SECURE_VALUE;
 
 describe("Configuration List command handler", () => {
@@ -139,13 +140,25 @@ describe("Configuration List command handler", () => {
         expect(formatObj).toEqual(dataObj);
     });
 
-    it("should output config property listed by location", async () => {
+    it("should output config property listed by location 1", async () => {
         (fakeConfig as any).mLayers = configLayers;
         handlerParms.arguments = { locations: true, property: "plugins" };
 
         await (new ListHandler()).process(handlerParms);
         expect(errorText).toBeNull();
         expect(dataObj.fakePath).toEqual(["fakePlugin"]);
+        expect(formatObj).toEqual(dataObj);
+    });
+
+    it("should output config property listed by location 2", async () => {
+        (fakeConfig as any).mLayers = configLayers;
+        handlerParms.arguments = { locations: true, property: "profiles" };
+
+        await (new ListHandler()).process(handlerParms);
+        expect(errorText).toBeNull();
+        expect(dataObj.fakePath).toEqual(configMaskedProps.profiles);
+        expect(dataObj.fakePath.email.properties.user).toBe(ConfigConstants.SECURE_VALUE);
+        expect(dataObj.fakePath.email.properties.password).toBeUndefined();
         expect(formatObj).toEqual(dataObj);
     });
 

--- a/packages/imperative/src/config/cmd/list/list.handler.ts
+++ b/packages/imperative/src/config/cmd/list/list.handler.ts
@@ -33,8 +33,6 @@ export default class ListHandler implements ICommandHandler {
                 for (const layer of config.layers) {
                     if (layer.exists) {
                         obj[layer.path] = layer.properties;
-                        if (property != null)
-                            obj[layer.path] = (layer.properties as any)[property];
                         if (obj[layer.path] != null) {
                             for (const secureProp of config.api.secure.secureFields(layer)) {
                                 if (lodash.has(obj[layer.path], secureProp)) {
@@ -42,6 +40,8 @@ export default class ListHandler implements ICommandHandler {
                                 }
                             }
                         }
+                        if (property != null)
+                            obj[layer.path] = (layer.properties as any)[property];
                     }
                 }
             } else {
@@ -52,11 +52,8 @@ export default class ListHandler implements ICommandHandler {
         }
 
         // If requested, only include the root property
-        if (params.arguments.root && !Array.isArray(obj)) {
-            const root = [];
-            for (const p of Object.keys(obj))
-                root.push(p);
-            obj = root;
+        if (params.arguments.root && lodash.isObject(obj)) {
+            obj = Object.keys(obj);
         }
 
         // output to terminal


### PR DESCRIPTION
**What It Does**
Fixes a logic error that causes unwanted behavior when both a positional and `--locations` are passed into the `zowe config list` command.

**How to Test**
Using the latest CLI, try the command described above with a configuration file. Link this branch of Imperative to the CLI, attempt a command as described above with a configuration file. Observe that the undesired behavior no longer occurs.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
