### PR TITLE
chore: Bump secrets SDK to 7.18.0

### DIFF
--- a/__tests__/__integration__/imperative/package.json
+++ b/__tests__/__integration__/imperative/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@zowe/imperative": "../../..",
-    "@zowe/secrets-for-zowe-sdk": "7.18.0-next.4"
+    "@zowe/secrets-for-zowe-sdk": "7.18.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.33.0",
         "@typescript-eslint/parser": "^5.33.0",
-        "@zowe/secrets-for-zowe-sdk": "^7.18.0-next.4",
+        "@zowe/secrets-for-zowe-sdk": "^7.18.0",
         "ansi-colors": "^4.1.1",
         "clear-require": "^2.0.0",
         "concurrently": "^7.5.0",
@@ -4005,9 +4005,9 @@
       }
     },
     "node_modules/@zowe/secrets-for-zowe-sdk": {
-      "version": "7.18.0-next.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0-next.4.tgz",
-      "integrity": "sha512-H3UElOA7UxZL+Ee3Q2cHCwF/T0s+SEv8Wof9kyzC0TiP71awBHZiPONY7bZIe3vbpRlckt2ECcG/os6qrDrjJw==",
+      "version": "7.18.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz",
+      "integrity": "sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==",
       "dev": true,
       "hasInstallScript": true,
       "engines": {
@@ -17902,9 +17902,9 @@
       }
     },
     "@zowe/secrets-for-zowe-sdk": {
-      "version": "7.18.0-next.4",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0-next.4.tgz",
-      "integrity": "sha512-H3UElOA7UxZL+Ee3Q2cHCwF/T0s+SEv8Wof9kyzC0TiP71awBHZiPONY7bZIe3vbpRlckt2ECcG/os6qrDrjJw==",
+      "version": "7.18.0",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-7.18.0.tgz",
+      "integrity": "sha512-QyZQh45pZEj9PWkqaTfMFIFDiHpMI4aCaZSbsbhanz54h/kN1s6nT4ri43EjQ3J3aUsG2wEjKkotjBZdGg3cHw==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
-    "@zowe/secrets-for-zowe-sdk": "^7.18.0-next.4",
+    "@zowe/secrets-for-zowe-sdk": "^7.18.0",
     "ansi-colors": "^4.1.1",
     "clear-require": "^2.0.0",
     "concurrently": "^7.5.0",


### PR DESCRIPTION
This PR bumps the secrets SDK to 7.18.0