### PR TITLE
Handle new APIML unique cookie identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Imperative package will be documented in this file.
 
 - Enhancement: Handled unique cookie identifier in the form of dynamic token types. [#966](https://github.com/zowe/imperative/pull/996)
 - Enhancement: Added a new utility method to `ImperativeExpect` to match regular expressions. [#966](https://github.com/zowe/imperative/pull/996)
-- Enhancement: Added support for mutliple login operations in a single `config secure` command execution. [#966](https://github.com/zowe/imperative/pull/996)
+- Enhancement: Added support for multiple login operations in a single `config secure` command execution. [#966](https://github.com/zowe/imperative/pull/996)
 - BugFix: Allowed for multiple `auth logout` operations. [#966](https://github.com/zowe/imperative/pull/996)
 - BugFix: Prevented `auto-init` from sending two `login` requests to the server. [#966](https://github.com/zowe/imperative/pull/996)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Handled unique cookie identifier in the form of dynamic token types. [#966](https://github.com/zowe/imperative/pull/996)
+- Enhancement: Added a new utility method to `ImperativeExpect` to match regular expressions. [#966](https://github.com/zowe/imperative/pull/996)
+- Enhancement: Added support for mutliple login operations in a single `config secure` command execution. [#966](https://github.com/zowe/imperative/pull/996)
+- BugFix: Allowed for multiple `auth logout` operations. [#966](https://github.com/zowe/imperative/pull/996)
+- BugFix: Prevented `auto-init` from sending two `login` requests to the server. [#966](https://github.com/zowe/imperative/pull/996)
+
+
 ## `5.15.0`
 
 - Enhancement: Enabled users to display errors in a more user-friendly format with the ZOWE_V3_ERR_FORMAT environment variable. [zowe-cli#935](https://github.com/zowe/zowe-cli/issues/935)

--- a/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.logout.fruit.integration.test.ts
+++ b/__tests__/__integration__/imperative/__tests__/__integration__/cli/auth/imperative.test.cli.auth.logout.fruit.integration.test.ts
@@ -19,9 +19,9 @@ import * as keytar from "keytar";
 let TEST_ENVIRONMENT: ITestEnvironment;
 describe("imperative-test-cli auth logout", () => {
     async function loadSecureProp(profileName: string): Promise<string> {
-        const securedValue = await keytar.getPassword("imperative-test-cli", "secure_config_props");
+        const securedValue = await keytar.getPassword("imperative-test-cli", "secure_config_props") as string;
         const securedValueJson = JSON.parse(Buffer.from(securedValue, "base64").toString());
-        return Object.values(securedValueJson)[0][`profiles.${profileName}.properties.tokenValue`];
+        return Object.values(securedValueJson)[0]?.[`profiles.${profileName}.properties.tokenValue`];
     }
 
     // Create the unique test environment
@@ -121,6 +121,7 @@ describe("imperative-test-cli auth logout", () => {
     it("should have auth logout command that invalidates another token", async () => {
         let response = runCliScript(__dirname + "/__scripts__/base_profile_and_auth_login_config_local.sh",
             TEST_ENVIRONMENT.workingDir + "/testDir", ["fakeUser", "fakePass"]);
+        expect(response.error).toBeFalsy();
         expect(response.stderr.toString()).toBe("");
         expect(response.status).toBe(0);
 

--- a/packages/config/__tests__/Config.api.test.ts
+++ b/packages/config/__tests__/Config.api.test.ts
@@ -216,6 +216,35 @@ describe("Config API tests", () => {
                 expect(profile).toBeNull();
             });
         });
+        describe("expandPath", () => {
+            it("should expand a short proeprty path", async () => {
+                const config = await Config.load(MY_APP);
+                const profilePath = "lpar1.zosmf";
+                expect(config.api.profiles.expandPath(profilePath)).toEqual("profiles.lpar1.profiles.zosmf");
+            });
+            it.skip("should not expand a complete path", async () => {
+                const config = await Config.load(MY_APP);
+                const profilePath = "profiles.lpar1.profiles.zosmf";
+                expect(config.api.profiles.expandPath(profilePath)).toEqual("profiles.lpar1.profiles.zosmf");
+            });
+            it.skip("should expand an incomplete path", async () => {
+                const config = await Config.load(MY_APP);
+                const profilePath = "profiles.lpar1.zosmf";
+                expect(config.api.profiles.expandPath(profilePath)).toEqual("profiles.lpar1.profiles.zosmf");
+            });
+        });
+        describe("getProfileNameFromPath", () => {
+            it("should shrink profile paths", async () => {
+                const config = await Config.load(MY_APP);
+                const propertyPath = "profiles.lpar1.profiles.zosmf.properties.host";
+                expect(config.api.profiles.getProfileNameFromPath(propertyPath)).toEqual("lpar1.zosmf");
+            });
+            it("should shrink incorrect profile paths", async () => {
+                const config = await Config.load(MY_APP);
+                const propertyPath = "profiles.profiles.lpar1.profiles.profiles.zosmf.profiles.properties.host";
+                expect(config.api.profiles.getProfileNameFromPath(propertyPath)).toEqual("lpar1.zosmf");
+            });
+        });
     });
     describe("plugins", () => {
         describe("get", () => {

--- a/packages/config/__tests__/Config.api.test.ts
+++ b/packages/config/__tests__/Config.api.test.ts
@@ -222,15 +222,10 @@ describe("Config API tests", () => {
                 const profilePath = "lpar1.zosmf";
                 expect(config.api.profiles.expandPath(profilePath)).toEqual("profiles.lpar1.profiles.zosmf");
             });
-            it.skip("should not expand a complete path", async () => {
+            it("should expand a path with the keyword profiles", async () => {
                 const config = await Config.load(MY_APP);
-                const profilePath = "profiles.lpar1.profiles.zosmf";
-                expect(config.api.profiles.expandPath(profilePath)).toEqual("profiles.lpar1.profiles.zosmf");
-            });
-            it.skip("should expand an incomplete path", async () => {
-                const config = await Config.load(MY_APP);
-                const profilePath = "profiles.lpar1.zosmf";
-                expect(config.api.profiles.expandPath(profilePath)).toEqual("profiles.lpar1.profiles.zosmf");
+                const profilePath = "profiles.zosmf";
+                expect(config.api.profiles.expandPath(profilePath)).toEqual("profiles.profiles.profiles.zosmf");
             });
         });
         describe("getProfileNameFromPath", () => {
@@ -239,10 +234,10 @@ describe("Config API tests", () => {
                 const propertyPath = "profiles.lpar1.profiles.zosmf.properties.host";
                 expect(config.api.profiles.getProfileNameFromPath(propertyPath)).toEqual("lpar1.zosmf");
             });
-            it("should shrink incorrect profile paths", async () => {
+            it("should shrink profile paths with the keyword profiles", async () => {
                 const config = await Config.load(MY_APP);
-                const propertyPath = "profiles.profiles.lpar1.profiles.profiles.zosmf.profiles.properties.host";
-                expect(config.api.profiles.getProfileNameFromPath(propertyPath)).toEqual("lpar1.zosmf");
+                const propertyPath = "profiles.profiles.profiles.zosmf.properties.host";
+                expect(config.api.profiles.getProfileNameFromPath(propertyPath)).toEqual("profiles.zosmf");
             });
         });
     });

--- a/packages/config/__tests__/ConfigAutoStore.test.ts
+++ b/packages/config/__tests__/ConfigAutoStore.test.ts
@@ -167,7 +167,7 @@ describe("ConfigAutoStore tests", () => {
             expect(authHandler).toBeUndefined();
         });
 
-        it("should not find auth handler if profile base path is undefined", async () => {
+        it("should find auth handler if profile base path is undefined", async () => {
             await setupConfigToLoad({
                 profiles: {
                     base: {
@@ -185,7 +185,8 @@ describe("ConfigAutoStore tests", () => {
             });
 
             const authHandler = ConfigAutoStore.findAuthHandlerForProfile("profiles.zosmf", {} as any);
-            expect(authHandler).toBeUndefined();
+            expect(authHandler).toBeDefined();
+            expect(authHandler instanceof AbstractAuthHandler).toBe(true);
         });
     });
 

--- a/packages/config/__tests__/ConfigAutoStore.test.ts
+++ b/packages/config/__tests__/ConfigAutoStore.test.ts
@@ -67,6 +67,24 @@ describe("ConfigAutoStore tests", () => {
             expect(authHandler instanceof AbstractAuthHandler).toBe(true);
         });
 
+        it("should be able to find auth handler for base profile with a dynamic token type", async () => {
+            await setupConfigToLoad({
+                profiles: {
+                    base: {
+                        type: "base",
+                        properties: {
+                            tokenType: SessConstants.TOKEN_TYPE_JWT + ".1"
+                        }
+                    }
+                },
+                defaults: { base: "base" }
+            });
+
+            const authHandler = ConfigAutoStore.findAuthHandlerForProfile("profiles.base", {} as any);
+            expect(authHandler).toBeDefined();
+            expect(authHandler instanceof AbstractAuthHandler).toBe(true);
+        });
+
         it("should be able to find auth handler for service profile", async () => {
             await setupConfigToLoad({
                 profiles: {

--- a/packages/config/__tests__/ConfigAutoStore.test.ts
+++ b/packages/config/__tests__/ConfigAutoStore.test.ts
@@ -67,7 +67,25 @@ describe("ConfigAutoStore tests", () => {
             expect(authHandler instanceof AbstractAuthHandler).toBe(true);
         });
 
-        it("should be able to find auth handler for base profile with a dynamic token type", async () => {
+        it("should be able to find auth handler for base profile with a dynamic APIML token type", async () => {
+            await setupConfigToLoad({
+                profiles: {
+                    base: {
+                        type: "base",
+                        properties: {
+                            tokenType: SessConstants.TOKEN_TYPE_APIML + ".1"
+                        }
+                    }
+                },
+                defaults: { base: "base" }
+            });
+
+            const authHandler = ConfigAutoStore.findAuthHandlerForProfile("profiles.base", {} as any);
+            expect(authHandler).toBeDefined();
+            expect(authHandler instanceof AbstractAuthHandler).toBe(true);
+        });
+
+        it("should  not be able to find auth handler for base profile with a dynamic JWT token type", async () => {
             await setupConfigToLoad({
                 profiles: {
                     base: {
@@ -81,8 +99,7 @@ describe("ConfigAutoStore tests", () => {
             });
 
             const authHandler = ConfigAutoStore.findAuthHandlerForProfile("profiles.base", {} as any);
-            expect(authHandler).toBeDefined();
-            expect(authHandler instanceof AbstractAuthHandler).toBe(true);
+            expect(authHandler).toBeUndefined();
         });
 
         it("should be able to find auth handler for service profile", async () => {

--- a/packages/config/__tests__/ConfigAutoStore.test.ts
+++ b/packages/config/__tests__/ConfigAutoStore.test.ts
@@ -167,7 +167,7 @@ describe("ConfigAutoStore tests", () => {
             expect(authHandler).toBeUndefined();
         });
 
-        it("should find auth handler if profile base path is undefined", async () => {
+        it("should not find auth handler if service profile base path is undefined", async () => {
             await setupConfigToLoad({
                 profiles: {
                     base: {
@@ -185,8 +185,7 @@ describe("ConfigAutoStore tests", () => {
             });
 
             const authHandler = ConfigAutoStore.findAuthHandlerForProfile("profiles.zosmf", {} as any);
-            expect(authHandler).toBeDefined();
-            expect(authHandler instanceof AbstractAuthHandler).toBe(true);
+            expect(authHandler).toBeUndefined();
         });
     });
 

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -79,12 +79,10 @@ export class ConfigAutoStore {
         const profileType = lodash.get(config.properties, `${opts.profilePath}.type`);
         const profile = config.api.profiles.get(opts.profilePath.replace(/profiles\./g, ""), false);
 
-        if (profile == null || (profileType == null && profile.tokenType == null)) {  // Profile must exist and have type defined
+        if (profile == null || profileType == null) {  // Profile must exist and have type defined
             return;
-        } else if (profileType === "base") {
-            if (profile.tokenType == null) {  // Base profile must have tokenType defined
-                return;
-            }
+        } else if (profileType === "base" && profile.tokenType == null) {  // Base profile must have tokenType defined
+            return;
         } else if (profile.tokenType == null) {  // If tokenType undefined in service profile, fall back to base profile
             const baseProfileName = ConfigUtils.getActiveProfileName("base", opts.cmdArguments, opts.defaultBaseProfileName);
             return this._findAuthHandlerForProfile({ ...opts, profilePath: config.api.profiles.getProfilePathFromName(baseProfileName) });

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -79,13 +79,20 @@ export class ConfigAutoStore {
         const profileType = lodash.get(config.properties, `${opts.profilePath}.type`);
         const profile = config.api.profiles.get(opts.profilePath.replace(/profiles\./g, ""), false);
 
-        if (profile == null || profileType == null) {  // Profile must exist and have type defined
+        if (profile == null || profileType == null) { // Profile must exist and have type defined
             return;
-        } else if (profileType === "base" && profile.tokenType == null) {  // Base profile must have tokenType defined
-            return;
-        } else if (profile.tokenType == null) {  // If tokenType undefined in service profile, fall back to base profile
-            const baseProfileName = ConfigUtils.getActiveProfileName("base", opts.cmdArguments, opts.defaultBaseProfileName);
-            return this._findAuthHandlerForProfile({ ...opts, profilePath: config.api.profiles.getProfilePathFromName(baseProfileName) });
+        } else if (profileType === "base") {
+            if (profile.tokenType == null) { // Base profile must have tokenType defined
+                return;
+            }
+        } else {
+            if (profile.basePath == null) { // Service profiles must have basePath defined
+                return;
+            }
+            if (profile.tokenType == null) {  // If tokenType undefined in service profile, fall back to base profile
+                const baseProfileName = ConfigUtils.getActiveProfileName("base", opts.cmdArguments, opts.defaultBaseProfileName);
+                return this._findAuthHandlerForProfile({ ...opts, profilePath: config.api.profiles.getProfilePathFromName(baseProfileName) });
+            }
         }
 
         const authConfigs: ICommandProfileAuthConfig[] = [];

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -106,7 +106,7 @@ export class ConfigAutoStore {
 
             if (authHandlerClass instanceof AbstractAuthHandler) {
                 const { promptParams } = authHandlerClass.getAuthHandlerApi();
-                if (profile.tokenType === promptParams.defaultTokenType) {
+                if (profile.tokenType.startsWith(promptParams.defaultTokenType)) {
                     return authHandlerClass;  // Auth service must have matching token type
                 }
             }

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -79,19 +79,15 @@ export class ConfigAutoStore {
         const profileType = lodash.get(config.properties, `${opts.profilePath}.type`);
         const profile = config.api.profiles.get(opts.profilePath.replace(/profiles\./g, ""), false);
 
-        if (profile == null || profileType == null) {  // Profile must exist and have type defined
+        if (profile == null || (profileType == null && profile.tokenType == null)) {  // Profile must exist and have type defined
             return;
         } else if (profileType === "base") {
             if (profile.tokenType == null) {  // Base profile must have tokenType defined
                 return;
             }
-        } else {
-            if (profile.basePath == null) {  // Service profiles must have basePath defined
-                return;
-            } else if (profile.tokenType == null) {  // If tokenType undefined in service profile, fall back to base profile
-                const baseProfileName = ConfigUtils.getActiveProfileName("base", opts.cmdArguments, opts.defaultBaseProfileName);
-                return this._findAuthHandlerForProfile({ ...opts, profilePath: config.api.profiles.getProfilePathFromName(baseProfileName) });
-            }
+        } else if (profile.tokenType == null) {  // If tokenType undefined in service profile, fall back to base profile
+            const baseProfileName = ConfigUtils.getActiveProfileName("base", opts.cmdArguments, opts.defaultBaseProfileName);
+            return this._findAuthHandlerForProfile({ ...opts, profilePath: config.api.profiles.getProfilePathFromName(baseProfileName) });
         }
 
         const authConfigs: ICommandProfileAuthConfig[] = [];

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -236,7 +236,7 @@ export class ConfigAutoStore {
 
         const api = authHandlerClass.getAuthHandlerApi();
         opts.sessCfg.type = AUTH_TYPE_TOKEN;
-        opts.sessCfg.tokenType = opts.params.arguments.tokenType ?? api.promptParams.defaultTokenType;
+        opts.sessCfg.tokenType = opts.params?.arguments?.tokenType ?? api.promptParams.defaultTokenType;
         const baseSessCfg: ISession = { type: opts.sessCfg.type };
 
         for (const propName of Object.keys(ImperativeConfig.instance.loadedConfig.baseProfile.schema.properties)) {

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -18,14 +18,13 @@ import { AbstractAuthHandler } from "../../imperative/src/auth/handlers/Abstract
 import { ImperativeConfig } from "../../utilities";
 import { ISession } from "../../rest/src/session/doc/ISession";
 import { Session } from "../../rest/src/session/Session";
-import { AUTH_TYPE_TOKEN } from "../../rest/src/session/SessConstants";
+import { AUTH_TYPE_TOKEN, TOKEN_TYPE_APIML } from "../../rest/src/session/SessConstants";
 import { Logger } from "../../logger";
 import {
     IConfigAutoStoreFindActiveProfileOpts,
     IConfigAutoStoreFindAuthHandlerForProfileOpts,
     IConfigAutoStoreStoreSessCfgPropsOpts
 } from "./doc/IConfigAutoStoreOpts";
-import { TOKEN_TYPE_APIML } from "../../rest/src/session/SessConstants";
 
 /**
  * Class to manage automatic storage of properties in team config.

--- a/packages/config/src/ConfigAutoStore.ts
+++ b/packages/config/src/ConfigAutoStore.ts
@@ -236,7 +236,7 @@ export class ConfigAutoStore {
 
         const api = authHandlerClass.getAuthHandlerApi();
         opts.sessCfg.type = AUTH_TYPE_TOKEN;
-        opts.sessCfg.tokenType = api.promptParams.defaultTokenType;
+        opts.sessCfg.tokenType = opts.params.arguments.tokenType ?? api.promptParams.defaultTokenType;
         const baseSessCfg: ISession = { type: opts.sessCfg.type };
 
         for (const propName of Object.keys(ImperativeConfig.instance.loadedConfig.baseProfile.schema.properties)) {
@@ -248,6 +248,7 @@ export class ConfigAutoStore {
 
         Logger.getAppLogger().info(`Fetching ${opts.sessCfg.tokenType} for ${opts.profilePath}`);
         opts.sessCfg.tokenValue = await api.sessionLogin(new Session(baseSessCfg));
+        opts.sessCfg.user = opts.sessCfg.password = undefined;
         return true;
     }
 }

--- a/packages/config/src/ConfigConstants.ts
+++ b/packages/config/src/ConfigConstants.ts
@@ -27,4 +27,9 @@ export class ConfigConstants {
      * ID used for storing secure credentials in vault
      */
     public static readonly SECURE_ACCT = "secure_config_props";
+
+    /**
+     * ID used for storing secure credentials in vault
+     */
+    public static readonly SKIP_PROMPT = "- Press ENTER to skip: ";
 }

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -449,7 +449,7 @@ export class ProfileInfo {
             const foundProfNm = configProperties.defaults[profileType];
 
             // for a team config, we use the last node of the jsonLoc as the name
-            const foundJson = this.mLoadedConfig.api.profiles.expandPath(foundProfNm);
+            const foundJson = this.mLoadedConfig.api.profiles.getProfilePathFromName(foundProfNm);
             const teamOsLocation: string[] = this.findTeamOsLocation(foundJson);
 
             // assign the required poperties to defaultProfile
@@ -1330,7 +1330,7 @@ export class ProfileInfo {
      * @param opts Set of options that allow this method to get the profile location
      */
     private argTeamConfigLoc(opts: IArgTeamConfigLoc): [IProfLoc, boolean] {
-        const segments = this.mLoadedConfig.api.profiles.expandPath(opts.profileName).split(".profiles.");
+        const segments = this.mLoadedConfig.api.profiles.getProfilePathFromName(opts.profileName).split(".profiles.");
         let osLocInfo: IProfLocOsLocLayer;
         if (opts.osLocInfo?.user != null || opts.osLocInfo?.global != null)
             osLocInfo = { user: opts.osLocInfo?.user, global: opts.osLocInfo?.global };

--- a/packages/config/src/api/ConfigLayers.ts
+++ b/packages/config/src/api/ConfigLayers.ts
@@ -196,7 +196,7 @@ export class ConfigLayers extends ConfigApi {
      * @returns User and global properties, or undefined if profile does not exist
      */
     public find(profileName: string): { user: boolean, global: boolean } {
-        const profilePath = this.mConfig.api.profiles.expandPath(profileName);
+        const profilePath = this.mConfig.api.profiles.getProfilePathFromName(profileName);
         for (const layer of this.mConfig.layers) {
             if (lodash.get(layer.properties, profilePath) != null) {
                 return layer;

--- a/packages/config/src/api/ConfigProfiles.ts
+++ b/packages/config/src/api/ConfigProfiles.ts
@@ -123,10 +123,13 @@ export class ConfigProfiles extends ConfigApi {
      */
     public getProfileNameFromPath(path: string): string {
         let profileName = "";
-        for (const p of path.split(".")) {
-            if (p === "profiles") continue;
+        const segments = path.split(".");
+        for (let i = 0; i < segments.length; i++) {
+            const p = segments[i];
             if (p === "properties") break;
-            profileName += profileName.length > 0 ? "." + p : p;
+            if (i%2) {
+                profileName += profileName.length > 0 ? "." + p : p;
+            }
         }
         return profileName;
     }

--- a/packages/config/src/api/ConfigProfiles.ts
+++ b/packages/config/src/api/ConfigProfiles.ts
@@ -112,6 +112,27 @@ export class ConfigProfiles extends ConfigApi {
 
     // _______________________________________________________________________
     /**
+     * Obtain the profile name (either nested or not) based on a property path.
+     *
+     * @param path The property path.
+     *
+     * @returns The corresponding profile name.
+     *
+     * @note This may be useful for supporting token authentication in a nested configuration
+     *
+     */
+    public getProfileNameFromPath(path: string): string {
+        let profileName = "";
+        for (const p of path.split(".")) {
+            if (p === "profiles") continue;
+            if (p === "properties") break;
+            profileName += profileName.length > 0 ? "." + p : p;
+        }
+        return profileName;
+    }
+
+    // _______________________________________________________________________
+    /**
      * Build the set of properties contained within a set of nested profiles.
      *
      * @param path The dotted path of desired location.

--- a/packages/config/src/api/ConfigProfiles.ts
+++ b/packages/config/src/api/ConfigProfiles.ts
@@ -105,8 +105,21 @@ export class ConfigProfiles extends ConfigApi {
      *
      * @returns The expanded path.
      *
+     * @deprecated Please use getProfilePathFromName
      */
     public expandPath(shortPath: string): string {
+        return this.getProfilePathFromName(shortPath);
+    }
+
+    // _______________________________________________________________________
+    /**
+     * Expands a short path into an expanded path.
+     *
+     * @param shortPath The short path.
+     *
+     * @returns The expanded path.
+     */
+    public getProfilePathFromName(shortPath: string): string {
         return shortPath.replace(/(^|\.)/g, "$1profiles.");
     }
 

--- a/packages/config/src/api/ConfigSecure.ts
+++ b/packages/config/src/api/ConfigSecure.ts
@@ -201,7 +201,7 @@ export class ConfigSecure extends ConfigApi {
      * @returns Array of secure property names
      */
     public securePropsForProfile(profileName: string) {
-        const profilePath = this.mConfig.api.profiles.expandPath(profileName);
+        const profilePath = this.mConfig.api.profiles.getProfilePathFromName(profileName);
         const secureProps = [];
         for (const propPath of this.secureFields()) {
             const pathSegments = propPath.split(".");  // profiles.XXX.properties.YYY

--- a/packages/expect/__tests__/ImperativeExpect.test.ts
+++ b/packages/expect/__tests__/ImperativeExpect.test.ts
@@ -33,6 +33,26 @@ const nestedObj = {
 };
 
 describe("ImperativeExpect tests", () => {
+    describe("toMatchRegExp", () => {
+        it("should not throw an error if the value matches the provided regular expression", () => {
+            let error: ImperativeError = {} as any;
+            try {
+                ImperativeExpect.toMatchRegExp("token", "^token$");
+            } catch(thrownError) {
+                error = thrownError;
+            }
+            expect(error).toBeUndefined();
+        });
+        it("should throw an error if the value does not match the provided regular expression with custom message", () => {
+            let error: ImperativeError = {} as any;
+            try {
+                ImperativeExpect.toMatchRegExp("token", "^token1", "test");
+            } catch(thrownError) {
+                error = thrownError;
+            }
+            expect(error.message).toContain("test");
+        });
+    });
 
     it("Should throw an error for an undefined key when we expect it to be defined", () => {
         let error: ImperativeError;

--- a/packages/expect/__tests__/ImperativeExpect.test.ts
+++ b/packages/expect/__tests__/ImperativeExpect.test.ts
@@ -41,7 +41,7 @@ describe("ImperativeExpect tests", () => {
             } catch(thrownError) {
                 error = thrownError;
             }
-            expect(error).toBeUndefined();
+            expect(error).toEqual({});
         });
         it("should throw an error if the value does not match the provided regular expression with custom message", () => {
             let error: ImperativeError = {} as any;

--- a/packages/expect/src/ImperativeExpect.ts
+++ b/packages/expect/src/ImperativeExpect.ts
@@ -79,6 +79,21 @@ export class ImperativeExpect {
     }
 
     /**
+     * Expect that value matches the regular expression (via ".test()" method).
+     * @static
+     * @param {*} value - Value
+     * @param {*} myRegex - Regular expression
+     * @param {string} [msg] - The message to throw - overrides the default message
+     * @memberof ImperativeExpect
+     */
+    public static toMatchRegExp(value: any, myRegex: string, msg?: string) {
+        if (!(new RegExp(myRegex).test(value))) {
+            throw new ImperativeError({msg: msg || "Input object/value does not match the regular expression"},
+                {tag: ImperativeExpect.ERROR_TAG});
+        }
+    }
+
+    /**
      * Expect the object passed to be defined.
      * @static
      * @param {*} obj - The object to check

--- a/packages/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/auto-init/BaseAutoInitHandler.test.ts
@@ -17,7 +17,7 @@ import * as jestDiff from "jest-diff";
 import stripAnsi = require("strip-ansi");
 import { ConfigSchema } from "../../../../../config";
 import { CredentialManagerFactory } from "../../../../../security";
-import { SessConstants } from "../../../../../rest";
+import { SessConstants, Session } from "../../../../../rest";
 import { OverridesLoader } from "../../../../src/OverridesLoader";
 
 jest.mock("strip-ansi");
@@ -122,11 +122,18 @@ describe("BaseAutoInitHandler", () => {
 
     it("should call init with token", async () => {
         const handler = new FakeAutoInitHandler();
+        handler.createSessCfgFromArgs = jest.fn().mockReturnValue({
+            hostname: "fakeHost", port: 3000, tokenValue: "fake"
+        });
         const params: IHandlerParameters = {
             ...mockParams,
             arguments: {
                 tokenType: "fake",
-                tokenValue: "fake"
+                tokenValue: "fake",
+                user: "toBeDeleted",
+                password: "toBeDeleted",
+                cert: "toBeDeleted",
+                certKey: "toBeDeleted"
             }
         } as any;
 
@@ -158,8 +165,15 @@ describe("BaseAutoInitHandler", () => {
             caughtError = error;
         }
 
+        const mSession: Session = doInitSpy.mock.calls[0][0] as any;
+
         expect(caughtError).toBeUndefined();
         expect(doInitSpy).toBeCalledTimes(1);
+        expect(mSession.ISession.user).toBeUndefined();
+        expect(mSession.ISession.password).toBeUndefined();
+        expect(mSession.ISession.base64EncodedAuth).toBeUndefined();
+        expect(mSession.ISession.cert).toBeUndefined();
+        expect(mSession.ISession.certKey).toBeUndefined();
         expect(processAutoInitSpy).toBeCalledTimes(1);
         expect(createSessCfgFromArgsSpy).toBeCalledTimes(1);
         expect(mockConfigApi.layers.merge).toHaveBeenCalledTimes(1);

--- a/packages/imperative/__tests__/config/cmd/auto-init/__data__/FakeAutoInitHandler.ts
+++ b/packages/imperative/__tests__/config/cmd/auto-init/__data__/FakeAutoInitHandler.ts
@@ -16,7 +16,7 @@ import { ISession, AbstractSession } from "../../../../../../rest";
 export class FakeAutoInitHandler extends BaseAutoInitHandler {
     public mProfileType: string = "fruit";
 
-    protected createSessCfgFromArgs(args: ICommandArguments): ISession {
+    public createSessCfgFromArgs(args: ICommandArguments): ISession {
         return { hostname: "fakeHost", port: 3000 };
     }
 

--- a/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
@@ -152,7 +152,7 @@ describe("Configuration Initialization command handler", () => {
 
             expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(user ? 0 : 1); // User config is a skeleton - no prompting should occur
             // Prompting for secure property
-            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
             expect(editFileSpy).not.toHaveBeenCalled();
 
             expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
@@ -241,7 +241,7 @@ describe("Configuration Initialization command handler", () => {
 
             expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(user ? 0 : 1);
             // Prompting for secure property
-            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
             expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
 
@@ -449,7 +449,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -493,7 +493,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -539,7 +539,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -583,7 +583,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -637,7 +637,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -691,7 +691,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -747,7 +747,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(2);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("blank to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config

--- a/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/init/init.handler.test.ts
@@ -152,7 +152,7 @@ describe("Configuration Initialization command handler", () => {
 
             expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(user ? 0 : 1); // User config is a skeleton - no prompting should occur
             // Prompting for secure property
-            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
             expect(editFileSpy).not.toHaveBeenCalled();
 
             expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
@@ -241,7 +241,7 @@ describe("Configuration Initialization command handler", () => {
 
             expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(user ? 0 : 1);
             // Prompting for secure property
-            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+            if (!user) expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
             expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
 
@@ -449,7 +449,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -493,7 +493,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -539,7 +539,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -583,7 +583,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -637,7 +637,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -691,7 +691,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(1);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config
@@ -747,7 +747,7 @@ describe("Configuration Initialization command handler", () => {
 
         expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(2);
         // Prompting for secure property
-        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("Press ENTER to skip:"), {"hideText": true});
+        expect(promptWithTimeoutSpy).toHaveBeenCalledWith(expect.stringContaining("to skip:"), {"hideText": true});
 
         expect(writeFileSyncSpy).toHaveBeenCalledTimes(2);
         // 1 = Schema and 2 = Config

--- a/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
+++ b/packages/imperative/__tests__/config/cmd/secure/secure.handler.test.ts
@@ -9,9 +9,9 @@
 *
 */
 
-import { IHandlerParameters } from "../../../../..";
+import { IHandlerParameters, Logger } from "../../../../..";
 import { Config } from "../../../../../config/src/Config";
-import { IConfig, IConfigOpts } from "../../../../../config";
+import { IConfig, IConfigOpts, IConfigProfile } from "../../../../../config";
 import { ImperativeConfig } from "../../../../../utilities";
 import { IImperativeConfig } from "../../../../src/doc/IImperativeConfig";
 import { ICredentialManagerInit } from "../../../../../security/src/doc/ICredentialManagerInit";
@@ -497,20 +497,22 @@ describe("Configuration Secure command handler", () => {
     });
 
     describe("special prompting for auth token", () => {
+        const baseProfile: IConfigProfile = {
+            type: "base",
+            properties: {
+                host: "example.com",
+                port: 443,
+                tokenType: SessConstants.TOKEN_TYPE_JWT
+            },
+            secure: [
+                "tokenValue"
+            ]
+        };
+
         const expectedConfigObjectWithToken: IConfig = {
             $schema: "./fakeapp.schema.json",
             profiles: {
-                base: {
-                    type: "base",
-                    properties: {
-                        host: "example.com",
-                        port: 443,
-                        tokenType: SessConstants.TOKEN_TYPE_JWT
-                    },
-                    secure: [
-                        "tokenValue"
-                    ]
-                },
+                base: baseProfile,
             },
             defaults: {
                 base: "base"
@@ -569,6 +571,12 @@ describe("Configuration Secure command handler", () => {
         it("should invoke auth handler to obtain token and store it securely", async () => {
             const eco = lodash.cloneDeep(expectedConfigObjectWithToken);
 
+            // Create another base profile and mock the loggers to test multiple login operations in a single config-secure
+            eco.profiles["base2"] = baseProfile;
+            const dummyLogger: any = {debug: jest.fn(), info: jest.fn()};
+            jest.spyOn(Logger, "getImperativeLogger").mockReturnValue(dummyLogger);
+            jest.spyOn(Logger, "getAppLogger").mockReturnValue(dummyLogger);
+
             readFileSyncSpy.mockReturnValueOnce(JSON.stringify(eco));
             existsSyncSpy.mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false); // Only the project config exists
             writeFileSyncSpy.mockImplementation();
@@ -576,7 +584,8 @@ describe("Configuration Secure command handler", () => {
 
             await setupConfigToLoad(undefined, configOpts); // Setup the config
 
-            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValueOnce({
+            jest.spyOn(ImperativeConfig.instance, "loadedConfig", "get").mockReturnValue({
+                ...fakeConfig,
                 profiles: [{
                     type: "base",
                     authConfig: [{ handler: authHandlerPath } as any]
@@ -588,7 +597,8 @@ describe("Configuration Secure command handler", () => {
             const fakeSecureDataExpectedJson = lodash.cloneDeep(fakeSecureDataJson);
             delete fakeSecureDataExpectedJson[fakeProjPath];
             fakeSecureDataExpectedJson[fakeProjPath] = {
-                "profiles.base.properties.tokenValue": "fakeLoginData"
+                "profiles.base.properties.tokenValue": "fakeLoginData",
+                "profiles.base2.properties.tokenValue": "fakeLoginData"
             };
             const fakeSecureDataExpected = Buffer.from(JSON.stringify(fakeSecureDataExpectedJson)).toString("base64");
 
@@ -597,13 +607,14 @@ describe("Configuration Secure command handler", () => {
             compObj.$schema = "./fakeapp.schema.json"; // Fill in the name of the schema file, and make it first
             lodash.merge(compObj, ImperativeConfig.instance.config.properties); // Add the properties from the config
             delete compObj.profiles.base.properties.tokenValue;  // Delete the secret
+            delete compObj.profiles.base2.properties.tokenValue;  // Delete the secret
 
             expect(keytarDeletePasswordSpy).toHaveBeenCalledTimes(process.platform === "win32" ? 4 : 3);
             expect(keytarGetPasswordSpy).toHaveBeenCalledTimes(1);
             expect(keytarSetPasswordSpy).toHaveBeenCalledTimes(1);
-            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(2);  // User and password
-            expect(mockAuthHandlerApi.createSessCfg).toHaveBeenCalledTimes(1);
-            expect(mockAuthHandlerApi.sessionLogin).toHaveBeenCalledTimes(1);
+            expect(promptWithTimeoutSpy).toHaveBeenCalledTimes(4);  // User and password
+            expect(mockAuthHandlerApi.createSessCfg).toHaveBeenCalledTimes(2);
+            expect(mockAuthHandlerApi.sessionLogin).toHaveBeenCalledTimes(2);
             expect(keytarSetPasswordSpy).toHaveBeenCalledWith("Zowe", "secure_config_props", fakeSecureDataExpected);
             expect(writeFileSyncSpy).toHaveBeenCalledTimes(1);
             expect(writeFileSyncSpy).toHaveBeenNthCalledWith(1, fakeProjPath, JSON.stringify(compObj, null, 4)); // Config

--- a/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
+++ b/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
@@ -532,7 +532,7 @@ describe("BaseAuthHandler config", () => {
 
             expect(caughtError).toBeUndefined();
             expect(doLogoutSpy).toBeCalledTimes(1);
-            expect(writeFileSpy).not.toHaveBeenCalled();
+            expect(writeFileSpy).toBeCalledTimes(0);
             expect(fakeConfig.properties.profiles.fruit.properties.tokenType).toBeDefined();
             expect(fakeConfig.properties.profiles.fruit.properties.tokenValue).toBeDefined();
         });

--- a/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
+++ b/packages/imperative/src/auth/__tests__/BaseAuthHandler.config.test.ts
@@ -440,7 +440,12 @@ describe("BaseAuthHandler config", () => {
         const logoutParams: IHandlerParameters = {
             response: {
                 console: {
+                    error: jest.fn(),
+                    errorHeader: jest.fn(),
                     log: jest.fn()
+                },
+                data: {
+                    setExitCode: jest.fn()
                 }
             },
             arguments: {
@@ -454,6 +459,7 @@ describe("BaseAuthHandler config", () => {
         } as any;
 
         beforeEach(async () => {
+            jest.restoreAllMocks();
             jest.spyOn(Config, "search").mockReturnValue(configPath);
             jest.spyOn(fs, "existsSync").mockReturnValueOnce(false).mockReturnValueOnce(true).mockReturnValue(false);
             fakeConfig = await Config.load(MY_APP, { vault: fakeVault });
@@ -554,6 +560,121 @@ describe("BaseAuthHandler config", () => {
             expect(caughtError).toBeUndefined();
             expect(doLogoutSpy).toBeCalledTimes(1);
             expect(writeFileSpy).not.toHaveBeenCalled();
+        });
+
+        it("should not logout without a token", async () => {
+            const handler = new FakeAuthHandler();
+            const params = lodash.cloneDeep(logoutParams);
+            delete params.arguments.tokenValue;
+
+            const doLogoutSpy = jest.spyOn(handler as any, "doLogout");
+            const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+
+            let caughtError;
+
+            try {
+                await handler.process(params);
+            } catch (error) {
+                caughtError = error;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(doLogoutSpy).not.toHaveBeenCalled();
+            expect(writeFileSpy).not.toHaveBeenCalled();
+            expect((params.response.console.error as any).mock.calls[0][0]).toContain("Token was not provided");
+            expect(params.response.data.setExitCode).toHaveBeenCalledWith(1);
+        });
+
+        it("should not touch the config file if there is no profile to modify", async () => {
+            const handler = new FakeAuthHandler();
+            const params = lodash.cloneDeep(logoutParams);
+
+            const doLogoutSpy = jest.spyOn(handler as any, "doLogout").mockRejectedValueOnce({errorCode: "401"});
+            const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+
+            let caughtError;
+
+            try {
+                await handler.process(params);
+            } catch (error) {
+                caughtError = error;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(doLogoutSpy).toHaveBeenCalled();
+            expect(writeFileSpy).not.toHaveBeenCalled();
+            expect((params.response.console.log as any).mock.calls[0][0]).toContain("Token is not valid or expired");
+            expect((params.response.console.log as any).mock.calls[0][0]).toContain("Empty profile was provided");
+        });
+
+        it("should not touch the config file if the token type was not specified", async () => {
+            const handler = new FakeAuthHandler();
+            const params = lodash.cloneDeep(logoutParams);
+            params.arguments["fruit-profile"] = "fruity";
+
+            const doLogoutSpy = jest.spyOn(handler as any, "doLogout");
+            const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+
+            let caughtError;
+
+            try {
+                await handler.process(params);
+            } catch (error) {
+                caughtError = error;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(doLogoutSpy).toHaveBeenCalled();
+            expect(writeFileSpy).not.toHaveBeenCalled();
+            expect((params.response.console.log as any).mock.calls[0][0]).toContain("Token type was not provided");
+        });
+
+        it("should not touch the config file if the token type does not match", async () => {
+            const handler = new FakeAuthHandler();
+            const params = lodash.cloneDeep(logoutParams);
+            params.arguments.tokenType = "fakeType.1";
+            params.arguments["fruit-profile"] = "fruit";
+            fakeConfig.properties.profiles.fruit.properties.tokenType = "fakeType.2";
+
+            const doLogoutSpy = jest.spyOn(handler as any, "doLogout");
+            const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+
+            let caughtError;
+
+            try {
+                await handler.process(params);
+            } catch (error) {
+                caughtError = error;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(doLogoutSpy).toHaveBeenCalled();
+            expect(writeFileSpy).not.toHaveBeenCalled();
+            expect((params.response.console.log as any).mock.calls[0][0]).toContain("Token type does not match the authentication service");
+        });
+
+        it("should not touch the config file if the token value does not match", async () => {
+            const handler = new FakeAuthHandler();
+            const params = lodash.cloneDeep(logoutParams);
+            params.arguments.tokenValue = "fakeValue.1";
+            params.arguments["fruit-profile"] = "fruit";
+            fakeConfig.properties.profiles.fruit.properties.tokenValue = "fakeValue.2";
+
+            const doLogoutSpy = jest.spyOn(handler as any, "doLogout");
+            const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+
+            let caughtError;
+
+            try {
+                await handler.process(params);
+            } catch (error) {
+                caughtError = error;
+            }
+
+            expect(caughtError).toBeUndefined();
+            expect(doLogoutSpy).toHaveBeenCalled();
+            expect(writeFileSpy).not.toHaveBeenCalled();
+            expect((params.response.console.log as any).mock.calls[0][0]).toContain("Token value does not match the securely stored value");
         });
     });
 });

--- a/packages/imperative/src/auth/__tests__/__resources__/auth.config.json
+++ b/packages/imperative/src/auth/__tests__/__resources__/auth.config.json
@@ -22,6 +22,16 @@
             "secure": [
                 "tokenValue"
             ]
+        },
+        "fruity": {
+            "type": "fruit",
+            "properties": {
+                "host": "example.com",
+                "port": 12345
+            },
+            "secure": [
+                "tokenValue"
+            ]
         }
     },
     "defaults": {},

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -278,8 +278,8 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
                 params.response.console.log(logoutMessage);
             } else {
                 params.response.console.errorHeader("Command Error");
-                params.response.console.error("Token was not provided, so can't log out!"+
-                    "\nYou need to authenticate using `zowe auth login`");
+                params.response.console.error("Token was not provided, so can't log out."+
+                    "\nYou need to authenticate first using `zowe auth login`.");
                 params.response.data.setExitCode(1);
             }
         }

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -12,7 +12,6 @@
 import { IHandlerParameters, IHandlerResponseApi } from "../../../../cmd";
 import { AbstractSession, ConnectionPropsForSessCfg, IOptionsForAddConnProps, ISession, SessConstants, Session } from "../../../../rest";
 import { Imperative } from "../../Imperative";
-import { ImperativeExpect } from "../../../../expect";
 import { ImperativeError } from "../../../../error";
 import { ISaveProfileFromCliArgs } from "../../../../profiles";
 import { ImperativeConfig } from "../../../../utilities";
@@ -230,8 +229,8 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
             let profileWithToken: string = null;
 
             // If you specified a token on the command line, then don't delete the one in the profile if it doesn't match
-            if (Object.keys(profileProps).length > 0 && (profileProps.tokenType != null || profileProps.tokenValue != null) &&
-                (profileProps.tokenType === params.arguments.tokenType || profileProps.tokenValue === params.arguments.tokenValue)) {
+            if (Object.keys(profileProps).length > 0 && profileProps.tokenType != null && profileProps.tokenValue != null &&
+                profileProps.tokenType === params.arguments.tokenType && profileProps.tokenValue === params.arguments.tokenValue) {
                 const profilePath = config.api.profiles.expandPath(profileName);
                 config.delete(`${profilePath}.properties.tokenType`);
                 config.delete(`${profilePath}.properties.tokenValue`);

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -211,7 +211,7 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
 
         const sessCfgWithCreds = await ConnectionPropsForSessCfg.addPropsOrPrompt<ISession>(
             sessCfg, params.arguments,
-                { requestToken: false, doPrompting: false, parms: params },
+            { requestToken: false, doPrompting: false, parms: params },
         );
 
         if (params.arguments.tokenValue != null) {

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -230,8 +230,8 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
             let profileWithToken: string = null;
 
             // If you specified a token on the command line, then don't delete the one in the profile if it doesn't match
-            if (Object.keys(profileProps).length > 0 && profileProps.tokenType != null && profileProps.tokenValue != null &&
-                profileProps.tokenType === params.arguments.tokenType && profileProps.tokenValue === params.arguments.tokenValue) {
+            if (Object.keys(profileProps).length > 0 && (profileProps.tokenType != null || profileProps.tokenValue != null) &&
+                (profileProps.tokenType === params.arguments.tokenType || profileProps.tokenValue === params.arguments.tokenValue)) {
                 const profilePath = config.api.profiles.expandPath(profileName);
                 config.delete(`${profilePath}.properties.tokenType`);
                 config.delete(`${profilePath}.properties.tokenValue`);

--- a/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
+++ b/packages/imperative/src/auth/handlers/BaseAuthHandler.ts
@@ -153,7 +153,7 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
                 }
             }
 
-            const profilePath = config.api.profiles.expandPath(profileName);
+            const profilePath = config.api.profiles.getProfilePathFromName(profileName);
             config.set(`${profilePath}.properties.tokenType`, this.mSession.ISession.tokenType);
             config.set(`${profilePath}.properties.tokenValue`, tokenValue, { secure: true });
 
@@ -237,7 +237,7 @@ export abstract class BaseAuthHandler extends AbstractAuthHandler {
             // If you specified a token on the command line, then don't delete the one in the profile if it doesn't match
             if (Object.keys(profileProps).length > 0 && profileProps.tokenType != null && profileProps.tokenValue != null &&
                 profileProps.tokenType === params.arguments.tokenType && profileProps.tokenValue === params.arguments.tokenValue) {
-                const profilePath = config.api.profiles.expandPath(profileName);
+                const profilePath = config.api.profiles.getProfilePathFromName(profileName);
                 config.delete(`${profilePath}.properties.tokenType`);
                 config.delete(`${profilePath}.properties.tokenValue`);
 

--- a/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
+++ b/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
@@ -90,7 +90,7 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
         );
         this.mSession = new Session(sessCfgWithCreds);
         if (this.mSession.ISession.tokenValue) {
-            this.mSession.ISession.user = this.mSession.ISession.password = this.mSession.ISession.cert = this.mSession.ISession.certKey = undefined;
+            this.mSession.ISession.base64EncodedAuth = this.mSession.ISession.user = this.mSession.ISession.password = this.mSession.ISession.cert = this.mSession.ISession.certKey = undefined;
         }
 
         // Use params to set which config layer to apply to

--- a/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
+++ b/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
@@ -90,7 +90,9 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
         );
         this.mSession = new Session(sessCfgWithCreds);
         if (this.mSession.ISession.tokenValue) {
-            this.mSession.ISession.base64EncodedAuth = this.mSession.ISession.user = this.mSession.ISession.password = this.mSession.ISession.cert = this.mSession.ISession.certKey = undefined;
+            this.mSession.ISession.base64EncodedAuth =
+            this.mSession.ISession.user = this.mSession.ISession.password =
+            this.mSession.ISession.cert = this.mSession.ISession.certKey = undefined;
         }
 
         // Use params to set which config layer to apply to

--- a/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
+++ b/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
@@ -89,6 +89,11 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
             sessCfg, params.arguments, { parms: params, doPrompting: true, serviceDescription: this.mServiceDescription },
         );
         this.mSession = new Session(sessCfgWithCreds);
+        if (this.mSession.ISession.tokenValue) {
+            this.mSession.ISession.base64EncodedAuth =
+            this.mSession.ISession.user = this.mSession.ISession.password =
+            this.mSession.ISession.cert = this.mSession.ISession.certKey = undefined;
+        }
 
         // Use params to set which config layer to apply to
         await OverridesLoader.ensureCredentialManagerLoaded();

--- a/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
+++ b/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
@@ -89,6 +89,9 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
             sessCfg, params.arguments, { parms: params, doPrompting: true, serviceDescription: this.mServiceDescription },
         );
         this.mSession = new Session(sessCfgWithCreds);
+        if (this.mSession.ISession.tokenValue) {
+            this.mSession.ISession.user = this.mSession.ISession.password = this.mSession.ISession.cert = this.mSession.ISession.certKey = undefined;
+        }
 
         // Use params to set which config layer to apply to
         await OverridesLoader.ensureCredentialManagerLoaded();

--- a/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
+++ b/packages/imperative/src/config/cmd/auto-init/handlers/BaseAutoInitHandler.ts
@@ -89,11 +89,6 @@ export abstract class BaseAutoInitHandler implements ICommandHandler {
             sessCfg, params.arguments, { parms: params, doPrompting: true, serviceDescription: this.mServiceDescription },
         );
         this.mSession = new Session(sessCfgWithCreds);
-        if (this.mSession.ISession.tokenValue) {
-            this.mSession.ISession.base64EncodedAuth =
-            this.mSession.ISession.user = this.mSession.ISession.password =
-            this.mSession.ISession.cert = this.mSession.ISession.certKey = undefined;
-        }
 
         // Use params to set which config layer to apply to
         await OverridesLoader.ensureCredentialManagerLoaded();

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -85,10 +85,12 @@ export default class InitHandler implements ICommandHandler {
             original = JSONC.stringify(originalProperties, null, ConfigConstants.INDENT);
             dryRun = JSONC.stringify(dryRunProperties, null, ConfigConstants.INDENT);
 
-            let jsonDiff = diff(original, dryRun, {aAnnotation: "Removed",
+            let jsonDiff = diff(original, dryRun, {
+                aAnnotation: "Removed",
                 bAnnotation: "Added",
                 aColor: TextUtils.chalk.red,
-                bColor: TextUtils.chalk.green});
+                bColor: TextUtils.chalk.green
+            });
 
             if (stripAnsi(jsonDiff) === "Compared values have no visual difference.") {
                 jsonDiff = dryRun;
@@ -186,7 +188,8 @@ export default class InitHandler implements ICommandHandler {
         }
 
         this.promptProps.push(propName);
-        const propValue: any = await this.params.response.console.prompt(`Enter ${propDesc} ${ConfigConstants.SKIP_PROMPT}`, { hideText: property.secure });
+        const propValue: any = await this.params.response.console.prompt(
+            `Enter ${propDesc} ${ConfigConstants.SKIP_PROMPT}`, { hideText: property.secure });
 
         // coerce to correct type
         if (propValue && propValue.trim().length > 0) {

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -186,7 +186,7 @@ export default class InitHandler implements ICommandHandler {
         }
 
         this.promptProps.push(propName);
-        const propValue: any = await this.params.response.console.prompt(`Enter ${propDesc} - blank to skip: `, { hideText: property.secure });
+        const propValue: any = await this.params.response.console.prompt(`Enter ${propDesc} - Press ENTER to skip: `, { hideText: property.secure });
 
         // coerce to correct type
         if (propValue && propValue.trim().length > 0) {

--- a/packages/imperative/src/config/cmd/init/init.handler.ts
+++ b/packages/imperative/src/config/cmd/init/init.handler.ts
@@ -186,7 +186,7 @@ export default class InitHandler implements ICommandHandler {
         }
 
         this.promptProps.push(propName);
-        const propValue: any = await this.params.response.console.prompt(`Enter ${propDesc} - Press ENTER to skip: `, { hideText: property.secure });
+        const propValue: any = await this.params.response.console.prompt(`Enter ${propDesc} ${ConfigConstants.SKIP_PROMPT}`, { hideText: property.secure });
 
         // coerce to correct type
         if (propValue && propValue.trim().length > 0) {

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -106,13 +106,17 @@ export default class SecureHandler implements ICommandHandler {
                 { parms: this.params, doPrompting: true, requestToken: true, ...api.promptParams });
             Logger.getAppLogger().info(`Fetching ${profile.tokenType} for ${propPath}`);
 
-            try {
-                return await api.sessionLogin(new Session(sessCfgWithCreds));
-            } catch (error) {
-                throw new ImperativeError({
-                    msg: `Failed to fetch ${profile.tokenType} for ${propPath}: ${error.message}`,
-                    causeErrors: error
-                });
+            if (ConnectionPropsForSessCfg.sessHasCreds(sessCfgWithCreds)) {
+                try {
+                    return await api.sessionLogin(new Session(sessCfgWithCreds));
+                } catch (error) {
+                    throw new ImperativeError({
+                        msg: `Failed to fetch ${profile.tokenType} for ${propPath}: ${error.message}`,
+                        causeErrors: error
+                    });
+                }
+            } else {
+                this.params.response.console.log("No credentials provided.");
             }
         }
     }

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -99,7 +99,7 @@ export default class SecureHandler implements ICommandHandler {
         if (authHandlerClass != null) {
             const api = authHandlerClass.getAuthHandlerApi();
             if (api.promptParams.serviceDescription != null) {
-                this.params.response.console.log(`Logging in to ${api.promptParams.serviceDescription} - blank to skip:`);
+                this.params.response.console.log(`Logging in to ${api.promptParams.serviceDescription} - Press ENTER to skip:`);
             }
 
             const profile = config.api.profiles.get(profilePath.replace(/profiles\./g, ""), false);

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -10,7 +10,7 @@
 */
 
 import { ICommandArguments, ICommandHandler, IHandlerParameters } from "../../../../../cmd";
-import { Config, ConfigAutoStore, ConfigSchema } from "../../../../../config";
+import { Config, ConfigAutoStore, ConfigConstants, ConfigSchema } from "../../../../../config";
 import { coercePropValue, secureSaveError } from "../../../../../config/src/ConfigUtils";
 import { ImperativeError } from "../../../../../error";
 import { Logger } from "../../../../../logger";
@@ -62,7 +62,7 @@ export default class SecureHandler implements ICommandHandler {
                 params.response.console.log(`Processing secure properties for profile: ${config.api.profiles.getProfileNameFromPath(propName)}`);
                 let propValue = await this.handlePromptForAuthToken(config, propName);
                 if (propValue === undefined) {
-                    propValue = await params.response.console.prompt(`Enter ${propName} - Press ENTER to skip: `, {hideText: true});
+                    propValue = await params.response.console.prompt(`Enter ${propName} ${ConfigConstants.SKIP_PROMPT}`, {hideText: true});
                 }
 
                 // Save the value in the config securely
@@ -70,7 +70,7 @@ export default class SecureHandler implements ICommandHandler {
                     config.set(propName, propValue, { secure: true });
                 }
             } else {
-                let propValue = await params.response.console.prompt(`Enter ${propName} - Press ENTER to skip: `, { hideText: true });
+                let propValue = await params.response.console.prompt(`Enter ${propName} ${ConfigConstants.SKIP_PROMPT}`, { hideText: true });
 
                 // Save the value in the config securely
                 if (propValue) {
@@ -99,7 +99,7 @@ export default class SecureHandler implements ICommandHandler {
         if (authHandlerClass != null) {
             const api = authHandlerClass.getAuthHandlerApi();
             if (api.promptParams.serviceDescription != null) {
-                this.params.response.console.log(`Logging in to ${api.promptParams.serviceDescription} - Press ENTER to skip:`);
+                this.params.response.console.log(`Logging in to ${api.promptParams.serviceDescription} ${ConfigConstants.SKIP_PROMPT}`);
             }
 
             const profile = config.api.profiles.get(profilePath.replace(/profiles\./g, ""), false);

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -61,14 +61,14 @@ export default class SecureHandler implements ICommandHandler {
             if (propName.endsWith(".tokenValue")) {
                 params.response.console.log(`Processing secure properties for profile: ${config.api.profiles.getProfileNameFromPath(propName)}`);
                 const propValue = await this.handlePromptForAuthToken(config, propName) ||
-                    await params.response.console.prompt(`Enter ${propName} - blank to skip: `, {hideText: true});
+                    await params.response.console.prompt(`Enter ${propName} - Press ENTER to skip: `, {hideText: true});
 
                 // Save the value in the config securely
                 if (propValue) {
                     config.set(propName, propValue, { secure: true });
                 }
             } else {
-                let propValue = await params.response.console.prompt(`Enter ${propName} - blank to skip: `, { hideText: true });
+                let propValue = await params.response.console.prompt(`Enter ${propName} - Press ENTER to skip: `, { hideText: true });
 
                 // Save the value in the config securely
                 if (propValue) {

--- a/packages/imperative/src/config/cmd/secure/secure.handler.ts
+++ b/packages/imperative/src/config/cmd/secure/secure.handler.ts
@@ -57,29 +57,24 @@ export default class SecureHandler implements ICommandHandler {
         }
 
         // Prompt for values designated as secure
-        let authTokenProp: string;
         for (const propName of secureProps) {
-            if (authTokenProp == null && propName.endsWith(".tokenValue")) {
-                authTokenProp = propName;
-                continue;
-            }
+            if (propName.endsWith(".tokenValue")) {
+                params.response.console.log(`Processing secure properties for profile: ${config.api.profiles.getProfileNameFromPath(propName)}`);
+                const propValue = await this.handlePromptForAuthToken(config, propName) ||
+                    await params.response.console.prompt(`Enter ${propName} - blank to skip: `, {hideText: true});
 
-            let propValue = await params.response.console.prompt(`Enter ${propName} - blank to skip: `, { hideText: true });
+                // Save the value in the config securely
+                if (propValue) {
+                    config.set(propName, propValue, { secure: true });
+                }
+            } else {
+                let propValue = await params.response.console.prompt(`Enter ${propName} - blank to skip: `, { hideText: true });
 
-            // Save the value in the config securely
-            if (propValue) {
-                propValue = coercePropValue(propValue, ConfigSchema.findPropertyType(propName, config.properties));
-                config.set(propName, propValue, { secure: true });
-            }
-        }
-
-        if (authTokenProp != null) {
-            const propValue = await this.handlePromptForAuthToken(config, authTokenProp) ||
-                await params.response.console.prompt(`Enter ${authTokenProp} - blank to skip: `, {hideText: true});
-
-            // Save the value in the config securely
-            if (propValue) {
-                config.set(authTokenProp, propValue, { secure: true });
+                // Save the value in the config securely
+                if (propValue) {
+                    propValue = coercePropValue(propValue, ConfigSchema.findPropertyType(propName, config.properties));
+                    config.set(propName, propValue, { secure: true });
+                }
             }
         }
 

--- a/packages/rest/src/client/AbstractRestClient.ts
+++ b/packages/rest/src/client/AbstractRestClient.ts
@@ -463,7 +463,15 @@ export abstract class AbstractRestClient {
          */
         if (this.session.ISession.type === SessConstants.AUTH_TYPE_BASIC ||
             this.session.ISession.type === SessConstants.AUTH_TYPE_TOKEN) {
-            if (this.session.ISession.tokenValue) {
+            if (this.session.ISession.base64EncodedAuth || (this.session.ISession.user && this.session.ISession.password)) {
+                this.log.trace("Using basic authentication");
+                const headerKeys: string[] = Object.keys(Headers.BASIC_AUTHORIZATION);
+                const authentication: string = AbstractSession.BASIC_PREFIX + this.session.ISession.base64EncodedAuth ??
+                    AbstractSession.getBase64Auth(this.session.ISession.user,  this.session.ISession.password);
+                headerKeys.forEach((property) => {
+                    options.headers[property] = authentication;
+                });
+            } else if (this.session.ISession.tokenValue) {
                 this.log.trace("Using cookie authentication with token %s", this.session.ISession.tokenValue);
                 const headerKeys: string[] = Object.keys(Headers.COOKIE_AUTHORIZATION);
                 const authentication: string = `${this.session.ISession.tokenType}=${this.session.ISession.tokenValue}`;
@@ -471,12 +479,7 @@ export abstract class AbstractRestClient {
                     options.headers[property] = authentication;
                 });
             } else {
-                this.log.trace("Using basic authentication");
-                const headerKeys: string[] = Object.keys(Headers.BASIC_AUTHORIZATION);
-                const authentication: string = AbstractSession.BASIC_PREFIX + this.session.ISession.base64EncodedAuth;
-                headerKeys.forEach((property) => {
-                    options.headers[property] = authentication;
-                });
+                throw new ImperativeError({msg: "No credentials for a BASIC or TOKEN type of session."});
             }
         } else if (this.session.ISession.type === SessConstants.AUTH_TYPE_BEARER) {
             this.log.trace("Using bearer authentication");

--- a/packages/rest/src/client/AbstractRestClient.ts
+++ b/packages/rest/src/client/AbstractRestClient.ts
@@ -466,8 +466,8 @@ export abstract class AbstractRestClient {
             if (this.session.ISession.base64EncodedAuth || (this.session.ISession.user && this.session.ISession.password)) {
                 this.log.trace("Using basic authentication");
                 const headerKeys: string[] = Object.keys(Headers.BASIC_AUTHORIZATION);
-                const authentication: string = AbstractSession.BASIC_PREFIX + this.session.ISession.base64EncodedAuth ??
-                    AbstractSession.getBase64Auth(this.session.ISession.user,  this.session.ISession.password);
+                const authentication: string = AbstractSession.BASIC_PREFIX + (this.session.ISession.base64EncodedAuth ??
+                    AbstractSession.getBase64Auth(this.session.ISession.user,  this.session.ISession.password));
                 headerKeys.forEach((property) => {
                     options.headers[property] = authentication;
                 });

--- a/packages/rest/src/session/ConnectionPropsForSessCfg.ts
+++ b/packages/rest/src/session/ConnectionPropsForSessCfg.ts
@@ -303,6 +303,26 @@ export class ConnectionPropsForSessCfg {
         ConnectionPropsForSessCfg.logSessCfg(sessCfg);
     }
 
+    // ***********************************************************************
+    /**
+     * Confirm whether the given session has a credentials.
+     *
+     * @param sessToTest
+     *       the session to be confirmed.
+     *
+     * @returns true is the session has credentials. false otherwise.
+     */
+    public static sessHasCreds(sessToTest: ISession) {
+        if (sessToTest == null) {
+            return false;
+        }
+        const hasToken = sessToTest.tokenType != null && sessToTest.tokenValue != null;
+        const hasCert = sessToTest.certKey != null && sessToTest.cert;
+        const hasBasicAuth = sessToTest.base64EncodedAuth != null;
+        const hasCreds = sessToTest.user != null && sessToTest.password;
+        return hasToken || hasCert || hasBasicAuth || hasCreds;
+    }
+
     /**
      * List of properties on `sessCfg` object that should be kept secret and
      * may not appear in Imperative log files.


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
- resolves #979
- added a new `add ImperativeExpect.toMatchRegExp` method
- prevented multiple `logout` operations from failing due to not having a token available 
- allowed `autoStore` for dynamic APIML token types
- ~allowed `logout` operation to remove token type and/or token value when either is not specified in the config file~
  - this cannot be done because it conflicts with the ability to logout a token different than the one stored in the vault
- added utility method: `getProfileNameFromPath` to help with nested token authentication
- added support for multiple token authentication processes in a single `config secure` command
  - added an entry to the `console.log` to inform which profile credentials are being prompted for
- prevented `auto-init` from performing two `login` operations on a single command

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

I recommend to combine this PR with the CLI counterpart:
  - https://github.com/zowe/zowe-cli/pull/1734

Please see the above PR for testing instructions.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**

Opened issues as a result of this PR:
 - https://github.com/zowe/imperative/issues/995
<!-- Anything else noteworthy about this pull request. This section is optional. -->