### PR TITLE
Use literal "ZOWE" as env prefix for NextVerFeatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Enabled NextVerFeatures.useV3ErrFormat() to form the right environment variable name even if Imperative.init() has not been called.
+
 ## `5.15.0`
 
 - Enhancement: Enabled users to display errors in a more user-friendly format with the ZOWE_V3_ERR_FORMAT environment variable. [zowe-cli#935](https://github.com/zowe/zowe-cli/issues/935)

--- a/packages/utilities/src/NextVerFeatures.ts
+++ b/packages/utilities/src/NextVerFeatures.ts
@@ -9,8 +9,6 @@
 *
 */
 
-import { ImperativeConfig } from "./ImperativeConfig";
-
 /**
  * This class contains logic to enable users to opt-in to features
  * that will become standard functionality in the next version of Zowe.
@@ -18,6 +16,8 @@ import { ImperativeConfig } from "./ImperativeConfig";
  * @class NextVerFeatures
  */
 export class NextVerFeatures {
+    private static ENV_VAR_PREFIX = "ZOWE";
+
     /**
      * Identify if we should use the V3 error message format.
      * That choice is determined by the value of the ZOWE_V3_ERR_FORMAT environment variable.
@@ -29,7 +29,7 @@ export class NextVerFeatures {
     public static useV3ErrFormat(): boolean {
         // our default is false
         let v3ErrFmtBoolVal: boolean = false;
-        const v3ErrFmtStringVal = process.env[`${ImperativeConfig.instance.envVariablePrefix}_V3_ERR_FORMAT`];
+        const v3ErrFmtStringVal = process.env[`${NextVerFeatures.ENV_VAR_PREFIX}_V3_ERR_FORMAT`];
         if (v3ErrFmtStringVal !== undefined) {
             // user has set the V3 error format environment variable
             if (v3ErrFmtStringVal.toUpperCase() === "TRUE") {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

I originally thought that using ImperativeConfig.instance.envVariablePrefix was the appropriate way to get the prefix for the ZOWE_V3_ERR_FORMAT variable. However, many API system tests do *NOT* call imperative.init(). We would be required to create very many mocks in our system tests to make such tests run successfully. That situation brought to light the possibility that any external app which uses a NextVerFeatures function, but which does not first call imperative.init(), will fail with some form of error.

This PR replaces the need for imperative.init() by simply placing the literal string "ZOWE" within the NextVerFeatures module for use as the prefix for environment variables.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

There is no new functionality in this PR. As long as automated tests run successfully, then this change should be good to release.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->

Testing of the zowe-cli v3-err-format branch cannot be completed until this imperative PR is merged and published.