### PR TITLE
Fix for request steam failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Imperative package will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Fix for `AbstactRestClient` failing to return when streaming a larger file [#1805](https://github.com/zowe/zowe-cli/issues/1805)
+
 ## `5.18.2`
 
 - BugFix: Fixed normalization on stream chunk boundaries [#1815](https://github.com/zowe/zowe-cli/issues/1815)

--- a/packages/rest/src/client/AbstractRestClient.ts
+++ b/packages/rest/src/client/AbstractRestClient.ts
@@ -699,6 +699,10 @@ export abstract class AbstractRestClient {
                 causeErrors: this.dataString,
                 source: "http"
             }));
+        }else if (this.mResponseStream != null && this.mResponseStream.writableEnded) {
+            // This will correct any instances where the finished event does not get emitted
+            // even though the stream processing has ended.
+            this.mResolve(this.dataString);
         } else if (this.mResponseStream != null && !this.mResponseStream.writableFinished) {
             this.mResponseStream.on("finish", () => this.mResolve(this.dataString));
         } else {


### PR DESCRIPTION
**What It Does**
Corrects a bug where the HTTP request does not return when downloading larger dataset or USS file to a stream. 

**How to Test**
Using the Zowe CLI, do a **'zowe files copy dsclp'** of a dataset that is larger than 16k. Without the fix it will fail with no error or warning message. With the fix applied it will complete as expected.  

**Review Checklist**
I certify that I have:
- [X ] tested my changes
- [ ] added/updated automated tests
- [X ] updated the changelog
- [ X] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

