### PR TITLE
Fix merging of profile properties in `ProfileInfo.createSession`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fixed merging of profile properties in `ProfileInfo.createSession`. [#1008](https://github.com/zowe/imperative/issues/1008)
+
 ## `5.18.0`
 
 - Enhancement: Replaced use of `node-keytar` with the new `keyring` module from `@zowe/secrets-for-zowe-sdk`. [zowe-cli#1622](https://github.com/zowe/zowe-cli/issues/1622)

--- a/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
+++ b/packages/config/__tests__/ProfileInfo.TeamConfig.test.ts
@@ -187,6 +187,18 @@ describe("TeamConfig ProfileInfo tests", () => {
                         locType: ProfLocType.TEAM_CONFIG
                     },
                 },
+                {
+                    argName: "tokenType", dataType: "string", argValue: SessConstants.TOKEN_TYPE_JWT,
+                    argLoc: {
+                        locType: ProfLocType.TEAM_CONFIG
+                    },
+                },
+                {
+                    argName: "tokenValue", dataType: "string", argValue: "testToken",
+                    argLoc: {
+                        locType: ProfLocType.TEAM_CONFIG
+                    },
+                },
             ];
 
             it("should create a session", async () => {
@@ -201,6 +213,7 @@ describe("TeamConfig ProfileInfo tests", () => {
                 expect(newSess.ISession.secureProtocol).toBe(AbstractSession.DEFAULT_SECURE_PROTOCOL);
                 expect(newSess.ISession.basePath).toBe(AbstractSession.DEFAULT_BASE_PATH);
                 expect(newSess.ISession.base64EncodedAuth).toBe(b64TestAuth);
+                // Auth token should be undefined because user and password takes precedence
                 expect(newSess.ISession.tokenType).toBeUndefined();
                 expect(newSess.ISession.tokenValue).toBeUndefined();
             });

--- a/packages/config/src/ProfileInfo.ts
+++ b/packages/config/src/ProfileInfo.ts
@@ -555,11 +555,15 @@ export class ProfileInfo {
         profArgs: IProfArgAttrs[],
         connOpts: IOptionsForAddConnProps = {}
     ): Session {
-        // initialize a session config with arguments from profile arguments
-        const sessCfg: ISession = ProfileInfo.initSessCfg(profArgs);
+        // Initialize a session config with values from profile arguments
+        const sessCfg: ISession = ProfileInfo.initSessCfg(profArgs,
+            ["rejectUnauthorized", "basePath", "protocol"]);
 
-        // we have no command arguments, so just supply an empty object
+        // Populate command arguments object with arguments to be resolved
         const cmdArgs: ICommandArguments = { $0: "", _: [] };
+        for (const { argName, argValue } of profArgs) {
+            cmdArgs[argName] = argValue;
+        }
 
         // resolve the choices among various session config properties
         ConnectionPropsForSessCfg.resolveSessCfgProps(sessCfg, cmdArgs, connOpts);
@@ -1061,15 +1065,18 @@ export class ProfileInfo {
      *
      * @param profArgs
      *      An array of profile argument attributes.
+     * @param argNames
+     *      An array of argument names to load from the profile. Defaults to
+     *      all arguments that have an associated ISession property.
      *
      * @returns A session containing all of the supplied profile argument
      *          attributes that are relevant to a session.
      */
-    public static initSessCfg(profArgs: IProfArgAttrs[]): ISession {
+    public static initSessCfg(profArgs: IProfArgAttrs[], argNames?: string[]): ISession {
         const sessCfg: any = {};
 
         // the set of names of arguments in IProfArgAttrs used in ISession
-        const profArgNames = [
+        const profArgNames = argNames ?? [
             "host", "port", "user", "password", "rejectUnauthorized",
             "protocol", "basePath", "tokenType", "tokenValue"
         ];


### PR DESCRIPTION
**What It Does**
Fixes #1008 so that user and password takes precedence over tokenValue when both are defined in profile properties.

**How to Test**
1. Create a team config file that has both user/password and tokenValue defined (such as the example provided in the linked issue).
2. Call `ProfileInfo.createSession` (using a test script like the one below) and verify that only user/password are present in the session.
```javascript
const { ProfileInfo } = require("@zowe/imperative");
(async () => {
    // Load connection info from default z/OSMF profile
    const profInfo = new ProfileInfo("zowe");
    await profInfo.readProfilesFromDisk();
    const zosmfProfAttrs = profInfo.getDefaultProfile("zosmf");
    const zosmfMergedArgs = profInfo.mergeArgsForProfile(zosmfProfAttrs, { getSecureVals: true });
    const session = ProfileInfo.createSession(zosmfMergedArgs.knownArgs);
    console.dir(session.ISession);
})();
```

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
There is logic in `ConnectionPropsForSessCfg.resolveSessCfgProps` to conditionally add either user/password or tokenValue to the session. But this logic only runs when user, password, and tokenValue are passed in `cmdArgs` instead of the `sessCfg` object. The fix implemented in this PR is consistent with how Zowe CLI command handlers resolve the properties - for example the [ZosFilesBaseHandler](https://github.com/zowe/zowe-cli/blob/master/packages/cli/src/zosfiles/ZosFilesBase.handler.ts#L44-L49).