### PR TITLE
Check for nulls in the Definition Tree Resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Handle logic for if a null command handler is provided
+
 
 ## `5.14.1`
 

--- a/packages/imperative/__tests__/DefinitionTreeResolver.test.ts
+++ b/packages/imperative/__tests__/DefinitionTreeResolver.test.ts
@@ -13,6 +13,25 @@ import { DefinitionTreeResolver } from "../src/DefinitionTreeResolver";
 import { ImperativeError } from "../../error";
 import { Logger } from "../../logger";
 import { Console } from "../../console";
+import { ICommandDefinition } from "../../cmd";
+
+const fakeDefinition: ICommandDefinition = {
+    name: "users",
+    aliases: ["u"],
+    description: "Users list",
+    type: "command",
+    handler: "/no/exist/some.handler",
+    options: [
+        {
+            name: "host",
+            description: "Hostname",
+            type: "string",
+        }
+    ],
+    profile: {
+        required: ["sample"]
+    }
+};
 
 describe("DefinitionTreeResolver tests", () => {
 
@@ -40,6 +59,51 @@ describe("DefinitionTreeResolver tests", () => {
 
     it("should match on glob with dummy handler", () => {
         const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), [], ["**/*.definition!(.d).*s"]);
+        expect(def.children).toBeDefined();
+        expect(def.children.length).toBe(1);
+        expect(def.children[0].profile).toBeDefined();
+        expect(def.children[0].profile.required).toEqual(["sample"]);
+        expect(def.children[0].profile.optional).toBeUndefined();
+    });
+
+    it("should match on definition with dummy handler", () => {
+        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), [fakeDefinition], []);
+        expect(def.children).toBeDefined();
+        expect(def.children.length).toBe(1);
+        expect(def.children[0].profile).toBeDefined();
+        expect(def.children[0].profile.required).toEqual(["sample"]);
+        expect(def.children[0].profile.optional).toBeUndefined();
+    });
+
+    it("should match on glob with dummy handler with null child definitions", () => {
+        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), null, ["**/*.definition!(.d).*s"]);
+        expect(def.children).toBeDefined();
+        expect(def.children.length).toBe(1);
+        expect(def.children[0].profile).toBeDefined();
+        expect(def.children[0].profile.required).toEqual(["sample"]);
+        expect(def.children[0].profile.optional).toBeUndefined();
+    });
+
+    it("should match on glob with dummy handler with undefined child definitions", () => {
+        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), undefined, ["**/*.definition!(.d).*s"]);
+        expect(def.children).toBeDefined();
+        expect(def.children.length).toBe(1);
+        expect(def.children[0].profile).toBeDefined();
+        expect(def.children[0].profile.required).toEqual(["sample"]);
+        expect(def.children[0].profile.optional).toBeUndefined();
+    });
+
+    it("should match on child definition with undefined glob", () => {
+        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), [fakeDefinition], undefined);
+        expect(def.children).toBeDefined();
+        expect(def.children.length).toBe(1);
+        expect(def.children[0].profile).toBeDefined();
+        expect(def.children[0].profile.required).toEqual(["sample"]);
+        expect(def.children[0].profile.optional).toBeUndefined();
+    });
+
+    it("should match on child definition with null glob", () => {
+        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), [fakeDefinition], null);
         expect(def.children).toBeDefined();
         expect(def.children.length).toBe(1);
         expect(def.children[0].profile).toBeDefined();

--- a/packages/imperative/__tests__/DefinitionTreeResolver.test.ts
+++ b/packages/imperative/__tests__/DefinitionTreeResolver.test.ts
@@ -76,7 +76,7 @@ describe("DefinitionTreeResolver tests", () => {
     });
 
     it("should match on glob with dummy handler with null child definitions", () => {
-        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), null, ["**/*.definition!(.d).*s"]);
+        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), null as any, ["**/*.definition!(.d).*s"]);
         expect(def.children).toBeDefined();
         expect(def.children.length).toBe(1);
         expect(def.children[0].profile).toBeDefined();
@@ -103,7 +103,7 @@ describe("DefinitionTreeResolver tests", () => {
     });
 
     it("should match on child definition with null glob", () => {
-        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), [fakeDefinition], null);
+        const def = DefinitionTreeResolver.resolve("", "", __dirname, new Logger(new Console()), [fakeDefinition], null as any);
         expect(def.children).toBeDefined();
         expect(def.children.length).toBe(1);
         expect(def.children[0].profile).toBeDefined();

--- a/packages/imperative/src/DefinitionTreeResolver.ts
+++ b/packages/imperative/src/DefinitionTreeResolver.ts
@@ -46,8 +46,7 @@ export class DefinitionTreeResolver {
                 "to Imperative. Specify modules and/or definitions on your Imperative" +
                 "configuration."
             });
-        }
-        if (childrenDefinitions == null) {
+        } else if (childrenDefinitions == null) {
             childrenDefinitions = [];
         } else if (childrenModuleGlobs == null) {
             childrenModuleGlobs = [];

--- a/packages/imperative/src/DefinitionTreeResolver.ts
+++ b/packages/imperative/src/DefinitionTreeResolver.ts
@@ -47,6 +47,11 @@ export class DefinitionTreeResolver {
                 "configuration."
             });
         }
+        if (childrenDefinitions == null) {
+            childrenDefinitions = [];
+        } else if (childrenModuleGlobs == null) {
+            childrenModuleGlobs = [];
+        }
         const root: ICommandDefinition =
             {
                 name: "",
@@ -90,7 +95,7 @@ export class DefinitionTreeResolver {
      */
     public static combineAllCmdDefs(
         callerDir: string,
-        cmdDefs: ICommandDefinition[]= [],
+        cmdDefs: ICommandDefinition[] = [],
         cmdModuleGlobs: string[] = [],
         addBaseProfile?: boolean
     ): ICommandDefinition[] {


### PR DESCRIPTION
**What It Does**
Checks for nulls in the DefinitionTreeResolver to fix scans.

**How to Test**
N/A

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->